### PR TITLE
Add start/stop dates

### DIFF
--- a/data.json
+++ b/data.json
@@ -76,9 +76,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0679"
+            },
             "label": "680 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0546"
+            },
             "label": "547 B.C."
           }
         },
@@ -96,9 +102,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1184"
+            },
             "label": "1185 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0679"
+            },
             "label": "680 B.C."
           }
         }
@@ -145,9 +157,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-699999"
+            },
             "label": "700000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-174999"
+            },
             "label": "175000 BCE "
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -166,9 +184,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-174999"
+            },
             "label": "175000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-39999"
+            },
             "label": "40000 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -187,9 +211,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-39999"
+            },
             "label": "40000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-34999"
+            },
             "label": "35000 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -208,9 +238,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-24999"
+            },
             "label": "25000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-6999"
+            },
             "label": "7000 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -229,9 +265,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6999"
+            },
             "label": "7000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-5999"
+            },
             "label": "6000 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -250,9 +292,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5999"
+            },
             "label": "6000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-4499"
+            },
             "label": "4500 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -275,9 +323,15 @@
           ],
           "spatialCoverageDescription": "Middle Egypt",
           "start": {
+            "in": {
+              "year": "-4499"
+            },
             "label": "4500 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -296,9 +350,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4499"
+            },
             "label": "4500 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2949"
+            },
             "label": "2950 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -322,9 +382,15 @@
           ],
           "spatialCoverageDescription": "Lower Nubia",
           "start": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-3399"
+            },
             "label": "3400 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -344,9 +410,15 @@
           ],
           "spatialCoverageDescription": "Upper Egypt",
           "start": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-3399"
+            },
             "label": "3400 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -370,9 +442,15 @@
           ],
           "spatialCoverageDescription": "Lower Egypt",
           "start": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-3399"
+            },
             "label": "3400 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -396,9 +474,15 @@
           ],
           "spatialCoverageDescription": "Lower Nubia",
           "start": {
+            "in": {
+              "year": "-3399"
+            },
             "label": "3400 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -418,9 +502,15 @@
           ],
           "spatialCoverageDescription": "Upper Egypt",
           "start": {
+            "in": {
+              "year": "-3399"
+            },
             "label": "3400 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -440,9 +530,15 @@
           ],
           "spatialCoverageDescription": "Lower Egypt",
           "start": {
+            "in": {
+              "year": "-3399"
+            },
             "label": "3400 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -466,9 +562,15 @@
           ],
           "spatialCoverageDescription": "Lower Nubia",
           "start": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-3149"
+            },
             "label": "3150 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -488,9 +590,15 @@
           ],
           "spatialCoverageDescription": "Upper Egypt",
           "start": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-3149"
+            },
             "label": "3150 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -510,9 +618,15 @@
           ],
           "spatialCoverageDescription": "Lower Egypt",
           "start": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-3149"
+            },
             "label": "3150 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -531,9 +645,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3149"
+            },
             "label": "3150 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2949"
+            },
             "label": "2950 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -553,9 +673,15 @@
           ],
           "spatialCoverageDescription": "Lower Egypt",
           "start": {
+            "in": {
+              "year": "-3149"
+            },
             "label": "3150 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2949"
+            },
             "label": "2950 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -574,9 +700,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2949"
+            },
             "label": "2950 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2669"
+            },
             "label": "2670 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -595,9 +727,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2949"
+            },
             "label": "2950 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2799"
+            },
             "label": "2800 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -617,9 +755,15 @@
           ],
           "spatialCoverageDescription": "Lower Egypt",
           "start": {
+            "in": {
+              "year": "-2949"
+            },
             "label": "2950 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2799"
+            },
             "label": "2800 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -638,9 +782,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2799"
+            },
             "label": "2800 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2669"
+            },
             "label": "2670 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -659,9 +809,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2669"
+            },
             "label": "2670 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2167"
+            },
             "label": "2168 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -680,9 +836,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2167"
+            },
             "label": "2168 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2039"
+            },
             "label": "2040 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -701,9 +863,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2039"
+            },
             "label": "2040 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1639"
+            },
             "label": "1640 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -722,9 +890,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1639"
+            },
             "label": "1640 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1547"
+            },
             "label": "1548 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -743,9 +917,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1547"
+            },
             "label": "1548 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1085"
+            },
             "label": "1086 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -764,9 +944,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1085"
+            },
             "label": "1086 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0663"
+            },
             "label": "664 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -785,9 +971,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0663"
+            },
             "label": "664 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0331"
+            },
             "label": "332 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -806,9 +998,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0524"
+            },
             "label": "525 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0401"
+            },
             "label": "402 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -827,9 +1025,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0342"
+            },
             "label": "343 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0331"
+            },
             "label": "332 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -848,9 +1052,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0331"
+            },
             "label": "332 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0303"
+            },
             "label": "304 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -869,9 +1079,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0303"
+            },
             "label": "304 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0029"
+            },
             "label": "30 BCE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -890,9 +1106,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0029"
+            },
             "label": "30 BCE"
           },
           "stop": {
+            "in": {
+              "year": "0394"
+            },
             "label": "394 CE"
           },
           "url": "http%3A%2F%2Fuee.ucla.edu%2Fchronology%2F"
@@ -927,9 +1149,15 @@
           ],
           "spatialCoverageDescription": "Roman Britain",
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0043"
+            },
             "label": "43 A.D."
           }
         }
@@ -970,9 +1198,15 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "480 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0329"
+            },
             "label": "330 B.C."
           }
         },
@@ -994,9 +1228,15 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "600 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0549"
+            },
             "label": "550 B.C."
           }
         },
@@ -1022,9 +1262,15 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "480 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0449"
+            },
             "label": "450 B.C."
           }
         },
@@ -1046,9 +1292,16 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "around 800 B.C."
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0666",
+              "latestYear": "-0633"
+            },
             "label": "mid seventh century B.C."
           }
         },
@@ -1070,9 +1323,15 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "around 800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0724"
+            },
             "label": "around 725 B.C."
           }
         },
@@ -1094,9 +1353,16 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0724"
+            },
             "label": "around 725 B.C."
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0666",
+              "latestYear": "-0633"
+            },
             "label": "mid seventh century B.C."
           }
         },
@@ -1118,9 +1384,15 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0299"
+            },
             "label": "300 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0099"
+            },
             "label": "100 B.C."
           }
         },
@@ -1142,9 +1414,15 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0519"
+            },
             "label": "520 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0469"
+            },
             "label": "470 B.C."
           }
         },
@@ -1167,9 +1445,15 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0299"
+            },
             "label": "300 B.C."
           }
         },
@@ -1191,9 +1475,15 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0549"
+            },
             "label": "550 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0519"
+            },
             "label": "520 B.C."
           }
         },
@@ -1216,9 +1506,15 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0449"
+            },
             "label": "450 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 B.C."
           }
         },
@@ -1240,9 +1536,15 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0679"
+            },
             "label": "680 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "600 B.C."
           }
         }
@@ -1288,9 +1590,16 @@
           ],
           "spatialCoverageDescription": "Carthage",
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "~800"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0674",
+              "latestYear": "-0649"
+            },
             "label": "675/650"
           }
         },
@@ -1314,9 +1623,17 @@
           ],
           "spatialCoverageDescription": "Carthage",
           "start": {
+            "in": {
+              "earliestYear": "-0674",
+              "latestYear": "-0649"
+            },
             "label": "675/650"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0549",
+              "latestYear": "-0524"
+            },
             "label": "550/525"
           }
         },
@@ -1340,9 +1657,17 @@
           ],
           "spatialCoverageDescription": "Carthage",
           "start": {
+            "in": {
+              "earliestYear": "-0549",
+              "latestYear": "-0524"
+            },
             "label": "550/525"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0299",
+              "latestYear": "-0274"
+            },
             "label": "300/275"
           }
         },
@@ -1365,9 +1690,17 @@
           ],
           "spatialCoverageDescription": "Carthage",
           "start": {
+            "in": {
+              "earliestYear": "-0299",
+              "latestYear": "-0274"
+            },
             "label": "300/275"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0145",
+              "latestYear": "-0124"
+            },
             "label": "146/125"
           }
         }
@@ -1408,9 +1741,15 @@
           ],
           "spatialCoverageDescription": "ancient Near East",
           "start": {
+            "in": {
+              "year": "0224"
+            },
             "label": "224 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0651"
+            },
             "label": "651 A.D."
           }
         }
@@ -1463,9 +1802,15 @@
           ],
           "spatialCoverageDescription": "North Syria",
           "start": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 BC"
           }
         },
@@ -1500,9 +1845,15 @@
           ],
           "spatialCoverageDescription": "North Syria",
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "600 BC"
           }
         },
@@ -1532,9 +1883,15 @@
           ],
           "spatialCoverageDescription": "North Syria",
           "start": {
+            "in": {
+              "year": "-0929"
+            },
             "label": "930 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0609"
+            },
             "label": "610 BC"
           }
         },
@@ -1589,9 +1946,17 @@
           ],
           "spatialCoverageDescription": "Near East and Greece",
           "start": {
+            "in": {
+              "earliestYear": "-1199",
+              "latestYear": "-1100"
+            },
             "label": "twelfth century BC"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0599",
+              "latestYear": "-0500"
+            },
             "label": "sixth century BC"
           }
         },
@@ -1625,9 +1990,17 @@
           ],
           "spatialCoverageDescription": "Coastal North Africa",
           "start": {
+            "in": {
+              "earliestYear": "-0799",
+              "latestYear": "-0700"
+            },
             "label": "eighth century BC"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0033",
+              "latestYear": "0000"
+            },
             "label": "end of the first century BC"
           }
         },
@@ -1661,9 +2034,17 @@
           ],
           "spatialCoverageDescription": "Interior North Africa",
           "start": {
+            "in": {
+              "earliestYear": "-0399",
+              "latestYear": "-0300"
+            },
             "label": "fourth century BC"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0033",
+              "latestYear": "0000"
+            },
             "label": "end of the first century BC"
           }
         },
@@ -1684,9 +2065,17 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "-0899",
+              "latestYear": "-0800"
+            },
             "label": "ninth century BC"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0499",
+              "latestYear": "-0400"
+            },
             "label": "fifth century BC"
           }
         }
@@ -1720,9 +2109,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0749"
+            },
             "label": "750 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0449"
+            },
             "label": "450 B.C."
           },
           "url": "http%3A%2F%2Fwww4.uwm.edu%2Fceltic%2Fekeltoi%2Fvolumes%2Fvol6%2F6_1%2Fparcero-cobas_6_1.html"
@@ -1758,9 +2153,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0849"
+            },
             "label": "850 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "700 B.C."
           }
         }
@@ -1822,9 +2223,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           }
         },
@@ -1866,9 +2273,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 BCE"
           }
         },
@@ -1910,9 +2323,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 BCE"
           }
         },
@@ -1954,9 +2373,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0299"
+            },
             "label": "ca. 300 BCE"
           }
         },
@@ -1998,9 +2423,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           }
         },
@@ -2042,9 +2473,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 BCE"
           }
         },
@@ -2086,9 +2523,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 BCE"
           }
         },
@@ -2130,9 +2573,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0299"
+            },
             "label": "ca. 300 BCE"
           }
         },
@@ -2177,9 +2626,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 BCE"
           }
         },
@@ -2221,9 +2676,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 BCE"
           }
         },
@@ -2268,9 +2729,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0299"
+            },
             "label": "ca. 300 BCE"
           }
         },
@@ -2315,9 +2782,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0585"
+            },
             "label": "586 B.C."
           }
         }
@@ -2363,9 +2836,15 @@
           ],
           "spatialCoverageDescription": "Babylonia",
           "start": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1349"
+            },
             "label": "1350 B.C."
           }
         },
@@ -2392,9 +2871,15 @@
           ],
           "spatialCoverageDescription": "Babylonia",
           "start": {
+            "in": {
+              "year": "-1156"
+            },
             "label": "1157 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1025"
+            },
             "label": "1026 B.C."
           }
         },
@@ -2420,9 +2905,15 @@
           ],
           "spatialCoverageDescription": "Near East",
           "start": {
+            "in": {
+              "year": "-8499"
+            },
             "label": "8500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-6999"
+            },
             "label": "7000 B.C."
           }
         },
@@ -2448,9 +2939,15 @@
           ],
           "spatialCoverageDescription": "Southern Mesopotamia",
           "start": {
+            "in": {
+              "year": "-6199"
+            },
             "label": "ca. 6200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-4099"
+            },
             "label": "4100 B.C."
           }
         },
@@ -2479,9 +2976,15 @@
           ],
           "spatialCoverageDescription": "Southern Mesopotamia",
           "start": {
+            "in": {
+              "year": "-4099"
+            },
             "label": "4100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3399"
+            },
             "label": "3400 B.C."
           }
         },
@@ -2510,9 +3013,15 @@
           ],
           "spatialCoverageDescription": "Southern Mesopotamia",
           "start": {
+            "in": {
+              "year": "-3399"
+            },
             "label": "3400 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 B.C."
           }
         },
@@ -2541,9 +3050,15 @@
           ],
           "spatialCoverageDescription": "Southern Mesopotamia",
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "2900 B.C."
           }
         },
@@ -2569,9 +3084,15 @@
           ],
           "spatialCoverageDescription": "Sumer, Akkad, northern Levant, eastern Anatolia, Zagros",
           "start": {
+            "in": {
+              "year": "-2333"
+            },
             "label": "2334 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2192"
+            },
             "label": "2193 B.C."
           }
         },
@@ -2600,9 +3121,15 @@
           ],
           "spatialCoverageDescription": "Babylonia",
           "start": {
+            "in": {
+              "year": "-2003"
+            },
             "label": "2004 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1779"
+            },
             "label": "ca.1780 B.C."
           }
         },
@@ -2631,9 +3158,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-0779"
+            },
             "label": "ca.780 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0608"
+            },
             "label": "609 B.C."
           }
         }
@@ -2666,9 +3199,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-12500"
+            },
             "label": "-12500"
           },
           "stop": {
+            "in": {
+              "year": "-9000"
+            },
             "label": "-9000"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2686,9 +3225,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-500000"
+            },
             "label": "-500000"
           },
           "stop": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2706,9 +3251,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-14000"
+            },
             "label": "-14000"
           },
           "stop": {
+            "in": {
+              "year": "-8200"
+            },
             "label": "-8200"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2726,9 +3277,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1500000"
+            },
             "label": "-1500000"
           },
           "stop": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2746,9 +3303,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3900"
+            },
             "label": "-3900"
           },
           "stop": {
+            "in": {
+              "year": "-1700"
+            },
             "label": "-1700"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2766,9 +3329,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1700"
+            },
             "label": "-1700"
           },
           "stop": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2786,9 +3355,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "stop": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2806,9 +3381,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050"
           },
           "stop": {
+            "in": {
+              "year": "1536"
+            },
             "label": "1536"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2826,9 +3407,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1536"
+            },
             "label": "1536"
           },
           "stop": {
+            "in": {
+              "year": "1660"
+            },
             "label": "1660"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2847,6 +3434,9 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1660"
+            },
             "label": "1660"
           },
           "stop": {
@@ -2867,9 +3457,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9000"
+            },
             "label": "-9000"
           },
           "stop": {
+            "in": {
+              "year": "-3900"
+            },
             "label": "-3900"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2891,6 +3487,9 @@
             "label": "before -6000"
           },
           "stop": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2908,9 +3507,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "-7000"
+            },
             "label": "-7000"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2928,9 +3533,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "stop": {
+            "in": {
+              "year": "-2200"
+            },
             "label": "-2200"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2948,9 +3559,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "stop": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2968,9 +3585,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "0043"
+            },
             "label": "43"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -2988,9 +3611,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3008,9 +3637,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0043"
+            },
             "label": "43"
           },
           "stop": {
+            "in": {
+              "year": "0410"
+            },
             "label": "410"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3028,9 +3663,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0410"
+            },
             "label": "410"
           },
           "stop": {
+            "in": {
+              "year": "1066"
+            },
             "label": "1066"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3048,9 +3689,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1066"
+            },
             "label": "1066"
           },
           "stop": {
+            "in": {
+              "year": "1540"
+            },
             "label": "1540"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3068,9 +3715,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1540"
+            },
             "label": "1540"
           },
           "stop": {
+            "in": {
+              "year": "1901"
+            },
             "label": "1901"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3089,6 +3742,9 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1901"
+            },
             "label": "1901"
           },
           "stop": {
@@ -3113,6 +3769,9 @@
             "label": "before 1000"
           },
           "stop": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3130,9 +3789,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100"
           },
           "stop": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3150,9 +3815,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "stop": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3171,6 +3842,9 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
@@ -3191,9 +3865,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "stop": {
+            "in": {
+              "year": "-1800"
+            },
             "label": "-1800"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3211,9 +3891,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1800"
+            },
             "label": "-1800"
           },
           "stop": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3231,9 +3917,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "stop": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3251,9 +3943,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050"
           },
           "stop": {
+            "in": {
+              "year": "1537"
+            },
             "label": "1537"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3272,6 +3970,9 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1537"
+            },
             "label": "1537"
           },
           "stop": {
@@ -3292,9 +3993,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8200"
+            },
             "label": "-8200"
           },
           "stop": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3312,9 +4019,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "stop": {
+            "in": {
+              "year": "-1800"
+            },
             "label": "-1800"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3332,9 +4045,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1800"
+            },
             "label": "-1800"
           },
           "stop": {
+            "in": {
+              "year": "-0400"
+            },
             "label": "-400"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3352,9 +4071,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0400"
+            },
             "label": "-400"
           },
           "stop": {
+            "in": {
+              "year": "0100"
+            },
             "label": "100"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3372,9 +4097,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0100"
+            },
             "label": "100"
           },
           "stop": {
+            "in": {
+              "year": "0375"
+            },
             "label": "375"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3392,9 +4123,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0375"
+            },
             "label": "375"
           },
           "stop": {
+            "in": {
+              "year": "0600"
+            },
             "label": "600"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3412,9 +4149,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0600"
+            },
             "label": "600"
           },
           "stop": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3432,9 +4175,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3453,6 +4202,9 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
@@ -3473,9 +4225,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-7000"
+            },
             "label": "-7000"
           },
           "stop": {
+            "in": {
+              "year": "-3200"
+            },
             "label": "-3200"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3493,9 +4251,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3200"
+            },
             "label": "-3200"
           },
           "stop": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3513,9 +4277,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "0106"
+            },
             "label": "106"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3533,9 +4303,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0650"
+            },
             "label": "-650"
           },
           "stop": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "-30"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3553,9 +4329,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0106"
+            },
             "label": "106"
           },
           "stop": {
+            "in": {
+              "year": "0602"
+            },
             "label": "602"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3573,9 +4355,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0353"
+            },
             "label": "353"
           },
           "stop": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3593,9 +4381,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1821"
+            },
             "label": "1821"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3613,9 +4407,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1821"
+            },
             "label": "1821"
           },
           "stop": {
+            "in": {
+              "year": "1918"
+            },
             "label": "1918"
           },
           "url": "http%3A%2F%2Fads.ahds.ac.uk%2Farena%2Fsearch%2Fperiod.cfm"
@@ -3652,9 +4452,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 B.C."
           },
           "url": "http%3A%2F%2Fwww4.uwm.edu%2Fceltic%2Fekeltoi%2Fvolumes%2Fvol6%2F6_4%2Florrio_zapatero_6_4.html"
@@ -3672,9 +4478,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0099"
+            },
             "label": "100 B.C."
           },
           "url": "http%3A%2F%2Fwww4.uwm.edu%2Fceltic%2Fekeltoi%2Fvolumes%2Fvol6%2F6_4%2Florrio_zapatero_6_4.html"
@@ -3710,9 +4522,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0549"
+            },
             "label": "550 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0205"
+            },
             "label": "206 B.C."
           }
         },
@@ -3729,9 +4547,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0549"
+            },
             "label": "550 B.C."
           }
         }
@@ -3772,9 +4596,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-500000"
+            },
             "label": "-500000"
           },
           "stop": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FPA"
@@ -3794,9 +4624,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-500000"
+            },
             "label": "-500000"
           },
           "stop": {
+            "in": {
+              "year": "-150000"
+            },
             "label": "-150000"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FLPA"
@@ -3816,9 +4652,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-150000"
+            },
             "label": "-150000"
           },
           "stop": {
+            "in": {
+              "year": "-40000"
+            },
             "label": "-40000"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FMPA"
@@ -3838,9 +4680,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-40000"
+            },
             "label": "-40000"
           },
           "stop": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FUPA"
@@ -3860,9 +4708,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FME"
@@ -3882,9 +4736,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "-7000"
+            },
             "label": "-7000"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FEME"
@@ -3904,9 +4764,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-7000"
+            },
             "label": "-7000"
           },
           "stop": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FLME"
@@ -3926,9 +4792,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-500000"
+            },
             "label": "-500000"
           },
           "stop": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FEPR"
@@ -3948,9 +4820,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "stop": {
+            "in": {
+              "year": "-2200"
+            },
             "label": "-2200"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FNE"
@@ -3970,9 +4848,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "stop": {
+            "in": {
+              "year": "-3300"
+            },
             "label": "-3300"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FENE"
@@ -3992,9 +4876,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3300"
+            },
             "label": "-3300"
           },
           "stop": {
+            "in": {
+              "year": "-2900"
+            },
             "label": "-2900"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FMNE"
@@ -4014,9 +4904,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2900"
+            },
             "label": "-2900"
           },
           "stop": {
+            "in": {
+              "year": "-2200"
+            },
             "label": "-2200"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FLNE"
@@ -4036,9 +4932,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2600"
+            },
             "label": "-2600"
           },
           "stop": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FBA"
@@ -4058,9 +4960,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2600"
+            },
             "label": "-2600"
           },
           "stop": {
+            "in": {
+              "year": "-1600"
+            },
             "label": "-1600"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FEBA"
@@ -4080,9 +4988,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1600"
+            },
             "label": "-1600"
           },
           "stop": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FMBA"
@@ -4102,9 +5016,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FLBA"
@@ -4124,9 +5044,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "0043"
+            },
             "label": "43"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FIA"
@@ -4146,9 +5072,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "-0300"
+            },
             "label": "-300"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FEIA"
@@ -4168,9 +5100,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0300"
+            },
             "label": "-300"
           },
           "stop": {
+            "in": {
+              "year": "-0100"
+            },
             "label": "-100"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FMIA"
@@ -4190,9 +5128,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0100"
+            },
             "label": "-100"
           },
           "stop": {
+            "in": {
+              "year": "0043"
+            },
             "label": "43"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FLIA"
@@ -4212,9 +5156,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "stop": {
+            "in": {
+              "year": "0043"
+            },
             "label": "43"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FLPR"
@@ -4234,9 +5184,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-500000"
+            },
             "label": "-500000"
           },
           "stop": {
+            "in": {
+              "year": "0043"
+            },
             "label": "43"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FPR"
@@ -4256,9 +5212,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0043"
+            },
             "label": "43"
           },
           "stop": {
+            "in": {
+              "year": "0410"
+            },
             "label": "410"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FRO"
@@ -4278,9 +5240,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0410"
+            },
             "label": "410"
           },
           "stop": {
+            "in": {
+              "year": "1066"
+            },
             "label": "1066"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FEM"
@@ -4300,9 +5268,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1066"
+            },
             "label": "1066"
           },
           "stop": {
+            "in": {
+              "year": "1540"
+            },
             "label": "1540"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FMD"
@@ -4322,9 +5296,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1540"
+            },
             "label": "1540"
           },
           "stop": {
+            "in": {
+              "year": "1901"
+            },
             "label": "1901"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FPM"
@@ -4344,9 +5324,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1485"
+            },
             "label": "1485"
           },
           "stop": {
+            "in": {
+              "year": "1603"
+            },
             "label": "1603"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FTUD"
@@ -4366,9 +5352,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1558"
+            },
             "label": "1558"
           },
           "stop": {
+            "in": {
+              "year": "1603"
+            },
             "label": "1603"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FLIZ"
@@ -4388,9 +5380,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1603"
+            },
             "label": "1603"
           },
           "stop": {
+            "in": {
+              "year": "1714"
+            },
             "label": "1714"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FSTU"
@@ -4410,9 +5408,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1603"
+            },
             "label": "1603"
           },
           "stop": {
+            "in": {
+              "year": "1625"
+            },
             "label": "1625"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FJAC"
@@ -4432,9 +5436,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1714"
+            },
             "label": "1714"
           },
           "stop": {
+            "in": {
+              "year": "1837"
+            },
             "label": "1837"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FHAN"
@@ -4454,9 +5464,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1714"
+            },
             "label": "1714"
           },
           "stop": {
+            "in": {
+              "year": "1830"
+            },
             "label": "1830"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FGEO"
@@ -4476,9 +5492,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1837"
+            },
             "label": "1837"
           },
           "stop": {
+            "in": {
+              "year": "1901"
+            },
             "label": "1901"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FVIC"
@@ -4498,9 +5520,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1901"
+            },
             "label": "1901"
           },
           "stop": {
+            "in": {
+              "year": "2000"
+            },
             "label": "2000"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FC20"
@@ -4520,9 +5548,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1901"
+            },
             "label": "1901"
           },
           "stop": {
+            "in": {
+              "year": "1932"
+            },
             "label": "1932"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FE20"
@@ -4542,9 +5576,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1902"
+            },
             "label": "1902"
           },
           "stop": {
+            "in": {
+              "year": "1910"
+            },
             "label": "1910"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FEDW"
@@ -4564,9 +5604,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1914"
+            },
             "label": "1914"
           },
           "stop": {
+            "in": {
+              "year": "1918"
+            },
             "label": "1918"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FWW1"
@@ -4586,9 +5632,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1933"
+            },
             "label": "1933"
           },
           "stop": {
+            "in": {
+              "year": "1966"
+            },
             "label": "1966"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FM20"
@@ -4608,9 +5660,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1939"
+            },
             "label": "1939"
           },
           "stop": {
+            "in": {
+              "year": "1945"
+            },
             "label": "1945"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FWW2"
@@ -4630,9 +5688,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1967"
+            },
             "label": "1967"
           },
           "stop": {
+            "in": {
+              "year": "2000"
+            },
             "label": "2000"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FL20"
@@ -4652,9 +5716,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1946"
+            },
             "label": "1946"
           },
           "stop": {
+            "in": {
+              "year": "1991"
+            },
             "label": "1991"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FWW3"
@@ -4674,9 +5744,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2001"
+            },
             "label": "2001"
           },
           "stop": {
+            "in": {
+              "year": "2100"
+            },
             "label": "2100"
           },
           "url": "http%3A%2F%2Fpurl.org%2Fheritagedata%2Fschemes%2Feh_period%2Fconcepts%2FC21"
@@ -4716,9 +5792,15 @@
           ],
           "spatialCoverageDescription": "ancient Middle East",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           }
         },
@@ -4740,9 +5822,15 @@
           ],
           "spatialCoverageDescription": "ancient Middle East",
           "start": {
+            "in": {
+              "year": "-2599"
+            },
             "label": "c. 2600 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2299"
+            },
             "label": "2300 BC"
           }
         }
@@ -4777,9 +5865,15 @@
           ],
           "spatialCoverageDescription": "Lepcis Magna",
           "start": {
+            "in": {
+              "year": "-0649"
+            },
             "label": "650 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 B.C."
           }
         }
@@ -4840,9 +5934,15 @@
           ],
           "spatialCoverageDescription": "west-central Austria",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "c.1200 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "480 BC"
           }
         },
@@ -4871,9 +5971,15 @@
           ],
           "spatialCoverageDescription": "west-central Austria",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "c.1200 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 BC"
           }
         },
@@ -4902,9 +6008,15 @@
           ],
           "spatialCoverageDescription": "west-central Austria",
           "start": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "c.1000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0749"
+            },
             "label": "750 BC"
           }
         },
@@ -4946,9 +6058,15 @@
           ],
           "spatialCoverageDescription": "west-central Austria",
           "start": {
+            "in": {
+              "year": "-0749"
+            },
             "label": "c.750 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "600 BC"
           }
         },
@@ -4990,9 +6108,15 @@
           ],
           "spatialCoverageDescription": "west-central Austria",
           "start": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "c.600 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "480 BC"
           }
         },
@@ -5027,9 +6151,15 @@
           ],
           "spatialCoverageDescription": "La Tène (north-west Switzerland), Bohemia, Marne-Champagne, Mosel-Rhineland",
           "start": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "c.480 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0049"
+            },
             "label": "50 BC"
           }
         },
@@ -5064,9 +6194,15 @@
           ],
           "spatialCoverageDescription": "La Tène (north-west Switzerland), Bohemia, Marne-Champagne, Mosel-Rhineland",
           "start": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "c.480 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 BC"
           }
         },
@@ -5101,9 +6237,15 @@
           ],
           "spatialCoverageDescription": "La Tène (north-west Switzerland), Bohemia, Marne-Champagne, Mosel-Rhineland",
           "start": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0249"
+            },
             "label": "250 BC"
           }
         },
@@ -5138,9 +6280,15 @@
           ],
           "spatialCoverageDescription": "La Tène (north-west Switzerland), Bohemia, Marne-Champagne, Mosel-Rhineland",
           "start": {
+            "in": {
+              "year": "-0249"
+            },
             "label": "c.250 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0119"
+            },
             "label": "120 BC"
           }
         },
@@ -5167,9 +6315,15 @@
           ],
           "spatialCoverageDescription": "La Tène (north-west Switzerland), Mosel-Rhineland",
           "start": {
+            "in": {
+              "year": "-0119"
+            },
             "label": "120 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0049"
+            },
             "label": "50 BC"
           }
         },
@@ -5192,9 +6346,15 @@
           ],
           "spatialCoverageDescription": "Mediolanum, River Po, Rome",
           "start": {
+            "in": {
+              "year": "-0049"
+            },
             "label": "50 BC"
           },
           "stop": {
+            "in": {
+              "year": "0300"
+            },
             "label": "AD 300"
           }
         },
@@ -5224,9 +6384,15 @@
           ],
           "spatialCoverageDescription": "Caledonia, Ireland",
           "start": {
+            "in": {
+              "year": "0300"
+            },
             "label": "AD 300"
           },
           "stop": {
+            "in": {
+              "year": "0500"
+            },
             "label": "AD 500"
           }
         },
@@ -5252,9 +6418,15 @@
           ],
           "spatialCoverageDescription": "East Britain",
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "AD 500"
           },
           "stop": {
+            "in": {
+              "year": "0800"
+            },
             "label": "AD 800"
           }
         },
@@ -5281,9 +6453,15 @@
           ],
           "spatialCoverageDescription": "Britain, Ireland",
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "AD 800"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "AD 1000"
           }
         }
@@ -5344,9 +6522,15 @@
           ],
           "spatialCoverageDescription": "ancient Near East",
           "start": {
+            "in": {
+              "year": "-0164"
+            },
             "label": "165 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0063"
+            },
             "label": "64 B.C."
           }
         }
@@ -5396,6 +6580,9 @@
             "label": "before 8800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-8799"
+            },
             "label": "8800 B.C."
           }
         },
@@ -5420,6 +6607,9 @@
             "label": "before 300000 BP"
           },
           "stop": {
+            "in": {
+              "year": "-298000"
+            },
             "label": "300000 C14 BP"
           }
         },
@@ -5440,9 +6630,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-298000"
+            },
             "label": "300000 C14 BP"
           },
           "stop": {
+            "in": {
+              "year": "-33000"
+            },
             "label": "35000 C14 BP"
           }
         },
@@ -5463,9 +6659,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-33000"
+            },
             "label": "35000 C14 BP"
           },
           "stop": {
+            "in": {
+              "year": "-8799"
+            },
             "label": "8800 B.C."
           }
         },
@@ -5486,9 +6688,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-33000"
+            },
             "label": "35000 C14 BP"
           },
           "stop": {
+            "in": {
+              "year": "-16000"
+            },
             "label": "18000 C14 BP"
           }
         },
@@ -5509,9 +6717,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-16000"
+            },
             "label": "18000 C14 BP"
           },
           "stop": {
+            "in": {
+              "year": "-8799"
+            },
             "label": "8800 B.C."
           }
         },
@@ -5532,9 +6746,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8799"
+            },
             "label": "8800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-4899"
+            },
             "label": "4900 B.C."
           }
         },
@@ -5555,9 +6775,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8799"
+            },
             "label": "8800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-7099"
+            },
             "label": "7100 B.C."
           }
         },
@@ -5578,9 +6804,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-7099"
+            },
             "label": "7100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-6449"
+            },
             "label": "6450 B.C."
           }
         },
@@ -5601,9 +6833,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6449"
+            },
             "label": "6450 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-4899"
+            },
             "label": "4900 B.C."
           }
         },
@@ -5624,9 +6862,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5299"
+            },
             "label": "5300 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C."
           }
         },
@@ -5647,9 +6891,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5299"
+            },
             "label": "5300 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-4199"
+            },
             "label": "4200 B.C."
           }
         },
@@ -5670,9 +6920,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5299"
+            },
             "label": "5300 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-4899"
+            },
             "label": "4900 B.C."
           }
         },
@@ -5693,9 +6949,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4899"
+            },
             "label": "4900 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-4199"
+            },
             "label": "4200 B.C."
           }
         },
@@ -5716,9 +6978,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4199"
+            },
             "label": "4200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2849"
+            },
             "label": "2850 B.C."
           }
         },
@@ -5739,9 +7007,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4199"
+            },
             "label": "4200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3399"
+            },
             "label": "3400 B.C."
           }
         },
@@ -5762,9 +7036,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3399"
+            },
             "label": "3400 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2849"
+            },
             "label": "2850 B.C."
           }
         },
@@ -5785,9 +7065,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2849"
+            },
             "label": "2850 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C."
           }
         },
@@ -5808,9 +7094,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2849"
+            },
             "label": "2850 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2449"
+            },
             "label": "2450 B.C."
           }
         },
@@ -5831,9 +7123,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2449"
+            },
             "label": "2450 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C."
           }
         },
@@ -5854,9 +7152,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           }
         },
@@ -5877,9 +7181,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "1800 B.C."
           }
         },
@@ -5900,9 +7210,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "1800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 B.C."
           }
         },
@@ -5923,9 +7239,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "1800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 B.C."
           }
         },
@@ -5946,9 +7268,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 B.C."
           }
         },
@@ -5969,9 +7297,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           }
         },
@@ -5992,9 +7326,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0011"
+            },
             "label": "12 B.C."
           }
         },
@@ -6015,9 +7355,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 B.C."
           }
         },
@@ -6038,9 +7384,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0249"
+            },
             "label": "250 B.C."
           }
         },
@@ -6061,9 +7413,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0249"
+            },
             "label": "250 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0011"
+            },
             "label": "12 B.C."
           }
         },
@@ -6084,9 +7442,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0011"
+            },
             "label": "12 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450 A.D."
           }
         },
@@ -6107,9 +7471,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0011"
+            },
             "label": "12 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0070"
+            },
             "label": "70 A.D."
           }
         },
@@ -6130,9 +7500,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0011"
+            },
             "label": "12 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0025"
+            },
             "label": "25 A.D."
           }
         },
@@ -6153,9 +7529,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0025"
+            },
             "label": "25 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0070"
+            },
             "label": "70 A.D."
           }
         },
@@ -6176,9 +7558,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0070"
+            },
             "label": "70 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0270"
+            },
             "label": "270 A.D."
           }
         },
@@ -6199,9 +7587,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0070"
+            },
             "label": "70 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0150"
+            },
             "label": "150 A.D."
           }
         },
@@ -6222,9 +7616,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0150"
+            },
             "label": "150 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0270"
+            },
             "label": "270 A.D."
           }
         },
@@ -6245,9 +7645,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0270"
+            },
             "label": "270 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450 A.D."
           }
         },
@@ -6268,9 +7674,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0270"
+            },
             "label": "270 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0350"
+            },
             "label": "350 A.D."
           }
         },
@@ -6291,9 +7703,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0350"
+            },
             "label": "350 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450 A.D."
           }
         },
@@ -6314,9 +7732,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500 A.D."
           }
         },
@@ -6337,9 +7761,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050 A.D."
           }
         },
@@ -6360,9 +7790,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0525"
+            },
             "label": "525 A.D."
           }
         },
@@ -6383,9 +7819,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0525"
+            },
             "label": "525 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0725"
+            },
             "label": "725 A.D."
           }
         },
@@ -6406,9 +7848,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0725"
+            },
             "label": "725 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900 A.D."
           }
         },
@@ -6429,9 +7877,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050 A.D."
           }
         },
@@ -6452,9 +7906,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500 A.D."
           }
         },
@@ -6475,9 +7935,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250 A.D."
           }
         },
@@ -6498,9 +7964,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500 A.D."
           }
         },
@@ -6521,9 +7993,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500 A.D."
           },
           "stop": {
+            "in": {
+              "year": "2050"
+            },
             "label": "2050 A.D."
           }
         },
@@ -6544,9 +8022,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650 A.D."
           }
         },
@@ -6567,9 +8051,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1850"
+            },
             "label": "1850 A.D."
           }
         },
@@ -6590,9 +8080,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1850"
+            },
             "label": "1850 A.D."
           },
           "stop": {
+            "in": {
+              "year": "2050"
+            },
             "label": "2050 A.D."
           }
         }
@@ -6632,9 +8128,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0752"
+            },
             "label": "753 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0579"
+            },
             "label": "580 B.C."
           }
         },
@@ -6655,9 +8157,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1019"
+            },
             "label": "1020 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0579"
+            },
             "label": "580 B.C."
           }
         },
@@ -6678,9 +8186,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           }
         },
@@ -6701,9 +8215,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0752"
+            },
             "label": "753 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0508"
+            },
             "label": "509 B.C."
           }
         },
@@ -6724,9 +8244,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0749"
+            },
             "label": "750 B.C."
           }
         }
@@ -6769,9 +8295,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-8499"
+            },
             "label": "ca. 8500 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-7499"
+            },
             "label": "7500 B.C.E."
           }
         },
@@ -6798,9 +8330,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-7499"
+            },
             "label": "7500 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-5999"
+            },
             "label": "6000 B.C.E."
           }
         },
@@ -6827,9 +8365,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-5999"
+            },
             "label": "6000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-4999"
+            },
             "label": "5000 B.C.E."
           }
         },
@@ -6856,9 +8400,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-4999"
+            },
             "label": "5000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-4299"
+            },
             "label": "4300 B.C.E."
           }
         },
@@ -6885,9 +8435,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-4299"
+            },
             "label": "4300 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 B.C.E."
           }
         },
@@ -6917,9 +8473,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C.E."
           }
         },
@@ -6949,9 +8511,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-2299"
+            },
             "label": "2300 B.C.E."
           }
         },
@@ -6978,9 +8546,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-3049"
+            },
             "label": "3050 B.C.E."
           }
         },
@@ -7007,9 +8581,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-3049"
+            },
             "label": "3050 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-2299"
+            },
             "label": "2300 B.C.E."
           }
         },
@@ -7036,9 +8616,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-2299"
+            },
             "label": "2300 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C.E."
           }
         },
@@ -7068,9 +8654,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-2299"
+            },
             "label": "2300 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 B.C.E."
           }
         },
@@ -7097,9 +8689,16 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C.E."
           },
           "stop": {
+            "in": {
+              "earliestYear": "-1799",
+              "latestYear": "-1749"
+            },
             "label": "1800/1750 B.C.E."
           }
         },
@@ -7126,9 +8725,16 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "earliestYear": "-1799",
+              "latestYear": "-1749"
+            },
             "label": "1800/1750 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 B.C.E."
           }
         },
@@ -7158,9 +8764,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C.E."
           }
         },
@@ -7187,9 +8799,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "1400 B.C.E."
           }
         },
@@ -7216,9 +8834,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "1400 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C.E."
           }
         },
@@ -7248,9 +8872,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0585"
+            },
             "label": "586 B.C.E."
           }
         },
@@ -7277,9 +8907,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 B.C.E."
           }
         },
@@ -7306,9 +8942,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1149"
+            },
             "label": "1150 B.C.E."
           }
         },
@@ -7335,9 +8977,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-1149"
+            },
             "label": "1150 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 B.C.E."
           }
         },
@@ -7364,9 +9012,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0585"
+            },
             "label": "586 B.C.E."
           }
         },
@@ -7393,9 +9047,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0924"
+            },
             "label": "925 B.C.E."
           }
         },
@@ -7422,9 +9082,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-0924"
+            },
             "label": "925 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0721"
+            },
             "label": "722 B.C.E."
           }
         },
@@ -7451,9 +9117,15 @@
           ],
           "spatialCoverageDescription": "Palestine",
           "start": {
+            "in": {
+              "year": "-0721"
+            },
             "label": "722 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0585"
+            },
             "label": "586 B.C.E."
           }
         },
@@ -7499,9 +9171,15 @@
           ],
           "spatialCoverageDescription": "Palestine, Egypt, Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "1900 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 B.C.E."
           }
         },
@@ -7547,9 +9225,15 @@
           ],
           "spatialCoverageDescription": "Israel, Phoenicia",
           "start": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 B.C.E."
           }
         }
@@ -7583,9 +9267,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2399"
+            },
             "label": "2400 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2099"
+            },
             "label": "2100 B.C."
           }
         }
@@ -7686,9 +9376,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9550"
+            },
             "label": "-9550"
           },
           "stop": {
+            "in": {
+              "year": "-7950"
+            },
             "label": "-7950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEB0B866B-B707-4690-FBF9-A32A7A2170C4"
@@ -7707,9 +9403,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9550"
+            },
             "label": "-9550"
           },
           "stop": {
+            "in": {
+              "year": "-9050"
+            },
             "label": "-9050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F577E7194-B33B-4928-04DA-16B855152EC9"
@@ -7728,9 +9430,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8550"
+            },
             "label": "-8550"
           },
           "stop": {
+            "in": {
+              "year": "-7950"
+            },
             "label": "-7950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F62B43AC0-75F8-4B38-3207-964ECFB9BAEE"
@@ -7749,9 +9457,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1540"
+            },
             "label": "1540"
           },
           "stop": {
+            "in": {
+              "year": "1640"
+            },
             "label": "1640"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2F280738-FB98-4047-062F-B3916A27ED89"
@@ -7770,9 +9484,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1350"
+            },
             "label": "1350"
           },
           "stop": {
+            "in": {
+              "year": "1540"
+            },
             "label": "1540"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF1C2B779-6985-4B1E-B3B6-DF6D6A169353"
@@ -7791,9 +9511,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFE56D76F-91C9-4F26-B010-BCB69332953E"
@@ -7812,9 +9538,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8050"
+            },
             "label": "-8050"
           },
           "stop": {
+            "in": {
+              "year": "-1050"
+            },
             "label": "-1050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2A24ECA7-D661-45AA-B869-D1BAC84C186E"
@@ -7833,9 +9565,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1050"
+            },
             "label": "-1050"
           },
           "stop": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F75944058-DF08-4A90-1C75-E82DAE5AA1D3"
@@ -7854,9 +9592,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1150"
+            },
             "label": "1150"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F275E6761-CAF0-436E-2119-20011CB7827E"
@@ -7875,9 +9619,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6050"
+            },
             "label": "-6050"
           },
           "stop": {
+            "in": {
+              "year": "-3050"
+            },
             "label": "-3050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FB863CFDD-C4CC-4D40-92EA-7D5FD2C9F156"
@@ -7896,9 +9646,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1540"
+            },
             "label": "1540"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC44C37CD-B609-4683-5FAD-018270CAF2AD"
@@ -7917,9 +9673,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1540"
+            },
             "label": "1540"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7E02955B-C113-48CF-9432-2B8AD311734B"
@@ -7938,9 +9700,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3050"
+            },
             "label": "-3050"
           },
           "stop": {
+            "in": {
+              "year": "-1050"
+            },
             "label": "-1050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FECC9AE2D-3548-40CD-9E4A-6D4AF9350DC8"
@@ -7959,9 +9727,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "stop": {
+            "in": {
+              "year": "1350"
+            },
             "label": "1350"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD42D4DD3-7DBD-43ED-D197-EFC2093B71DC"
@@ -7980,9 +9754,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9550"
+            },
             "label": "-9550"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0104F292-7A50-4920-275D-03799C529FCD"
@@ -8001,9 +9781,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1050"
+            },
             "label": "-1050"
           },
           "stop": {
+            "in": {
+              "year": "1150"
+            },
             "label": "1150"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FDAD05B09-9F46-4F2D-B1EB-A8C803C2C187"
@@ -8022,9 +9808,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1540"
+            },
             "label": "1540"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F62432CA4-632C-4B57-042B-DA08A1DB3099"
@@ -8043,9 +9835,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "stop": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF9226478-270C-48EF-C2B6-B8A392186D48"
@@ -8064,9 +9862,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8050"
+            },
             "label": "-8050"
           },
           "stop": {
+            "in": {
+              "year": "-6050"
+            },
             "label": "-6050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F15EFE289-8711-4A85-8127-2852A3B16B4A"
@@ -8085,9 +9889,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F95E1FA65-FC34-499D-52FA-6EC121EFC629"
@@ -8106,9 +9916,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE0B3BB8C-34B0-4D38-3A1D-C6CEED6664A2"
@@ -8127,9 +9943,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9500"
+            },
             "label": "-9500"
           },
           "stop": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F236B7CBB-1052-4C05-5411-ACE21863C9D5"
@@ -8148,9 +9970,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "-7500"
+            },
             "label": "-7500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6B33B7E2-AA94-43C8-C600-7D0542643B16"
@@ -8169,9 +9997,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0390"
+            },
             "label": "390"
           },
           "stop": {
+            "in": {
+              "year": "1400"
+            },
             "label": "1400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F51912EEB-DFFE-4F27-70B9-FAAEE78846A8"
@@ -8193,9 +10027,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0950"
+            },
             "label": "950"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F601418E2-A552-4C75-2276-6238DEB78E6F"
@@ -8214,9 +10054,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FBCAF0CAF-D4A6-42E0-EB7A-5E403C9BDD4F"
@@ -8235,9 +10081,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F5425C0F4-E3A1-4D32-1088-7F12D64C9283"
@@ -8256,9 +10108,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F21E09884-56A5-472A-ADFD-7BC6E6C772A1"
@@ -8277,9 +10135,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FED4A5A2B-8906-4BC8-B4FC-37F85BBDC5FC"
@@ -8298,9 +10162,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FBBBE2872-E2BB-4AED-88BA-0425BEC292CE"
@@ -8319,9 +10189,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0200"
+            },
             "label": "200"
           },
           "stop": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7785668B-DFDA-40EE-979D-E2E91BDB9E21"
@@ -8340,9 +10216,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F29015DF4-C4CE-4C08-D3D5-4723C4F071AC"
@@ -8361,9 +10243,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "stop": {
+            "in": {
+              "year": "0100"
+            },
             "label": "100"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6357D487-6ADB-475B-B8F4-40C1A579AADA"
@@ -8382,9 +10270,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1350"
+            },
             "label": "1350"
           },
           "stop": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6A98E397-3CB0-486A-756E-C97248997166"
@@ -8403,9 +10297,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "stop": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F63339B73-F076-4ACD-B897-60E75DC66A73"
@@ -8424,9 +10324,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1565"
+            },
             "label": "1565"
           },
           "stop": {
+            "in": {
+              "year": "1821"
+            },
             "label": "1821"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4730C898-F214-40F5-DABF-7B00349975C1"
@@ -8445,9 +10351,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1350"
+            },
             "label": "1350"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F39ED9C66-B668-48D8-6AAC-0D159F4C51AE"
@@ -8466,9 +10378,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3D22A324-6ECA-41C2-961F-1588016646C7"
@@ -8487,9 +10405,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "stop": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F18C0FFE0-F906-4940-3619-36DA8614515A"
@@ -8511,9 +10435,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F5AC649C4-E169-49E5-09B0-C2F501D4F225"
@@ -8535,9 +10465,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "0700"
+            },
             "label": "700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEE939F33-7506-472B-0413-2C1B68F8CF08"
@@ -8556,9 +10492,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "stop": {
+            "in": {
+              "year": "1350"
+            },
             "label": "1350"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE98C8BA0-06C8-4BB6-28DE-BD4B6A875E7C"
@@ -8577,9 +10519,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F120E3920-2732-4798-457C-D827E7DC6228"
@@ -8598,9 +10546,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFB3291E2-DFF7-4706-BBEA-F17AD15B7A1B"
@@ -8619,9 +10573,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "stop": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F09C441EC-2991-4D7B-C494-76643EB520A0"
@@ -8643,9 +10603,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3EFF5BFB-F855-48BB-DD87-7C22B011F505"
@@ -8664,9 +10630,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1712"
+            },
             "label": "1712"
           },
           "stop": {
+            "in": {
+              "year": "1836"
+            },
             "label": "1836"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6D3B2544-73D5-4039-BE29-3CCEA49C906D"
@@ -8685,9 +10657,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FDF011360-3883-4CFE-7F71-E38070433156"
@@ -8706,9 +10684,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "stop": {
+            "in": {
+              "year": "-1500"
+            },
             "label": "-1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3519B151-F0BB-4608-4DE5-8FB8DE675FBC"
@@ -8727,9 +10711,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0100"
+            },
             "label": "100"
           },
           "stop": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6998A94A-A667-484B-D076-9301FA0B627F"
@@ -8748,9 +10738,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1300"
+            },
             "label": "1300"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8A27AE27-ADDC-4837-4564-DE132531ACEA"
@@ -8769,9 +10765,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0300"
+            },
             "label": "-300"
           },
           "stop": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4B9D4152-335D-4CD3-36D0-30BEECF9DF21"
@@ -8790,9 +10792,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4FF94278-0012-4946-65AB-BE641ECB84C7"
@@ -8811,9 +10819,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F03AC316A-6D63-464A-D049-D729BFAD831D"
@@ -8832,9 +10846,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F5196D75D-4999-4CB1-8DC4-D14BA291704E"
@@ -8853,9 +10873,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0100"
+            },
             "label": "100"
           },
           "stop": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3CE39F99-29D8-432B-47BE-016BEB989446"
@@ -8874,9 +10900,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0100"
+            },
             "label": "100"
           },
           "stop": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4792A466-BF9C-484E-5C38-6BC82351F1FC"
@@ -8895,9 +10927,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0100"
+            },
             "label": "100"
           },
           "stop": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F70A61106-5734-4E4B-BF7E-E0D428055300"
@@ -8919,9 +10957,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEA126D7F-F578-4E5D-D1B8-B4CF84A1F9E9"
@@ -8940,9 +10984,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFB907C06-A658-4124-D148-B04BF5B4209C"
@@ -8961,9 +11011,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA6AC6596-6B43-4F3C-3484-B308F4EA3AA8"
@@ -8982,9 +11038,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEA858FF3-9923-4841-C83C-EB9595CFF6DA"
@@ -9003,9 +11065,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0390"
+            },
             "label": "390"
           },
           "stop": {
+            "in": {
+              "year": "0700"
+            },
             "label": "700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F99A40928-231E-4274-9F13-DA2E29325A2B"
@@ -9024,9 +11092,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0650"
+            },
             "label": "650"
           },
           "stop": {
+            "in": {
+              "year": "1400"
+            },
             "label": "1400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F29185C6E-8A84-4DA5-D3D3-1AE56B1700B3"
@@ -9045,9 +11119,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD1889205-046A-4601-950A-53519AFC60D5"
@@ -9070,9 +11150,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1856"
+            },
             "label": "1856"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7C5749B9-5A65-45EE-712F-65B61AB4EE37"
@@ -9091,9 +11177,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2CC22BA8-0414-4F4C-8EAF-C2F5C3E7567D"
@@ -9112,9 +11204,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA47D1EA7-20C1-4518-DCF5-46E6E096545E"
@@ -9133,9 +11231,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA0E84B35-E8BB-4C2A-0060-AF65823B8D6B"
@@ -9154,9 +11258,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFC88F6E9-326D-49F6-99D8-E776FFDD9F25"
@@ -9175,9 +11285,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA15C3953-F51F-4492-9D6E-B73FCA61CA7E"
@@ -9196,9 +11312,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF0E815B1-8B70-442D-B37E-319A1E04A387"
@@ -9217,9 +11339,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD7F5D020-08F0-4990-1031-C24B58D91ACF"
@@ -9238,9 +11366,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE1F43301-E494-4157-4037-480F4E51B9E8"
@@ -9262,9 +11396,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6F09CE0E-FB02-479C-E6E8-00AB4BDB90F1"
@@ -9286,9 +11426,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FCA783E80-4E7F-43EC-5F3B-9ACFC244A7C6"
@@ -9310,9 +11456,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F43821D1D-F2C1-474A-E722-C715070CCC7F"
@@ -9334,9 +11486,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD5D8804B-605F-4ACA-FB36-E09CFEFE1289"
@@ -9355,9 +11513,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA30398C9-9E55-4D73-E46C-BED6330CAA7B"
@@ -9376,9 +11540,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "stop": {
+            "in": {
+              "year": "-7000"
+            },
             "label": "-7000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE99618FC-0EFE-473F-FFB3-BFCE6D4AE9EE"
@@ -9397,9 +11567,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F14A2A4FB-AAC0-4C75-6E09-739E302FB5C5"
@@ -9418,9 +11594,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F5BA4B4AF-4AE7-41F9-6F82-39BDFDE1D9FF"
@@ -9439,9 +11621,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FED033FE6-4592-4A2A-39DC-600BEC4F1F91"
@@ -9463,9 +11651,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F986388EB-BF21-4D1F-EDF2-48000CAFAE83"
@@ -9484,9 +11678,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8750"
+            },
             "label": "-8750"
           },
           "stop": {
+            "in": {
+              "year": "-6900"
+            },
             "label": "-6900"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD87815EB-246B-46B1-C27F-FADA168FE17F"
@@ -9508,9 +11708,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1783"
+            },
             "label": "1783"
           },
           "stop": {
+            "in": {
+              "year": "1821"
+            },
             "label": "1821"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F67FAA4AC-E4F1-4D8F-C608-10F39C9FECCD"
@@ -9532,9 +11738,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1513"
+            },
             "label": "1513"
           },
           "stop": {
+            "in": {
+              "year": "1599"
+            },
             "label": "1599"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3684EBEF-C8AA-498D-66E4-B6B12E36D94E"
@@ -9553,9 +11765,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0C23A0CD-88A0-498C-3530-8DAEFDD5E339"
@@ -9577,9 +11795,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1880"
+            },
             "label": "1880"
           },
           "stop": {
+            "in": {
+              "year": "1897"
+            },
             "label": "1897"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3F80B3EA-DC7A-4ACC-1FBA-C3C05A263A6A"
@@ -9601,9 +11825,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1898"
+            },
             "label": "1898"
           },
           "stop": {
+            "in": {
+              "year": "1916"
+            },
             "label": "1916"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFB4D9687-337F-4C72-5C44-CD2A161DBE9C"
@@ -9625,9 +11855,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1941"
+            },
             "label": "1941"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F304BE504-79BF-471C-3A16-8723B3875371"
@@ -9649,9 +11885,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1917"
+            },
             "label": "1917"
           },
           "stop": {
+            "in": {
+              "year": "1920"
+            },
             "label": "1920"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8EA7A3CE-A242-4010-035F-AA99235F542A"
@@ -9673,9 +11915,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1930"
+            },
             "label": "1930"
           },
           "stop": {
+            "in": {
+              "year": "1940"
+            },
             "label": "1940"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F943655DD-15E8-4F29-932B-46DAF670FDA4"
@@ -9697,9 +11945,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1921"
+            },
             "label": "1921"
           },
           "stop": {
+            "in": {
+              "year": "1929"
+            },
             "label": "1929"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF47133D3-59E7-4CE9-DEA7-91DC12527D1D"
@@ -9718,9 +11972,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE2D7C68F-5457-48F3-A8B5-65CED1F6BDF8"
@@ -9742,9 +12002,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0300"
+            },
             "label": "-300"
           },
           "stop": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6C6CD1C0-329A-4045-AD06-D2665539FB73"
@@ -9767,9 +12033,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1817"
+            },
             "label": "1817"
           },
           "stop": {
+            "in": {
+              "year": "1834"
+            },
             "label": "1834"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FDED69450-32A0-495A-092A-1F9F88088E42"
@@ -9791,9 +12063,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1763"
+            },
             "label": "1763"
           },
           "stop": {
+            "in": {
+              "year": "1783"
+            },
             "label": "1783"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F474648DF-D7C7-4C7D-408F-EFEE98DCCFEB"
@@ -9812,9 +12090,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FBC6A2BC6-8A7C-42FD-B58B-D9A7E00F4F66"
@@ -9833,9 +12117,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250"
           },
           "stop": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F12F99E4F-47F1-4701-DDD5-DF0D60AAF80C"
@@ -9857,9 +12147,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1716"
+            },
             "label": "1716"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1B1AF87E-8A53-47AA-2040-662D3FC39495"
@@ -9881,9 +12177,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FBA8A9C49-6C9C-440E-D9B9-A8DB23663980"
@@ -9902,9 +12204,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-7500"
+            },
             "label": "-7500"
           },
           "stop": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F16C8A39D-92F3-4B33-5050-C668F8B5A5A1"
@@ -9923,9 +12231,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1763"
+            },
             "label": "1763"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC09EA9ED-96D2-4387-D3D7-2C35438979CD"
@@ -9944,9 +12258,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "stop": {
+            "in": {
+              "year": "1699"
+            },
             "label": "1699"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFBB65406-C10C-4D1A-C453-B9FD2616B610"
@@ -9965,9 +12285,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0700"
+            },
             "label": "700"
           },
           "stop": {
+            "in": {
+              "year": "1702"
+            },
             "label": "1702"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F35EA50F9-D885-4671-95F5-B81A686FACDB"
@@ -9989,9 +12315,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F54A61BE6-E216-457F-9982-7A24DF9447FF"
@@ -10013,9 +12345,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3A754B8A-5139-4987-B8E0-A90F40EE1EF1"
@@ -10037,9 +12375,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1866"
+            },
             "label": "1866"
           },
           "stop": {
+            "in": {
+              "year": "1879"
+            },
             "label": "1879"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F718AE70B-8276-4919-7A0A-7CB963812701"
@@ -10061,9 +12405,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1845"
+            },
             "label": "1845"
           },
           "stop": {
+            "in": {
+              "year": "1860"
+            },
             "label": "1860"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F64C71572-90F0-4BB0-DA71-377941EF483C"
@@ -10085,9 +12435,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1821"
+            },
             "label": "1821"
           },
           "stop": {
+            "in": {
+              "year": "1845"
+            },
             "label": "1845"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1FE18981-57F4-4560-6F28-54A5E8F9073C"
@@ -10109,9 +12465,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1861"
+            },
             "label": "1861"
           },
           "stop": {
+            "in": {
+              "year": "1865"
+            },
             "label": "1865"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F782FEB97-D8FD-4499-C8A4-D10D252067F1"
@@ -10130,9 +12492,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F34D19695-ECF1-4436-0C1F-B68261CAC9E9"
@@ -10154,9 +12522,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1821"
+            },
             "label": "1821"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F017CC57D-FB11-43CA-25A3-6C482C566DFF"
@@ -10175,9 +12549,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF5B4E88C-27BE-4D29-751A-5511E8813EB5"
@@ -10199,9 +12579,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1513"
+            },
             "label": "1513"
           },
           "stop": {
+            "in": {
+              "year": "1763"
+            },
             "label": "1763"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F72C457AA-9666-4FF0-D9C8-3DCBA0734BA0"
@@ -10220,9 +12606,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1513"
+            },
             "label": "1513"
           },
           "stop": {
+            "in": {
+              "year": "1821"
+            },
             "label": "1821"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FAB1DC2DB-F2B6-482D-D56F-A484BBC0662B"
@@ -10241,9 +12633,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8F4B762D-8E4D-49C6-004A-E9D39A905EF2"
@@ -10265,9 +12663,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1821"
+            },
             "label": "1821"
           },
           "stop": {
+            "in": {
+              "year": "1899"
+            },
             "label": "1899"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6111A9D2-BE5D-4CA6-3826-3C01B52CC3C6"
@@ -10289,9 +12693,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8AEC9106-3A3B-4D63-946A-2B90A49157B4"
@@ -10313,9 +12723,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1750"
+            },
             "label": "1750"
           },
           "stop": {
+            "in": {
+              "year": "1816"
+            },
             "label": "1816"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9A04FA9D-DB51-49A6-ADF5-D78913CD9C9B"
@@ -10338,9 +12754,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1835"
+            },
             "label": "1835"
           },
           "stop": {
+            "in": {
+              "year": "1855"
+            },
             "label": "1855"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2E18C950-266B-432F-0CAF-5A2F739EF7B6"
@@ -10362,9 +12784,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD3931474-E652-4C83-AE1F-4FA4018E22B1"
@@ -10383,9 +12811,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F952994BE-DD31-462E-B548-ACBBDE2EE436"
@@ -10407,9 +12841,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1D98A81D-3840-45DC-AF4F-74D549897958"
@@ -10428,9 +12868,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250"
           },
           "stop": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF771FA19-7CB6-42CB-31DA-DC2DDCBBD271"
@@ -10449,9 +12895,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "stop": {
+            "in": {
+              "year": "-1500"
+            },
             "label": "-1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F5E65E973-2E28-4AC9-D925-8DAE1A8C5C73"
@@ -10470,9 +12922,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F56F6D705-4AEC-4117-D486-2673C59FE727"
@@ -10494,9 +12952,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "-0300"
+            },
             "label": "-300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F02C41DAB-14FD-457D-F538-B1D0D378A399"
@@ -10518,9 +12982,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0300"
+            },
             "label": "-300"
           },
           "stop": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD7D519BC-B5CC-4D28-B851-B46151A6EF52"
@@ -10539,9 +13009,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "stop": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F541B8388-BCFF-4C49-E0D9-3198776CC5AE"
@@ -10560,9 +13036,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4398A89B-2A59-4C2F-49EB-C574434B926E"
@@ -10581,9 +13063,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F87C41FF6-6E07-4196-2646-09471E96C547"
@@ -10602,9 +13090,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA472FE17-4E58-437B-DB03-D46BB8B2D086"
@@ -10623,9 +13117,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FAFA3D820-E181-44D6-DE3A-797D848774B9"
@@ -10644,9 +13144,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0B97190C-E7F0-4BE0-2DB3-C9F3A80A50B5"
@@ -10668,9 +13174,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F65F53D16-4005-457A-F232-A8899921ADBB"
@@ -10692,9 +13204,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "stop": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD18910CF-4712-41CB-E697-6CA2AD4957EA"
@@ -10713,9 +13231,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450"
           },
           "stop": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0E8CF331-A58E-4D7E-05BC-8A579A230958"
@@ -10734,9 +13258,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F826032F9-3EF8-47DC-6EC3-04B4F290533F"
@@ -10755,9 +13285,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8050"
+            },
             "label": "-8050"
           },
           "stop": {
+            "in": {
+              "year": "-1050"
+            },
             "label": "-1050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7D0BAB0B-7F90-47DB-D764-95B4D190DB6C"
@@ -10776,9 +13312,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F56088190-810C-46EF-E05D-2DA6963CC178"
@@ -10797,9 +13339,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F98D61BEA-EA9D-4D4A-3575-DE5C2BE422F3"
@@ -10818,9 +13366,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F133464FE-2148-454A-0295-8CF1C8A024E0"
@@ -10839,9 +13393,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F5BF424CF-67A0-4B4B-EACB-40AF85B06372"
@@ -10860,9 +13420,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1050"
+            },
             "label": "-1050"
           },
           "stop": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F86E90D12-346A-4659-8BDD-EF4FEA361E95"
@@ -10881,9 +13447,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "stop": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE2ADFDC9-2E5F-40B6-D4F7-93EC1C170608"
@@ -10902,9 +13474,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1150"
+            },
             "label": "1150"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F47AF8F77-70B3-4D2E-7182-64F6CCBD6A64"
@@ -10923,9 +13501,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3050"
+            },
             "label": "-3050"
           },
           "stop": {
+            "in": {
+              "year": "-1050"
+            },
             "label": "-1050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0620DFF0-23F4-4B4A-CF94-C57F782C0C0B"
@@ -10944,9 +13528,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F51781134-C327-460D-AD96-602454CE0678"
@@ -10965,9 +13555,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1540"
+            },
             "label": "1540"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FBCD7BA42-2C2D-4CC1-9252-26B9ACA41680"
@@ -10986,9 +13582,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F035538FF-7D24-441F-D52D-D48AE338F969"
@@ -11007,9 +13609,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F448D7FBC-D4B7-4990-4A75-2D7CD35643D4"
@@ -11028,9 +13636,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "stop": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0F928470-4C21-423A-4AC6-0DC26D92A5CE"
@@ -11049,9 +13663,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9550"
+            },
             "label": "-9550"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6610E074-4951-4932-C448-F2E71C5030AA"
@@ -11070,9 +13690,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6050"
+            },
             "label": "-6050"
           },
           "stop": {
+            "in": {
+              "year": "-3050"
+            },
             "label": "-3050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFF393305-EDB7-4847-103D-4824B4C17C7C"
@@ -11091,9 +13717,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-14050"
+            },
             "label": "-14050"
           },
           "stop": {
+            "in": {
+              "year": "-8050"
+            },
             "label": "-8050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA239791E-9D69-4BC8-1598-9D8BCB1664B2"
@@ -11112,9 +13744,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1050"
+            },
             "label": "-1050"
           },
           "stop": {
+            "in": {
+              "year": "1150"
+            },
             "label": "1150"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6DBB2EAD-6C83-4408-7828-94AD12E55E6E"
@@ -11133,9 +13771,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8050"
+            },
             "label": "-8050"
           },
           "stop": {
+            "in": {
+              "year": "-6050"
+            },
             "label": "-6050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0F539EB6-0397-4BFF-8423-B6512CF616B4"
@@ -11157,9 +13801,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1803"
+            },
             "label": "1803"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0137FA57-CCF7-4972-09CF-54EF00E773B8"
@@ -11178,9 +13828,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "stop": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F359E9E0A-2479-42C0-A1C7-F0A827DD0430"
@@ -11199,9 +13855,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1750"
+            },
             "label": "1750"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FB38B16A1-15E1-4203-8955-47FDD0205A52"
@@ -11220,9 +13882,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-13050"
+            },
             "label": "-13050"
           },
           "stop": {
+            "in": {
+              "year": "-12000"
+            },
             "label": "-12000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6565A100-6E90-4100-7D2F-B98FD4B3F089"
@@ -11241,9 +13909,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-12000"
+            },
             "label": "-12000"
           },
           "stop": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F04ADF628-52D5-46AB-C7B7-C6EFE34E0B07"
@@ -11262,9 +13936,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100"
           },
           "stop": {
+            "in": {
+              "year": "1350"
+            },
             "label": "1350"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE0C2EF8F-59BD-4497-B562-E02949C18280"
@@ -11283,9 +13963,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1350"
+            },
             "label": "1350"
           },
           "stop": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F673A125C-16ED-4147-1C01-AD7FFF935E88"
@@ -11304,9 +13990,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3E183FD8-E71B-4596-0AE3-E85FBE3C5409"
@@ -11329,9 +14021,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA8728477-F389-4448-B8F3-A3CA087A232C"
@@ -11353,9 +14051,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1804"
+            },
             "label": "1804"
           },
           "stop": {
+            "in": {
+              "year": "1820"
+            },
             "label": "1820"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F153C21D9-5CF8-42BD-6089-2E08568BBF03"
@@ -11377,9 +14081,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F79767E0A-47E9-4601-111A-6C2BC7E8F054"
@@ -11398,9 +14108,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FB3A86927-58B6-4D42-BE8F-EC224E189338"
@@ -11419,9 +14135,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "stop": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6F103F51-8D45-481B-6A4E-06637E3901CD"
@@ -11440,9 +14162,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA13C87F6-B0F0-4F74-1BCC-03EFCD834712"
@@ -11461,9 +14189,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-7000"
+            },
             "label": "-7000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F52195D8F-13FA-4EE7-20FF-BDACEACA1A83"
@@ -11482,9 +14216,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9D596173-0F7E-4398-A590-556C916EA3C0"
@@ -11503,9 +14243,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FCFFA45A4-54FE-4DD2-D555-4223416EB22B"
@@ -11524,9 +14270,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-7000"
+            },
             "label": "-7000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F81F77055-9B58-47D4-3C8A-3F166A9A0A81"
@@ -11545,9 +14297,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F747F7304-5026-4352-035C-899CCB5378CF"
@@ -11566,9 +14324,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "stop": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F777A70BD-1319-4D98-75AC-229C32B4D20F"
@@ -11587,9 +14351,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FB52AA736-ACF4-4537-A585-C18273288CC0"
@@ -11608,9 +14378,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-7000"
+            },
             "label": "-7000"
           },
           "stop": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F73E8F508-C5F5-455F-3003-2D0371899690"
@@ -11629,9 +14405,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3BA660F1-40E2-4504-5F9C-77F13D2C7946"
@@ -11650,9 +14432,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1740A3B0-8E14-445A-A62F-0CBEBD53D999"
@@ -11674,9 +14462,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1866"
+            },
             "label": "1866"
           },
           "stop": {
+            "in": {
+              "year": "1899"
+            },
             "label": "1899"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FBC26C1AF-A4C3-4285-163D-AC7BD151B61A"
@@ -11698,9 +14492,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1861"
+            },
             "label": "1861"
           },
           "stop": {
+            "in": {
+              "year": "1865"
+            },
             "label": "1865"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F70EC5819-CAB0-4A8A-7E61-F8D10894D894"
@@ -11722,9 +14522,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1821"
+            },
             "label": "1821"
           },
           "stop": {
+            "in": {
+              "year": "1861"
+            },
             "label": "1861"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9BF5DCF8-0E20-4F52-D4BF-A17438F54686"
@@ -11743,9 +14549,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-12000"
+            },
             "label": "-12000"
           },
           "stop": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC83686E7-C5DA-4BC9-DB3A-E187C1D99D62"
@@ -11764,9 +14576,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1500"
+            },
             "label": "-1500"
           },
           "stop": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA8B72A2F-6235-4DD9-3DA9-89F78B463200"
@@ -11785,9 +14603,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-1500"
+            },
             "label": "-1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8679296D-5D0A-4C8A-A2A1-18B4C76B19E1"
@@ -11806,9 +14630,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "stop": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F47BFF2B1-FDF5-48A3-D353-CAFA39CBF18F"
@@ -11827,9 +14657,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "-7500"
+            },
             "label": "-7500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2D4B092C-EA60-487E-A2FA-CECD20A5E034"
@@ -11848,9 +14684,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F03217784-DB7D-4B1A-51F1-A8319FBFF6F5"
@@ -11869,9 +14711,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "stop": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6903B5ED-9E49-4C46-D91D-AA28BE52DB73"
@@ -11890,9 +14738,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1500"
+            },
             "label": "-1500"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0D688C61-389F-42CF-BCA1-9B52693815C2"
@@ -11911,9 +14765,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-3500"
+            },
             "label": "-3500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE83D8362-AFAD-4644-8685-A34CC1436B6C"
@@ -11932,9 +14792,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0200"
+            },
             "label": "200"
           },
           "stop": {
+            "in": {
+              "year": "0600"
+            },
             "label": "600"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA3F2023D-95C4-46B6-9FAB-2E02673F033A"
@@ -11953,9 +14819,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD3771A53-EEE3-4862-B600-14A5F7EB9776"
@@ -11974,9 +14846,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEC1A5EF1-19F7-477F-B1CD-0D9747213CE5"
@@ -11995,9 +14873,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "stop": {
+            "in": {
+              "year": "-1500"
+            },
             "label": "-1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD75F3BC0-6EA4-41B2-63B2-3022F61E7447"
@@ -12016,9 +14900,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F86326F24-6EC3-407B-F9F6-DCFB02577EDF"
@@ -12037,9 +14927,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F5186DDFF-A905-484C-B18F-46CD93F30307"
@@ -12058,9 +14954,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "stop": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FB88798D2-914B-4B7A-EFCF-EE0BE2E4ACBF"
@@ -12079,9 +14981,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F36E6C64E-B75B-4AD2-F53E-D709F30EFDFC"
@@ -12100,9 +15008,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4FD8F891-5724-4424-5813-11A02FA4BD95"
@@ -12121,9 +15035,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8550"
+            },
             "label": "-8550"
           },
           "stop": {
+            "in": {
+              "year": "-7550"
+            },
             "label": "-7550"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F27EA910B-9622-4C41-CAC2-B673F3AB7CAB"
@@ -12142,9 +15062,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F90E8AA99-FDF3-4FF2-6975-7A7CCBEA5D86"
@@ -12163,9 +15089,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9035AFFE-E8C2-4102-4962-8C17590B9302"
@@ -12184,9 +15116,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10050"
+            },
             "label": "-10050"
           },
           "stop": {
+            "in": {
+              "year": "-9050"
+            },
             "label": "-9050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFA5245CA-3937-49B8-537B-732175DAE156"
@@ -12205,9 +15143,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1400"
+            },
             "label": "1400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8BD1EC82-4A7C-4707-007E-F06AA70EE8AE"
@@ -12226,9 +15170,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8550"
+            },
             "label": "-8550"
           },
           "stop": {
+            "in": {
+              "year": "-6050"
+            },
             "label": "-6050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA84C8A10-FDA2-4DBD-B766-6D688809A513"
@@ -12247,9 +15197,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1400"
+            },
             "label": "1400"
           },
           "stop": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F85A62458-9D4A-4EA5-0B1B-03DD6599E61B"
@@ -12268,9 +15224,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9500"
+            },
             "label": "-9500"
           },
           "stop": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8C2D9FAE-8F46-4A73-020D-5EC5B39D0C5C"
@@ -12289,9 +15251,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FDEE5A469-FD48-4AE0-000D-4875B5FD4EB3"
@@ -12310,9 +15278,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9500"
+            },
             "label": "-9500"
           },
           "stop": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2F3170C6-FCF8-409E-1FC0-0811FA363ACB"
@@ -12331,9 +15305,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9500"
+            },
             "label": "-9500"
           },
           "stop": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F15331E48-028F-4725-82BE-F2F98E9D0E97"
@@ -12352,9 +15332,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9500"
+            },
             "label": "-9500"
           },
           "stop": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FB286D7B8-6808-42E3-D483-533B53B0BF88"
@@ -12373,9 +15359,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "stop": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F754057AA-9B40-405A-393C-C9E1FEC207A9"
@@ -12394,9 +15386,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "stop": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFD5BBCA2-1591-4CC9-46ED-3960760C2628"
@@ -12415,9 +15413,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "stop": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4FB1E1AC-7887-4E4B-77A5-0BD06BE2841E"
@@ -12436,9 +15440,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF081E6B6-D65B-48B3-647F-3099552C12C1"
@@ -12457,9 +15467,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7E6F1BA2-468B-41E4-7A2B-721604F9C11B"
@@ -12478,9 +15494,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F366E7E81-C631-4745-9C91-98168CFF1A6E"
@@ -12499,9 +15521,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD641A871-9D25-4684-1904-F3FF6DB56CF6"
@@ -12520,9 +15548,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F27CEE2D3-F894-4901-E3E0-578198D24F5A"
@@ -12541,9 +15575,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0CF8A7D4-5BF6-4EA2-E82C-55DCB08FD817"
@@ -12562,9 +15602,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F261FFCD5-304A-4F36-F22D-D2857FDC6CAD"
@@ -12583,9 +15629,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9B5E8341-D8CD-4203-5EB3-EB84B66573B6"
@@ -12604,9 +15656,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F07998460-9BF7-4FFD-2D24-EE457F3E56F1"
@@ -12625,9 +15683,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6B333A6B-3393-4859-51E2-A1C43606F243"
@@ -12646,9 +15710,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F72697637-E3C0-44EE-94AE-F4CEE55740BB"
@@ -12667,9 +15737,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC8CD25E0-7438-4E7A-C0BE-504F620539D4"
@@ -12688,9 +15764,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F95ACEE52-F80B-40F5-F40A-FB4B41822073"
@@ -12709,9 +15791,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1C8103C9-2526-41FE-CBB6-AFAE219547F5"
@@ -12730,9 +15818,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA61DCEFF-E0F8-496E-FA74-D29CE01D7FA9"
@@ -12751,9 +15845,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F09951120-3F26-47C8-B091-8DAF27E43EF8"
@@ -12772,9 +15872,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F92926BCA-BC13-4F3E-7359-3737B81396BB"
@@ -12793,9 +15899,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F83CFBC69-4159-4144-AD5D-9FE0D54A2465"
@@ -12814,9 +15926,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2754FA47-4A36-4EB9-F58E-0269427436CA"
@@ -12835,9 +15953,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0DEA3A67-B909-4391-B8CA-28E63A2A3F20"
@@ -12856,9 +15980,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FB9DFD653-8AF5-470D-0DF9-15099D8532D6"
@@ -12877,9 +16007,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9194C3C5-A37C-4EB3-F1C4-ACDD110252E1"
@@ -12898,9 +16034,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "stop": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA8269B3D-CBA1-474B-95F4-2B758276588F"
@@ -12919,9 +16061,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2F559B39-505A-4857-B623-7999C1D9B3FE"
@@ -12940,9 +16088,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F43430EBB-F900-4645-ECA7-ECE19B11483E"
@@ -12961,9 +16115,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F400EB26A-9217-41B2-5068-9754F6DF37FE"
@@ -12982,9 +16142,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7EC753E6-EC7F-41DF-67A9-EC7F5073330F"
@@ -13003,9 +16169,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE5A67D78-4B8F-4D38-B284-387419D16BB5"
@@ -13024,9 +16196,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FBD4E4AEE-BF8B-4B3A-32F0-CF6C6B7547CC"
@@ -13045,9 +16223,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F15F95FAC-CA0E-4FFA-BDEA-5529F782C732"
@@ -13066,9 +16250,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FBBACCE72-7B51-4E9B-9A69-0FF3CEC63EA5"
@@ -13087,9 +16277,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9015DB7B-8AD5-44AC-B1FF-890E21D62A9F"
@@ -13108,9 +16304,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC039D308-0CE1-4B4F-FFFB-2267CD2E67F3"
@@ -13129,9 +16331,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0B7A065C-0340-4FB0-7007-2D24A6F8EB21"
@@ -13150,9 +16358,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE98E225A-584B-4473-B3AF-8F10286355BE"
@@ -13171,9 +16385,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F624C7B94-4B20-4246-0FEB-7E862E9573DB"
@@ -13192,9 +16412,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6D056E72-3178-4145-5FAC-96880EDF3B38"
@@ -13213,9 +16439,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F714D3E9E-44A2-48E8-535A-20BB1AF572EA"
@@ -13234,9 +16466,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F757BCC2B-5E91-4B2F-F48A-EEC3F826288E"
@@ -13255,9 +16493,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF6F56EE7-E105-4D44-709C-FD28A86338F6"
@@ -13276,9 +16520,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9500"
+            },
             "label": "-9500"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE92B91A1-3674-4AC7-B7C8-1A7542FB76D2"
@@ -13297,9 +16547,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0BEE1265-F11B-43A3-550A-35B160F040C6"
@@ -13318,9 +16574,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEE9EA169-1E68-4E8A-C69A-E2B7E023F7B0"
@@ -13339,9 +16601,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F195A7002-147B-44B1-36DE-20C8D1ABF6A5"
@@ -13360,9 +16628,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F95575D12-705C-4240-3A38-A53A7EC90844"
@@ -13381,9 +16655,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1CF11E29-829F-4ABB-98AD-83D576DED667"
@@ -13402,9 +16682,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA1241E28-3F4D-4DD1-815D-31E3EF7B9B49"
@@ -13423,9 +16709,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9CF41622-1919-4F82-33E8-A92F5D9AA87B"
@@ -13444,9 +16736,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEE5704FB-E8A1-4DEA-A152-798624281CAE"
@@ -13465,9 +16763,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA14F0B53-B048-433F-2AB6-2287E68772C9"
@@ -13486,9 +16790,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD3BAF420-D541-40EF-2A5B-4024B8F12A49"
@@ -13507,9 +16817,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F77E0F699-202C-4C6A-4655-00E7FCF5D4F7"
@@ -13528,9 +16844,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9F6D991E-74C6-43FE-3315-46113FAA04BE"
@@ -13549,9 +16871,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4A3CB884-C968-49F2-2F52-8580B806E368"
@@ -13570,9 +16898,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F108BE619-23E4-4E8F-77EE-C3FF29B42CBB"
@@ -13591,9 +16925,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FBC52B421-9893-4AAA-9B4C-C896049AED4D"
@@ -13612,9 +16952,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F211B1300-9E8D-4783-9047-002CA1571A32"
@@ -13633,9 +16979,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F09818082-7F55-40A8-96B8-C3E0CE1A063A"
@@ -13654,9 +17006,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8AFF99C7-B613-4FE4-8015-C73A1C01201A"
@@ -13675,9 +17033,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "stop": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F493BB2A0-AF86-4066-749B-2F46F3461262"
@@ -13696,9 +17060,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "stop": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F966D32E5-ACCF-4568-49DD-A7553017990B"
@@ -13717,9 +17087,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF8E3036A-BD2D-41BF-5DB7-6F3AAD149BF3"
@@ -13738,9 +17114,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1400"
+            },
             "label": "1400"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF25C16B9-E26F-4CEF-30A2-9F566E26E92E"
@@ -13759,9 +17141,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F018A19EA-A3E0-450D-E3AC-0606BA8D54F4"
@@ -13780,9 +17168,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4223B3F2-9A6D-4FE9-D63D-7D3BB88FA7D4"
@@ -13801,9 +17195,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE8A29672-1D79-42F5-A11E-E4DA23C10E28"
@@ -13822,9 +17222,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "stop": {
+            "in": {
+              "year": "1781"
+            },
             "label": "1781"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F13CC65B7-1422-4994-C3F1-28D4B8587064"
@@ -13843,9 +17249,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1781"
+            },
             "label": "1781"
           },
           "stop": {
+            "in": {
+              "year": "1841"
+            },
             "label": "1841"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2CA2C305-7D0B-4732-C6C3-246A42684200"
@@ -13864,9 +17276,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1841"
+            },
             "label": "1841"
           },
           "stop": {
+            "in": {
+              "year": "1871"
+            },
             "label": "1871"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F35F5F056-4182-4331-24D0-6495CD154109"
@@ -13885,9 +17303,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1871"
+            },
             "label": "1871"
           },
           "stop": {
+            "in": {
+              "year": "1901"
+            },
             "label": "1901"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FB647AAF8-C8B1-4E03-F8BF-5854CBF14A28"
@@ -13906,9 +17330,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "1945"
+            },
             "label": "1945"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1C6C8030-CB72-4DE3-00C1-6179C736FBBA"
@@ -13927,9 +17357,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1945"
+            },
             "label": "1945"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F495A09EC-3838-4E8B-CFD7-689887430638"
@@ -13948,9 +17384,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1852"
+            },
             "label": "1852"
           },
           "stop": {
+            "in": {
+              "year": "1879"
+            },
             "label": "1879"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FB5BC8B09-2699-4578-DF63-A9DF23F5E2EC"
@@ -13969,9 +17411,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F040D19A1-9106-4F18-90BA-D5DCF3FDAABA"
@@ -13990,9 +17438,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA518E257-D564-4D78-6AF9-8169BAC90C3F"
@@ -14011,9 +17465,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA707A607-5C90-4B44-FE8F-40B17DA1AB1B"
@@ -14032,9 +17492,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FADE27363-666D-402C-1DC8-B935DDF13E88"
@@ -14053,9 +17519,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "stop": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F677C8297-28EB-4841-71F3-EAD380B8A60D"
@@ -14074,9 +17546,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "stop": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFC817A18-B67B-4C01-F401-47AD6A950926"
@@ -14095,9 +17573,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FB2E9FD93-E917-4508-4EB6-DFCFA45FF053"
@@ -14116,9 +17600,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0050"
+            },
             "label": "50"
           },
           "stop": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3190E482-744D-4593-266A-240C8652E3C2"
@@ -14137,9 +17627,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9550"
+            },
             "label": "-9550"
           },
           "stop": {
+            "in": {
+              "year": "-8850"
+            },
             "label": "-8850"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FCB0787B0-AC07-4B2D-C707-6D79F4260887"
@@ -14158,9 +17654,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F093188C6-E964-4C7A-3C8E-69D7FAE94237"
@@ -14179,9 +17681,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8950"
+            },
             "label": "-8950"
           },
           "stop": {
+            "in": {
+              "year": "-8450"
+            },
             "label": "-8450"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F01FC7500-35CA-4F7D-3218-0A91983B9C82"
@@ -14200,9 +17708,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA2011F72-447A-4EB2-22B7-F33485EDFB18"
@@ -14221,9 +17735,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FAB733313-86C2-4D37-D708-A5245156D8F3"
@@ -14242,9 +17762,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "stop": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6AEFA71E-2474-45F6-55C1-666E17E30BEA"
@@ -14263,9 +17789,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "stop": {
+            "in": {
+              "year": "0650"
+            },
             "label": "650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F083A84F3-E0A0-4BAB-82F4-FF0554FF93B4"
@@ -14284,9 +17816,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD2C72B89-C738-4F55-62FF-CC23FFB7E1EF"
@@ -14305,9 +17843,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F166B08F3-DF91-4526-EE65-883F725A1CF3"
@@ -14326,9 +17870,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8550"
+            },
             "label": "-8550"
           },
           "stop": {
+            "in": {
+              "year": "-7550"
+            },
             "label": "-7550"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEF239277-2EED-46A4-7209-59F90889332E"
@@ -14347,9 +17897,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2500"
+            },
             "label": "2500"
           },
           "stop": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF352CBDC-3764-4F9B-095E-0318949949C9"
@@ -14368,9 +17924,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F178F7FD9-921F-49D5-FB87-DF9B4A1D7F55"
@@ -14389,9 +17951,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1300"
+            },
             "label": "1300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F61D42EF0-A435-4C3F-2407-A4C1DAA5B653"
@@ -14410,9 +17978,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7D80F34A-B26D-4DAD-4895-0CE066329126"
@@ -14431,9 +18005,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FBE05B0E8-E27A-47FD-3E19-80794EDAA05E"
@@ -14452,9 +18032,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA7DB7998-7A10-4B35-311A-9C336ECE7D55"
@@ -14473,9 +18059,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6FA842E7-1B88-47D6-E593-1CE58F283B74"
@@ -14494,9 +18086,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2950"
+            },
             "label": "-2950"
           },
           "stop": {
+            "in": {
+              "year": "-0750"
+            },
             "label": "-750"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF80F4B46-F1DA-490D-27C2-BAF6FE46BAB9"
@@ -14515,9 +18113,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050"
           },
           "stop": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4F9136CE-BE83-440B-FF6B-194936935DCF"
@@ -14536,9 +18140,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8565F236-BD12-45AB-47A6-95D7D1B4CB2E"
@@ -14557,9 +18167,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F512B135E-1CA4-4884-3441-F7ABA3E0F125"
@@ -14578,9 +18194,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0100"
+            },
             "label": "-100"
           },
           "stop": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC87FBFF2-A6E5-405F-2F23-BCE4F6D504AF"
@@ -14599,9 +18221,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF39EC07D-EB94-4555-F354-370D3F76195E"
@@ -14620,9 +18248,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4A70B3B6-579A-4F80-7EFB-0DC31364E292"
@@ -14641,9 +18275,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD48E49CE-3B30-498D-C75B-C55B083FCBBC"
@@ -14662,9 +18302,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC29D9AB8-9504-454E-9ACF-574077B748A3"
@@ -14683,9 +18329,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0061A103-C3D9-458A-0B9A-9B371A0A3E61"
@@ -14704,9 +18356,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9550"
+            },
             "label": "-9550"
           },
           "stop": {
+            "in": {
+              "year": "-8550"
+            },
             "label": "-8550"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FDFAF78CD-206B-4142-F452-E48023551BE6"
@@ -14725,9 +18383,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F742FE59A-79A1-4F17-0E9B-69425681AE2B"
@@ -14746,9 +18410,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "-0600"
+            },
             "label": "-600"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F178BA692-2DA7-4464-DB8B-9F36E88648EE"
@@ -14767,9 +18437,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7DFD4305-3B6E-40E2-27B5-B4517DF1820B"
@@ -14788,9 +18464,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FDCDC64A7-06B0-40CD-B2B3-37E1DF2BBB33"
@@ -14809,9 +18491,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0650"
+            },
             "label": "-650"
           },
           "stop": {
+            "in": {
+              "year": "0050"
+            },
             "label": "50"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F035EB7F1-F22D-4471-D1C4-C0679E612354"
@@ -14830,9 +18518,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-7450"
+            },
             "label": "-7450"
           },
           "stop": {
+            "in": {
+              "year": "-7050"
+            },
             "label": "-7050"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2A4AEAB9-3566-47BA-4431-F877BFC81BAB"
@@ -14851,9 +18545,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F163C039D-7A1C-456E-74EA-B8C1D6191B7B"
@@ -14872,9 +18572,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8E52B87E-330E-4620-27F5-EAD5291E2E32"
@@ -14893,9 +18599,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1300"
+            },
             "label": "1300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4EC9ACA1-3EE4-48D9-C03A-C69FD1B078E2"
@@ -14914,9 +18626,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F74B1BBDA-5B64-4F22-41F1-0E8EE73D33FA"
@@ -14935,9 +18653,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "stop": {
+            "in": {
+              "year": "0650"
+            },
             "label": "650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F505F085E-4175-42A6-A019-937F92A99DC5"
@@ -14956,9 +18680,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1300"
+            },
             "label": "1300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FAFA24246-88E3-4251-33C1-10A06662585C"
@@ -14977,9 +18707,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1300"
+            },
             "label": "1300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE27D62A1-1110-434E-753A-78FDC19A0202"
@@ -14998,9 +18734,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050"
           },
           "stop": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FCB404A33-1CCE-464F-09FD-0791EDCC1EB9"
@@ -15019,9 +18761,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250"
           },
           "stop": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F406B3F6B-1A98-417E-4EC8-D7128B298708"
@@ -15040,9 +18788,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3E9093AC-D394-4049-F68C-D2D98965A267"
@@ -15061,9 +18815,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F580E80CB-6781-40E2-2FC8-9A53E2D6CE18"
@@ -15082,9 +18842,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F16A1F520-91C5-43C5-21AE-65A2405ABD3E"
@@ -15103,9 +18869,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2950"
+            },
             "label": "-2950"
           },
           "stop": {
+            "in": {
+              "year": "-2750"
+            },
             "label": "-2750"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9D6D5BD4-4877-4E5F-8C77-8EA6A47C8D7B"
@@ -15124,9 +18896,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F81E681D0-4E4B-4B3C-866E-EBF1F5B2DFB3"
@@ -15145,9 +18923,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7CDAA5F8-BB7A-4D9A-ACEC-1ECBD6883680"
@@ -15166,9 +18950,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0610FD9A-F341-417B-C07B-6D82664C8796"
@@ -15187,9 +18977,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF74CC356-D472-4852-7216-F4F087BD88C2"
@@ -15208,9 +19004,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0C34D45D-87E2-4A30-1B29-1AF7DB7A4532"
@@ -15229,9 +19031,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F5C8599B8-1247-4B3D-F365-B87F9280F6CF"
@@ -15250,9 +19058,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F31210831-95F3-4B14-9B89-7103A0862057"
@@ -15271,9 +19085,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FDD445A92-36CE-4E59-2F9F-6AB51FAC568F"
@@ -15292,9 +19112,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F41158095-4553-4865-BF97-AD862F87F7A8"
@@ -15313,9 +19139,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE942DB9F-D3E1-4439-5D62-0356991099E0"
@@ -15334,9 +19166,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F05F571C5-5405-4C81-0ABC-5B5D26060753"
@@ -15355,9 +19193,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5500"
+            },
             "label": "-5500"
           },
           "stop": {
+            "in": {
+              "year": "-4250"
+            },
             "label": "-4250"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F46AF1E9F-BEB3-4F3B-2964-8EB50807AA6B"
@@ -15376,9 +19220,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FDB1339E2-B9FF-4DC8-BD8B-7507A62DD53C"
@@ -15397,9 +19247,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3800"
+            },
             "label": "-3800"
           },
           "stop": {
+            "in": {
+              "year": "-2800"
+            },
             "label": "-2800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F96181A64-FBB2-4544-5654-9EEB011A9226"
@@ -15418,9 +19274,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1050"
+            },
             "label": "-1050"
           },
           "stop": {
+            "in": {
+              "year": "0350"
+            },
             "label": "350"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F561EBF02-B8F1-4A9F-0A0E-9AF7FC8E8FD9"
@@ -15439,9 +19301,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1300"
+            },
             "label": "1300"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F63846CF3-27AE-4719-A44F-844F9AB28C00"
@@ -15460,9 +19328,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA4E5FB26-5E10-4DB7-6109-C5E32B7DE3E6"
@@ -15481,9 +19355,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0600"
+            },
             "label": "600"
           },
           "stop": {
+            "in": {
+              "year": "0700"
+            },
             "label": "700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEB3E8C94-6C8D-4F9B-CBAE-9F41EF7A9610"
@@ -15502,9 +19382,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1300"
+            },
             "label": "1300"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F43EF73D0-4AE0-44FB-49D4-4549FAFCA3F7"
@@ -15523,9 +19409,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F186C4457-203C-4001-F08D-A400BCB7ECA6"
@@ -15544,9 +19436,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0250"
+            },
             "label": "250"
           },
           "stop": {
+            "in": {
+              "year": "0650"
+            },
             "label": "650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3581114E-8126-457A-AECC-D888F85EB4F2"
@@ -15565,9 +19463,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC3471B8A-2495-490D-6EBC-25028C3ABC5F"
@@ -15586,9 +19490,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "stop": {
+            "in": {
+              "year": "0650"
+            },
             "label": "650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA3A4CAA5-F021-46E3-1901-AA0982F2EC8D"
@@ -15607,9 +19517,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD1D17BCA-72D0-4DFC-F40B-275BEACEAA09"
@@ -15628,9 +19544,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7A4F97F3-623E-40A5-FB8F-0F2567482986"
@@ -15649,9 +19571,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1914"
+            },
             "label": "1914"
           },
           "stop": {
+            "in": {
+              "year": "1919"
+            },
             "label": "1919"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC8DB1AF3-904B-4B22-0229-1C0B074C993D"
@@ -15670,9 +19598,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FAA591401-E558-47BA-21BF-551FAEC87FCB"
@@ -15691,9 +19625,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8550"
+            },
             "label": "-8550"
           },
           "stop": {
+            "in": {
+              "year": "-7550"
+            },
             "label": "-7550"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F546D6126-EE5B-464B-D117-99A0B5289F8E"
@@ -15712,9 +19652,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F5B3461FB-D904-4548-5ADB-09788BE2E0E9"
@@ -15733,9 +19679,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4F2D905A-C1BA-49C2-2F32-5A424B4BA23C"
@@ -15754,9 +19706,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-7500"
+            },
             "label": "-7500"
           },
           "stop": {
+            "in": {
+              "year": "-6300"
+            },
             "label": "-6300"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F39A7F6DA-2DC0-4AE1-B3F5-0BF0AAB8BB3C"
@@ -15775,9 +19733,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0850"
+            },
             "label": "850"
           },
           "stop": {
+            "in": {
+              "year": "0950"
+            },
             "label": "950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD415A671-F1AE-412A-8E73-D333D7B306B9"
@@ -15796,9 +19760,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F33953028-54F0-4AE9-8555-0867AE7D2FDF"
@@ -15817,9 +19787,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1870"
+            },
             "label": "1870"
           },
           "stop": {
+            "in": {
+              "year": "1998"
+            },
             "label": "1998"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9829C47C-2F7B-4DE4-BB49-3D033FFCF4A8"
@@ -15841,9 +19817,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1870"
+            },
             "label": "1870"
           },
           "stop": {
+            "in": {
+              "year": "1930"
+            },
             "label": "1930"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2FE03CB5-7F0C-481B-C0E7-822E8F99092C"
@@ -15862,9 +19844,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900"
           },
           "stop": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD85598EF-3ED4-4992-D3BF-256C2B68F0F0"
@@ -15883,9 +19871,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0850"
+            },
             "label": "850"
           },
           "stop": {
+            "in": {
+              "year": "0950"
+            },
             "label": "950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1D741A67-F531-4DA2-E6C8-1043C810B1B0"
@@ -15904,9 +19898,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5500"
+            },
             "label": "-5500"
           },
           "stop": {
+            "in": {
+              "year": "-4250"
+            },
             "label": "-4250"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F197BD103-E08F-4488-D817-C02304E97105"
@@ -15925,9 +19925,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8000"
+            },
             "label": "-8000"
           },
           "stop": {
+            "in": {
+              "year": "-5500"
+            },
             "label": "-5500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F42591C3E-1F4E-4797-32F5-AF305635FFE8"
@@ -15946,9 +19952,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9EEED479-C6FB-4CFD-04D8-788130749241"
@@ -15967,9 +19979,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "stop": {
+            "in": {
+              "year": "0050"
+            },
             "label": "50"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC51C9364-0770-4BC3-B946-439BB513FB19"
@@ -15988,9 +20006,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F663AEA22-C0DD-4CDF-7A5B-C7431DC7341B"
@@ -16009,9 +20033,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0350"
+            },
             "label": "350"
           },
           "stop": {
+            "in": {
+              "year": "0650"
+            },
             "label": "650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA72E7B70-BA05-42C3-AC92-2201028080DE"
@@ -16030,9 +20060,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF0142845-B0B1-42A5-88B9-10BB016A2436"
@@ -16051,9 +20087,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "stop": {
+            "in": {
+              "year": "-0850"
+            },
             "label": "-850"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F06A6670A-782D-464B-78EE-3260AA5963B7"
@@ -16072,9 +20114,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA5537537-21D1-4D3C-EE83-1F1A76EA2D69"
@@ -16093,9 +20141,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F132C6182-5039-4D87-3068-3AAD6470F1BF"
@@ -16114,9 +20168,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-7250"
+            },
             "label": "-7250"
           },
           "stop": {
+            "in": {
+              "year": "-6850"
+            },
             "label": "-6850"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F19DEB4FD-C5DD-4CF1-A03C-2209AD59B8F7"
@@ -16135,9 +20195,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF4CE6AB4-42A5-4169-A162-A089206A9B6E"
@@ -16156,9 +20222,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4400"
+            },
             "label": "-4400"
           },
           "stop": {
+            "in": {
+              "year": "-3700"
+            },
             "label": "-3700"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8CE2783D-E3FA-4F4D-9970-21E6BE1E560E"
@@ -16177,9 +20249,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9550"
+            },
             "label": "-9550"
           },
           "stop": {
+            "in": {
+              "year": "-8850"
+            },
             "label": "-8850"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F5F839007-D6B0-4B2A-DA7F-B4BE983E6953"
@@ -16198,9 +20276,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1935"
+            },
             "label": "1935"
           },
           "stop": {
+            "in": {
+              "year": "2000"
+            },
             "label": "2000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FADB82F49-40A1-4C51-D3BB-96AB63434B82"
@@ -16219,9 +20303,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1050"
+            },
             "label": "1050"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0EDDAB3F-E086-40B9-795D-1D0976E9F8C2"
@@ -16240,9 +20330,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F57FC54C8-5A59-4F40-4BE9-6C1C6C34C661"
@@ -16261,9 +20357,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0350"
+            },
             "label": "350"
           },
           "stop": {
+            "in": {
+              "year": "0650"
+            },
             "label": "650"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF5379CC7-726C-4D96-D170-661E953FAF81"
@@ -16282,9 +20384,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "stop": {
+            "in": {
+              "year": "1899"
+            },
             "label": "1899"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF95DF0C9-5195-4E18-2C1E-4ABE3220E811"
@@ -16303,9 +20411,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "stop": {
+            "in": {
+              "year": "1899"
+            },
             "label": "1899"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFD466FF5-59F9-4F37-B419-18A67775231A"
@@ -16324,9 +20438,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9665102F-0FA4-4D8D-4630-AB388BC1C6A2"
@@ -16345,9 +20465,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1850"
+            },
             "label": "1850"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFE2584CE-86E0-4123-4F8B-E688073DF7F3"
@@ -16366,9 +20492,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1825"
+            },
             "label": "1825"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1C74B93E-C81B-4CB3-0304-26F24D4C42C8"
@@ -16387,9 +20519,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1885"
+            },
             "label": "1885"
           },
           "stop": {
+            "in": {
+              "year": "1980"
+            },
             "label": "1980"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F72F92326-E950-4075-21EC-7288AF2845C7"
@@ -16408,9 +20546,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC855C6DF-7125-4D65-C00C-0AA0168C0CE2"
@@ -16429,9 +20573,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1937"
+            },
             "label": "1937"
           },
           "stop": {
+            "in": {
+              "year": "2000"
+            },
             "label": "2000"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FDF33D7D1-FC77-4ED0-8C17-A472DDD31F70"
@@ -16450,9 +20600,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1873"
+            },
             "label": "1873"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FAAAAFEBC-0FF6-4081-C80C-3AB706B4ECCA"
@@ -16471,9 +20627,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1812"
+            },
             "label": "1812"
           },
           "stop": {
+            "in": {
+              "year": "1815"
+            },
             "label": "1815"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F525BC45A-3AEB-46DF-32C5-2E56B2F89E91"
@@ -16492,9 +20654,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1930"
+            },
             "label": "1930"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC458ADC4-7082-4548-35E0-E6B4B03420B6"
@@ -16513,9 +20681,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1929"
+            },
             "label": "1929"
           },
           "stop": {
+            "in": {
+              "year": "1941"
+            },
             "label": "1941"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9BE06F88-C795-49B9-45A1-A620CBF98A00"
@@ -16534,9 +20708,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10500"
+            },
             "label": "-10500"
           },
           "stop": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6DEDCFE7-5584-4E96-9795-204B7705069A"
@@ -16555,9 +20735,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3B9FFCD2-0BDF-4384-7187-5333708D9BC7"
@@ -16576,9 +20762,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "stop": {
+            "in": {
+              "year": "-5500"
+            },
             "label": "-5500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7CED115E-5050-4CC2-AFC6-A4006AF5E07F"
@@ -16597,9 +20789,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "stop": {
+            "in": {
+              "year": "1899"
+            },
             "label": "1899"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC094FBF5-80FF-4B7F-3A72-E79245B6DBBE"
@@ -16618,9 +20816,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1673"
+            },
             "label": "1673"
           },
           "stop": {
+            "in": {
+              "year": "1840"
+            },
             "label": "1840"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE268C482-469A-4076-A750-F0CA15AD0B8D"
@@ -16639,9 +20843,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FED932033-458A-45F2-511B-839504A35F57"
@@ -16660,9 +20870,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0850"
+            },
             "label": "850"
           },
           "stop": {
+            "in": {
+              "year": "0950"
+            },
             "label": "950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FABDA2799-98F2-4D5A-9964-2832B8B00FC6"
@@ -16681,9 +20897,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "stop": {
+            "in": {
+              "year": "1850"
+            },
             "label": "1850"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F30C0C06A-EF20-48F4-F6B8-011CAA015EBE"
@@ -16702,9 +20924,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0700"
+            },
             "label": "700"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC7DF6332-F87A-443F-B319-679EBF7C87BF"
@@ -16723,9 +20951,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0650"
+            },
             "label": "650"
           },
           "stop": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F01FF5A74-2E89-4323-5D08-894329F77C1E"
@@ -16744,9 +20978,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1880"
+            },
             "label": "1880"
           },
           "stop": {
+            "in": {
+              "year": "2008"
+            },
             "label": "2008"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FAA0996D2-3AAB-49BE-E040-ED7583A42BE9"
@@ -16765,9 +21005,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1850"
+            },
             "label": "1850"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F62AA420D-75EF-41D3-F28D-3BABC5C27156"
@@ -16786,9 +21032,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "stop": {
+            "in": {
+              "year": "1860"
+            },
             "label": "1860"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F07ED7E7F-F445-45BF-AD82-FDCE6D6F08D7"
@@ -16807,9 +21059,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "stop": {
+            "in": {
+              "year": "-5500"
+            },
             "label": "-5500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1F1A56D0-3B49-4170-B901-68C33243971F"
@@ -16828,9 +21086,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FDDAAF711-CD38-47A3-0DB0-5EF440A39724"
@@ -16849,9 +21113,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10500"
+            },
             "label": "-10500"
           },
           "stop": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FAAC8775A-472C-483E-F044-D7574E94EE94"
@@ -16870,9 +21140,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1812"
+            },
             "label": "1812"
           },
           "stop": {
+            "in": {
+              "year": "1815"
+            },
             "label": "1815"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEC6BFE35-73FC-43C7-BBF5-F568779CDD19"
@@ -16891,9 +21167,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1FE7801E-6419-4C75-9BAB-277490ABED03"
@@ -16915,9 +21197,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "stop": {
+            "in": {
+              "year": "1606"
+            },
             "label": "1606"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2D28FA37-8852-4D7B-ED5F-2DC0C084DFC6"
@@ -16939,9 +21227,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-15000"
+            },
             "label": "-15000"
           },
           "stop": {
+            "in": {
+              "year": "1606"
+            },
             "label": "1606"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA125AE87-6245-44AC-0872-097DE82AC257"
@@ -16963,9 +21257,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1799"
+            },
             "label": "1799"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD69CCE20-E3F1-49E2-D7D0-F5E05F7D8DE8"
@@ -16987,9 +21287,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "stop": {
+            "in": {
+              "year": "-6501"
+            },
             "label": "-6501"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F04E849D9-8140-4087-7976-375569DCB4EE"
@@ -17011,9 +21317,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8500"
+            },
             "label": "-8500"
           },
           "stop": {
+            "in": {
+              "year": "-1201"
+            },
             "label": "-1201"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FC0EB9F31-F0D7-41D1-F708-D185AF03BEFD"
@@ -17035,9 +21347,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6500"
+            },
             "label": "-6500"
           },
           "stop": {
+            "in": {
+              "year": "-3001"
+            },
             "label": "-3001"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA195BA60-1191-4B70-E563-2A6C3F34CCEB"
@@ -17059,9 +21377,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "1606"
+            },
             "label": "1606"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9DB20CB0-AE43-4CA9-2CF7-536F748C9FD2"
@@ -17083,9 +21407,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-1201"
+            },
             "label": "-1201"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8FD0F656-1685-41A3-7889-1F28D502D331"
@@ -17107,9 +21437,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "stop": {
+            "in": {
+              "year": "1899"
+            },
             "label": "1899"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1FDD94E2-2283-48A8-030B-81C0D02D21F9"
@@ -17128,9 +21464,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-13050"
+            },
             "label": "-13050"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6FD0FABA-C903-4B66-804A-4D1325FCCFE5"
@@ -17152,9 +21494,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1750"
+            },
             "label": "1750"
           },
           "stop": {
+            "in": {
+              "year": "1799"
+            },
             "label": "1799"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FBB1AB4F3-C78D-4DBD-C85C-CF1A4C102B3C"
@@ -17176,9 +21524,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1775"
+            },
             "label": "1775"
           },
           "stop": {
+            "in": {
+              "year": "1799"
+            },
             "label": "1799"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FCC1E3F6C-ED07-470F-21B3-983554047069"
@@ -17200,9 +21554,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1750"
+            },
             "label": "1750"
           },
           "stop": {
+            "in": {
+              "year": "1774"
+            },
             "label": "1774"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA6560500-CD17-4428-065B-6712C28D5855"
@@ -17224,9 +21584,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1850"
+            },
             "label": "1850"
           },
           "stop": {
+            "in": {
+              "year": "1899"
+            },
             "label": "1899"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FAFE1EF29-FA17-4AD2-FE11-63E5C9083F0E"
@@ -17248,9 +21614,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1825"
+            },
             "label": "1825"
           },
           "stop": {
+            "in": {
+              "year": "1874"
+            },
             "label": "1874"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F33849CC2-9CB9-482D-3070-B64EF19EE944"
@@ -17272,9 +21644,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "1999"
+            },
             "label": "1999"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE9705D35-FC13-42AC-5EBA-D7C7094C9847"
@@ -17296,9 +21674,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1875"
+            },
             "label": "1875"
           },
           "stop": {
+            "in": {
+              "year": "1899"
+            },
             "label": "1899"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4EBA60A7-2856-4AB8-8A89-C21C88F7929F"
@@ -17320,9 +21704,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "1924"
+            },
             "label": "1924"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F45835294-4799-470D-C99E-EBAAE2820888"
@@ -17344,9 +21734,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "1949"
+            },
             "label": "1949"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7B7E6BC1-2EE6-4B82-8674-0E9C287E22D6"
@@ -17368,9 +21764,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1925"
+            },
             "label": "1925"
           },
           "stop": {
+            "in": {
+              "year": "1949"
+            },
             "label": "1949"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1636C51B-97D0-42B5-BA12-F2BF7660D0C8"
@@ -17392,9 +21794,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1850"
+            },
             "label": "1850"
           },
           "stop": {
+            "in": {
+              "year": "1874"
+            },
             "label": "1874"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F860B3959-968D-49C0-EF52-448F73D1B1BC"
@@ -17416,9 +21824,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "0299"
+            },
             "label": "299"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F673082A2-2159-49DF-DF1D-4576079C1B08"
@@ -17440,9 +21854,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "0999"
+            },
             "label": "999"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEEABA899-74E4-4299-B960-79752EE8FCB2"
@@ -17461,9 +21881,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-13050"
+            },
             "label": "-13050"
           },
           "stop": {
+            "in": {
+              "year": "1607"
+            },
             "label": "1607"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F675F1DFE-6D51-487E-C1E6-AD492E843286"
@@ -17485,9 +21911,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1925"
+            },
             "label": "1925"
           },
           "stop": {
+            "in": {
+              "year": "1974"
+            },
             "label": "1974"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD66ACBA4-D80B-43F8-293A-555BBA2471DD"
@@ -17509,9 +21941,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "stop": {
+            "in": {
+              "year": "1825"
+            },
             "label": "1825"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4FDB5251-8ED3-497B-FD41-110A0365F6DF"
@@ -17533,9 +21971,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1830"
+            },
             "label": "1830"
           },
           "stop": {
+            "in": {
+              "year": "1860"
+            },
             "label": "1860"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F93B43E77-43B2-4E00-94F2-DF62D35E7164"
@@ -17557,9 +22001,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1725"
+            },
             "label": "1725"
           },
           "stop": {
+            "in": {
+              "year": "1774"
+            },
             "label": "1774"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA5B92D72-750A-4E1E-A184-9A6D48DE9E74"
@@ -17581,9 +22031,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1790"
+            },
             "label": "1790"
           },
           "stop": {
+            "in": {
+              "year": "1829"
+            },
             "label": "1829"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF94C40E6-9732-45A4-424F-909A09A5ADC2"
@@ -17605,9 +22061,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "stop": {
+            "in": {
+              "year": "1699"
+            },
             "label": "1699"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F198326A5-09C3-40E7-088D-7D0496A8A746"
@@ -17629,9 +22091,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1724"
+            },
             "label": "1724"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FECA39B77-B04F-44D2-3FA7-62238AF14478"
@@ -17653,9 +22121,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1675"
+            },
             "label": "1675"
           },
           "stop": {
+            "in": {
+              "year": "1699"
+            },
             "label": "1699"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FFBD86B0A-8C52-4E5F-BDE0-DEF7B7985A23"
@@ -17677,9 +22151,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1749"
+            },
             "label": "1749"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FCF6FA5BC-8769-4356-7F82-5BF8F5CE7FA6"
@@ -17701,9 +22181,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1725"
+            },
             "label": "1725"
           },
           "stop": {
+            "in": {
+              "year": "1749"
+            },
             "label": "1749"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3F4DF0F6-87DC-4C12-E631-0C2F55E7F0FE"
@@ -17725,9 +22211,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "stop": {
+            "in": {
+              "year": "1849"
+            },
             "label": "1849"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F64DC3A33-EE47-412D-4675-15CC49BBDA33"
@@ -17749,9 +22241,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1825"
+            },
             "label": "1825"
           },
           "stop": {
+            "in": {
+              "year": "1849"
+            },
             "label": "1849"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEF6A031A-B430-4842-86FD-D04E2CAF9A87"
@@ -17773,9 +22271,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1975"
+            },
             "label": "1975"
           },
           "stop": {
+            "in": {
+              "year": "1999"
+            },
             "label": "1999"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE3B4D88E-CE57-4AB7-6FA5-19D456E50775"
@@ -17797,9 +22301,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1866"
+            },
             "label": "1866"
           },
           "stop": {
+            "in": {
+              "year": "1916"
+            },
             "label": "1916"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FDA509016-8E11-471E-4A51-618CA845E1C6"
@@ -17821,9 +22331,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-15000"
+            },
             "label": "-15000"
           },
           "stop": {
+            "in": {
+              "year": "-8501"
+            },
             "label": "-8501"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3131A9C4-3F59-4241-674D-97758B66759F"
@@ -17845,9 +22361,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "stop": {
+            "in": {
+              "year": "1999"
+            },
             "label": "1999"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD5F22DF3-7393-4C99-A19D-F21632B181A0"
@@ -17866,9 +22388,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-13050"
+            },
             "label": "-13050"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F569821D5-CBB0-4D75-20F3-E65CF516190C"
@@ -17890,9 +22418,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1989"
+            },
             "label": "1989"
           },
           "stop": {
+            "in": {
+              "year": "2014"
+            },
             "label": "2014"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F3F6F8594-EC43-4D59-AA0D-0A63F1D2FD2F"
@@ -17914,9 +22448,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1625"
+            },
             "label": "1625"
           },
           "stop": {
+            "in": {
+              "year": "1649"
+            },
             "label": "1649"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FEC87DC89-5047-49CA-1497-89E554BB5DCC"
@@ -17938,9 +22478,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "stop": {
+            "in": {
+              "year": "1649"
+            },
             "label": "1649"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F0C0EC914-A371-44DD-DB16-7E5EA46BA597"
@@ -17962,9 +22508,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "stop": {
+            "in": {
+              "year": "1624"
+            },
             "label": "1624"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F97AA1EDD-B08F-4D27-DDC5-7C2196ABAA65"
@@ -17986,9 +22538,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "stop": {
+            "in": {
+              "year": "1699"
+            },
             "label": "1699"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F7C8AFDAB-6081-4CBE-9B4F-3E2753336DB7"
@@ -18010,9 +22568,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1861"
+            },
             "label": "1861"
           },
           "stop": {
+            "in": {
+              "year": "1865"
+            },
             "label": "1865"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F634ADFB8-84A0-4D35-002E-44E50B1C3842"
@@ -18034,9 +22598,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1946"
+            },
             "label": "1946"
           },
           "stop": {
+            "in": {
+              "year": "1988"
+            },
             "label": "1988"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA434C77C-BD38-4B4E-83C1-5E957EE0AAFE"
@@ -18058,9 +22628,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1751"
+            },
             "label": "1751"
           },
           "stop": {
+            "in": {
+              "year": "1789"
+            },
             "label": "1789"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2CD70C87-E741-46A3-35F4-9AFD75DF5CCF"
@@ -18082,9 +22658,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1917"
+            },
             "label": "1917"
           },
           "stop": {
+            "in": {
+              "year": "1945"
+            },
             "label": "1945"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F9C4EA3ED-0A28-4ECF-31A7-D01CDBFB345F"
@@ -18106,9 +22688,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "stop": {
+            "in": {
+              "year": "1974"
+            },
             "label": "1974"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF602349E-B9DC-4754-5757-0A021C0AEB40"
@@ -18130,9 +22718,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1650"
+            },
             "label": "1650"
           },
           "stop": {
+            "in": {
+              "year": "1674"
+            },
             "label": "1674"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F5C6DB9A8-DD7D-486D-F8DE-C3CCC32F8779"
@@ -18154,9 +22748,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1625"
+            },
             "label": "1625"
           },
           "stop": {
+            "in": {
+              "year": "1674"
+            },
             "label": "1674"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F49E55AC8-4D9D-419D-48A7-F306F997D66F"
@@ -18178,9 +22778,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1607"
+            },
             "label": "1607"
           },
           "stop": {
+            "in": {
+              "year": "1750"
+            },
             "label": "1750"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F338E1BD9-B21D-4C46-F8B1-BFAFCE71D92B"
@@ -18199,9 +22805,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1450"
+            },
             "label": "1450"
           },
           "stop": {
+            "in": {
+              "year": "1550"
+            },
             "label": "1550"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4B3201ED-970B-43F1-70B5-FC165D295AF2"
@@ -18220,9 +22832,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-11550"
+            },
             "label": "-11550"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4BA40E1A-75A8-4221-4857-00E2B6136112"
@@ -18241,9 +22859,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F8A7AB37F-D71E-4232-698D-63C1630F5A80"
@@ -18262,9 +22886,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1250"
+            },
             "label": "-1250"
           },
           "stop": {
+            "in": {
+              "year": "0950"
+            },
             "label": "950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FA0835291-1BBC-4BD0-0960-1FB93FB0B21E"
@@ -18283,9 +22913,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3950"
+            },
             "label": "-3950"
           },
           "stop": {
+            "in": {
+              "year": "-1250"
+            },
             "label": "-1250"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD70B05BB-E9A1-4C2A-E20E-3879E5F0278B"
@@ -18304,9 +22940,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9550"
+            },
             "label": "-9550"
           },
           "stop": {
+            "in": {
+              "year": "-6950"
+            },
             "label": "-6950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FBAF38442-445F-43C0-8941-346ACBAD0D74"
@@ -18325,9 +22967,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "stop": {
+            "in": {
+              "year": "-0100"
+            },
             "label": "-100"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE6AE7CB3-3E57-4437-057C-D742211F9D63"
@@ -18346,9 +22994,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0350"
+            },
             "label": "350"
           },
           "stop": {
+            "in": {
+              "year": "0950"
+            },
             "label": "950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F6B94B036-4B2E-475B-DD21-3213252CFC63"
@@ -18367,9 +23021,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0050"
+            },
             "label": "-50"
           },
           "stop": {
+            "in": {
+              "year": "0350"
+            },
             "label": "350"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FCCBA9ADC-85F5-410C-7C29-05E96DB0386A"
@@ -18388,9 +23048,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10550"
+            },
             "label": "-10550"
           },
           "stop": {
+            "in": {
+              "year": "-9550"
+            },
             "label": "-9550"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FDCFA8120-9ED4-4957-9360-B5CA2523DD2F"
@@ -18409,9 +23075,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F4A5AED81-3996-4A74-66C7-0247174E2CFD"
@@ -18430,9 +23102,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0950"
+            },
             "label": "950"
           },
           "stop": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F817091D5-8E10-437F-038E-44B39DF2FF4A"
@@ -18451,9 +23129,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "stop": {
+            "in": {
+              "year": "-0100"
+            },
             "label": "-100"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FAB3BD9D1-2F3C-4B7D-1685-4AE5ACA9AB0A"
@@ -18472,9 +23156,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6950"
+            },
             "label": "-6950"
           },
           "stop": {
+            "in": {
+              "year": "-3950"
+            },
             "label": "-3950"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F70D7C0D8-8C30-4387-A3BF-0E1093E7B2A2"
@@ -18493,9 +23183,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-11550"
+            },
             "label": "-11550"
           },
           "stop": {
+            "in": {
+              "year": "-10900"
+            },
             "label": "-10900"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF6CBACF7-FC35-4968-8471-64CD32EC8639"
@@ -18514,9 +23210,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1350"
+            },
             "label": "1350"
           },
           "stop": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F10E9844F-7B87-417B-C2DC-AB49BD660FA1"
@@ -18535,9 +23237,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F2481B6D1-9190-4899-3299-619CB32B0B55"
@@ -18556,9 +23264,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F826EE243-5308-4767-61B4-AC029CBBC9D8"
@@ -18577,9 +23291,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1150"
+            },
             "label": "1150"
           },
           "stop": {
+            "in": {
+              "year": "1350"
+            },
             "label": "1350"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD5CC9962-B4DB-4F2E-44C8-A3A12C58C258"
@@ -18598,9 +23318,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FD47875AF-F1FA-4845-B10A-60546DC6F719"
@@ -18619,9 +23345,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FAD873264-B84E-429A-8D45-71EF93B37BD6"
@@ -18640,9 +23372,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FAFE77FAF-3C66-4010-FB78-CB2D3B3C2BC6"
@@ -18661,9 +23399,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FB0B00D35-F34E-4A8D-C709-9181A9D4882D"
@@ -18682,9 +23426,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "stop": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FCC066A00-AAF0-4A87-A0E0-13669A664812"
@@ -18703,9 +23453,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1250"
+            },
             "label": "-1250"
           },
           "stop": {
+            "in": {
+              "year": "-0050"
+            },
             "label": "-50"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F41B622F5-E47F-4DF2-CEEA-D9720CF7A05E"
@@ -18724,9 +23480,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0950"
+            },
             "label": "950"
           },
           "stop": {
+            "in": {
+              "year": "1150"
+            },
             "label": "1150"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F24ED1509-2E82-436F-4600-9184B7A13A55"
@@ -18745,9 +23507,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-11550"
+            },
             "label": "-11550"
           },
           "stop": {
+            "in": {
+              "year": "-9550"
+            },
             "label": "-9550"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FE286D32C-6267-4F92-E9AA-4DE71E84CDD3"
@@ -18766,9 +23534,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F40B5E148-5B14-4842-5087-0160C928F8B6"
@@ -18787,9 +23561,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9550"
+            },
             "label": "-9550"
           },
           "stop": {
+            "in": {
+              "year": "-1250"
+            },
             "label": "-1250"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F61D1FBB3-87DD-4D88-537C-30479877769E"
@@ -18808,9 +23588,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-10900"
+            },
             "label": "-10900"
           },
           "stop": {
+            "in": {
+              "year": "-10550"
+            },
             "label": "-10550"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FCD41671F-ED96-4F84-7E4D-0F9E3DAE07C4"
@@ -18829,9 +23615,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1B08A37E-A673-42DD-7400-C746065974C7"
@@ -18850,9 +23642,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FF3162456-9D8E-4190-8962-C7F65014C328"
@@ -18871,9 +23669,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F897D4DEF-5C33-4091-7A30-2B0747767E30"
@@ -18892,9 +23696,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F5D6D7806-21E7-48AC-94F8-A726AE5D623D"
@@ -18913,9 +23723,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2FCF984D14-009F-4F0E-0A09-7AC1AA07FD6D"
@@ -18934,9 +23750,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1490"
+            },
             "label": "1490"
           },
           "stop": {
+            "in": {
+              "year": "1770"
+            },
             "label": "1770"
           },
           "url": "http%3A%2F%2Fopencontext.org%2Ftypes%2F1970AC12-0CCD-47D6-EE48-DB810A849560"
@@ -19026,9 +23848,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-0585"
+            },
             "label": "586 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0538"
+            },
             "label": "539 B.C.E."
           }
         },
@@ -19079,9 +23907,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-8499"
+            },
             "label": "8500 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-4499"
+            },
             "label": "4500 B.C.E."
           }
         },
@@ -19124,9 +23958,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-4499"
+            },
             "label": "4500 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 B.C.E."
           }
         },
@@ -19169,9 +24009,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-2249"
+            },
             "label": "2250 B.C.E."
           }
         },
@@ -19214,9 +24060,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-2249"
+            },
             "label": "2250 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1924"
+            },
             "label": "1925 B.C.E."
           }
         },
@@ -19259,9 +24111,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-1924"
+            },
             "label": "1925 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 B.C.E."
           }
         },
@@ -19304,9 +24162,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C.E."
           }
         },
@@ -19349,9 +24213,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0585"
+            },
             "label": "586 B.C.E."
           }
         },
@@ -19394,9 +24264,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-0538"
+            },
             "label": "539 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0331"
+            },
             "label": "332 B.C.E."
           }
         },
@@ -19439,9 +24315,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-0331"
+            },
             "label": "332 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0052"
+            },
             "label": "53 B.C.E."
           }
         }
@@ -19485,9 +24367,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1074"
+            },
             "label": "ca. 1075 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0974"
+            },
             "label": "975 B.C."
           }
         },
@@ -19508,9 +24396,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0974"
+            },
             "label": "ca. 975 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           }
         },
@@ -19531,9 +24425,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "ca. 800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0749"
+            },
             "label": "750 B.C."
           }
         },
@@ -19551,9 +24451,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0749"
+            },
             "label": "ca. 750 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "700 B.C."
           }
         },
@@ -19573,9 +24479,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0849"
+            },
             "label": "ca. 850 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           }
         }
@@ -19629,9 +24541,17 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "0201",
+              "latestYear": "0300"
+            },
             "label": "3rd cent."
           },
           "stop": {
+            "in": {
+              "earliestYear": "0501",
+              "latestYear": "0600"
+            },
             "label": "6th cent."
           }
         },
@@ -19648,9 +24568,17 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "0001",
+              "latestYear": "0100"
+            },
             "label": "1st cent."
           },
           "stop": {
+            "in": {
+              "earliestYear": "0201",
+              "latestYear": "0300"
+            },
             "label": "3rd cent."
           }
         },
@@ -19667,9 +24595,17 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "0301",
+              "latestYear": "0400"
+            },
             "label": "4th cent."
           },
           "stop": {
+            "in": {
+              "earliestYear": "0601",
+              "latestYear": "0700"
+            },
             "label": "7th cent."
           }
         },
@@ -19686,9 +24622,17 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "0601",
+              "latestYear": "0700"
+            },
             "label": "7th cent."
           },
           "stop": {
+            "in": {
+              "earliestYear": "1001",
+              "latestYear": "1100"
+            },
             "label": "11th cent."
           }
         }
@@ -19728,6 +24672,9 @@
             "label": "31 December 192 AD"
           },
           "stop": {
+            "in": {
+              "year": "0421"
+            },
             "label": "421 AD"
           }
         },
@@ -19750,9 +24697,15 @@
           ],
           "spatialCoverageDescription": "Late Roman Empire",
           "start": {
+            "in": {
+              "year": "-0322"
+            },
             "label": "323 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0330"
+            },
             "label": "331 BC"
           }
         }
@@ -19823,9 +24776,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-0538"
+            },
             "label": "539 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0330"
+            },
             "label": "331 B.C.E."
           }
         },
@@ -19851,9 +24810,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2333"
+            },
             "label": "2334 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-2192"
+            },
             "label": "2193 B.C.E."
           }
         },
@@ -19884,9 +24849,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-5799"
+            },
             "label": "ca. 5800 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-3749"
+            },
             "label": "3750 B.C.E."
           }
         },
@@ -19916,9 +24887,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-69999"
+            },
             "label": "70000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-8999"
+            },
             "label": "9000 B.C.E."
           }
         },
@@ -19948,9 +24925,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-8999"
+            },
             "label": "9000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-6999"
+            },
             "label": "7000 B.C.E."
           }
         },
@@ -19980,9 +24963,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-6999"
+            },
             "label": "7000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-5799"
+            },
             "label": "5800 B.C.E."
           }
         },
@@ -20012,9 +25001,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-5799"
+            },
             "label": "5800 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 B.C.E."
           }
         },
@@ -20037,9 +25032,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-3749"
+            },
             "label": "3750 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-3149"
+            },
             "label": "3150 B.C.E."
           }
         },
@@ -20062,9 +25063,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-3149"
+            },
             "label": "3150 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "2900 B.C.E."
           }
         },
@@ -20087,9 +25094,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "2900 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-2333"
+            },
             "label": "2334 B.C.E."
           }
         },
@@ -20112,9 +25125,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 B.C.E."
           }
         },
@@ -20145,9 +25164,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 B.C.E."
           }
         },
@@ -20177,9 +25202,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-0330"
+            },
             "label": "331 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0125"
+            },
             "label": "126 B.C.E."
           }
         },
@@ -20202,9 +25233,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-0624"
+            },
             "label": "625 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0538"
+            },
             "label": "539 B.C.E."
           }
         },
@@ -20235,9 +25272,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 B.C.E."
           }
         },
@@ -20270,9 +25313,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0604"
+            },
             "label": "605 B.C.E."
           }
         },
@@ -20299,9 +25348,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2111"
+            },
             "label": "2112 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-2003"
+            },
             "label": "2004 B.C.E."
           }
         },
@@ -20332,9 +25387,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "-0125"
+            },
             "label": "126 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "0227"
+            },
             "label": "227 C.E."
           }
         },
@@ -20360,9 +25421,15 @@
           ],
           "spatialCoverageDescription": "Ancient Mesopotamia",
           "start": {
+            "in": {
+              "year": "0227"
+            },
             "label": "227 C.E."
           },
           "stop": {
+            "in": {
+              "year": "0651"
+            },
             "label": "651 C.E."
           }
         }
@@ -20400,9 +25467,15 @@
           ],
           "spatialCoverageDescription": "Bethsaida",
           "start": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0924"
+            },
             "label": "925 BCE"
           }
         },
@@ -20424,9 +25497,15 @@
           ],
           "spatialCoverageDescription": "Bethsaida",
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0721"
+            },
             "label": "722 BCE"
           }
         },
@@ -20448,6 +25527,9 @@
           ],
           "spatialCoverageDescription": "Bethsaida",
           "start": {
+            "in": {
+              "year": "-0721"
+            },
             "label": "722 BCE"
           },
           "stop": {
@@ -20476,9 +25558,15 @@
           ],
           "spatialCoverageDescription": "Bethsaida",
           "start": {
+            "in": {
+              "year": "-0585"
+            },
             "label": "586 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0538"
+            },
             "label": "539 BCE"
           }
         }
@@ -20516,9 +25604,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0138"
+            },
             "label": "138 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0192"
+            },
             "label": "192 A.D."
           }
         },
@@ -20540,9 +25634,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "-0011"
+            },
             "label": "12 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0014"
+            },
             "label": "14 A.D."
           }
         },
@@ -20564,9 +25664,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "-0026"
+            },
             "label": "27 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0014"
+            },
             "label": "14 A.D."
           }
         },
@@ -20588,9 +25694,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0069"
+            },
             "label": "69 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0096"
+            },
             "label": "96 A.D."
           }
         },
@@ -20612,9 +25724,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0260"
+            },
             "label": "260 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0274"
+            },
             "label": "274 A.D."
           }
         },
@@ -20636,9 +25754,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0117"
+            },
             "label": "117 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0138"
+            },
             "label": "138 A.D."
           }
         },
@@ -20660,9 +25784,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0096"
+            },
             "label": "96 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0193"
+            },
             "label": "193 A.D."
           }
         },
@@ -20684,9 +25814,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "-0026"
+            },
             "label": "27 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0476"
+            },
             "label": "476 A.D."
           }
         },
@@ -20709,9 +25845,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0014"
+            },
             "label": "14 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0069"
+            },
             "label": "69 A.D."
           }
         },
@@ -20733,9 +25875,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0235"
+            },
             "label": "235 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0410"
+            },
             "label": "410 A.D."
           }
         },
@@ -20758,9 +25906,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "-0271"
+            },
             "label": "272 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0141"
+            },
             "label": "142 B.C."
           }
         },
@@ -20782,9 +25936,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0193"
+            },
             "label": "193 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0235"
+            },
             "label": "235 A.D."
           }
         },
@@ -20806,9 +25966,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0098"
+            },
             "label": "98 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0117"
+            },
             "label": "117 A.D."
           }
         },
@@ -20830,9 +25996,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "-0579"
+            },
             "label": "580 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "480 B.C."
           }
         },
@@ -20854,9 +26026,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "-0724"
+            },
             "label": "725 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0579"
+            },
             "label": "580 B.C."
           }
         }
@@ -20899,9 +26077,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2349"
+            },
             "label": "2350 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "801 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F13"
@@ -20919,9 +26103,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2349"
+            },
             "label": "2350 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1600"
+            },
             "label": "1601 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F13"
@@ -20939,9 +26129,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3500"
+            },
             "label": "3501 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F9"
@@ -20959,9 +26155,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0042"
+            },
             "label": "A.D. 42"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F16"
@@ -20979,9 +26181,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0400"
+            },
             "label": "401 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F16"
@@ -20999,9 +26207,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0100"
+            },
             "label": "101 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F16"
@@ -21019,9 +26233,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0099"
+            },
             "label": "100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0042"
+            },
             "label": "A.D. 42"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F16"
@@ -21039,9 +26259,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "801 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F13"
@@ -21059,9 +26285,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2699"
+            },
             "label": "2700 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2350"
+            },
             "label": "2351 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F9"
@@ -21079,9 +26311,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "1001 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F13"
@@ -21099,9 +26337,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2700"
+            },
             "label": "2701 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F9"
@@ -21119,9 +26363,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2350"
+            },
             "label": "2351 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F9"
@@ -21140,9 +26390,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "700 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0297"
+            },
             "label": "A.D. 297"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F66"
@@ -21161,9 +26417,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-499999"
+            },
             "label": "500000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "10001 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F2"
@@ -21185,9 +26447,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-499999"
+            },
             "label": "500000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-150000"
+            },
             "label": "150001 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F2"
@@ -21205,9 +26473,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-149999"
+            },
             "label": "150000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-40000"
+            },
             "label": "40001 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F2"
@@ -21229,9 +26503,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-39999"
+            },
             "label": "40000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "10001 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F2"
@@ -21250,9 +26530,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9999"
+            },
             "label": "10000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "4001 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F6"
@@ -21270,9 +26556,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9999"
+            },
             "label": "10000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-7000"
+            },
             "label": "7001 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F6"
@@ -21290,9 +26582,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6999"
+            },
             "label": "7000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "4001 B.C."
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F6"
@@ -21311,9 +26609,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0043"
+            },
             "label": "A.D. 43"
           },
           "stop": {
+            "in": {
+              "year": "0410"
+            },
             "label": "A.D. 410"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F21"
@@ -21331,9 +26635,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0043"
+            },
             "label": "A.D. 43"
           },
           "stop": {
+            "in": {
+              "year": "0200"
+            },
             "label": "A.D. 200"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F21"
@@ -21351,9 +26661,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0201"
+            },
             "label": "A.D. 201"
           },
           "stop": {
+            "in": {
+              "year": "0410"
+            },
             "label": "A.D. 410"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F21"
@@ -21372,9 +26688,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0410"
+            },
             "label": "A.D. 410"
           },
           "stop": {
+            "in": {
+              "year": "1066"
+            },
             "label": "A.D. 1066"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F47"
@@ -21392,9 +26714,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0410"
+            },
             "label": "A.D. 410"
           },
           "stop": {
+            "in": {
+              "year": "0700"
+            },
             "label": "A.D. 700"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F47"
@@ -21412,9 +26740,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0701"
+            },
             "label": "A.D. 701"
           },
           "stop": {
+            "in": {
+              "year": "0850"
+            },
             "label": "A.D. 850"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F47"
@@ -21432,9 +26766,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0851"
+            },
             "label": "A.D. 851"
           },
           "stop": {
+            "in": {
+              "year": "1066"
+            },
             "label": "A.D. 1066"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F47"
@@ -21453,9 +26793,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0491"
+            },
             "label": "A.D. 491"
           },
           "stop": {
+            "in": {
+              "year": "1453"
+            },
             "label": "A.D. 1453"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F67"
@@ -21474,9 +26820,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1066"
+            },
             "label": "A.D. 1066"
           },
           "stop": {
+            "in": {
+              "year": "1539"
+            },
             "label": "A.D. 1539"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F29"
@@ -21495,9 +26847,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "A.D. 1500"
           },
           "stop": {
+            "in": {
+              "year": "1900"
+            },
             "label": "A.D. 1900"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F36"
@@ -21515,9 +26873,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1901"
+            },
             "label": "A.D. 1901"
           },
           "stop": {
+            "in": {
+              "year": "2050"
+            },
             "label": "A.D. 2050"
           },
           "url": "http%3A%2F%2Ffinds.org.uk%2Fdatabase%2Fterminology%2Fperiod%2Fid%2F41"
@@ -21559,9 +26923,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           }
         },
@@ -21586,9 +26956,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           }
         },
@@ -21613,9 +26989,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2699"
+            },
             "label": "2700 BCE"
           }
         },
@@ -21640,9 +27022,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2699"
+            },
             "label": "2700 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "2200 BCE"
           }
         },
@@ -21667,9 +27055,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "2200 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           }
         },
@@ -21694,9 +27088,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           }
         },
@@ -21721,9 +27121,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2699"
+            },
             "label": "2700 BCE"
           }
         },
@@ -21748,9 +27154,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2699"
+            },
             "label": "2700 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2399"
+            },
             "label": "2400 BCE"
           }
         },
@@ -21775,9 +27187,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2399"
+            },
             "label": "2400 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "2200 BCE"
           }
         },
@@ -21802,9 +27220,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "2200 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           }
         },
@@ -21829,9 +27253,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           }
         },
@@ -21856,9 +27286,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2699"
+            },
             "label": "2700 BCE"
           }
         },
@@ -21883,9 +27319,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2699"
+            },
             "label": "2700 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2399"
+            },
             "label": "2400 BCE"
           }
         },
@@ -21910,9 +27352,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2399"
+            },
             "label": "2400 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "2200 BCE"
           }
         },
@@ -21937,9 +27385,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "2200 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           }
         },
@@ -21964,9 +27418,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1079"
+            },
             "label": "1080 BCE"
           }
         },
@@ -21991,9 +27451,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1079"
+            },
             "label": "1080 BCE"
           }
         },
@@ -22018,9 +27484,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 BCE"
           }
         },
@@ -22045,9 +27517,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1389"
+            },
             "label": "1390 BCE"
           }
         },
@@ -22072,9 +27550,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1389"
+            },
             "label": "1390 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1079"
+            },
             "label": "1080 BCE"
           }
         },
@@ -22099,9 +27583,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1079"
+            },
             "label": "1080 BCE"
           }
         },
@@ -22126,9 +27616,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 BCE"
           }
         },
@@ -22153,9 +27649,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "1400 BCE"
           }
         },
@@ -22180,9 +27682,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1449"
+            },
             "label": "1450 BCE"
           }
         },
@@ -22207,9 +27715,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1449"
+            },
             "label": "1450 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "1400 BCE"
           }
         },
@@ -22234,9 +27748,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "1400 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1369"
+            },
             "label": "1370 BCE"
           }
         },
@@ -22261,9 +27781,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1369"
+            },
             "label": "1370 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 BCE"
           }
         },
@@ -22288,9 +27814,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1189"
+            },
             "label": "1190 BCE"
           }
         },
@@ -22315,9 +27847,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1189"
+            },
             "label": "1190 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1079"
+            },
             "label": "1080 BCE"
           }
         },
@@ -22342,9 +27880,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1079"
+            },
             "label": "1080 BCE"
           }
         },
@@ -22369,9 +27913,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 BCE"
           }
         },
@@ -22396,9 +27946,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1424"
+            },
             "label": "1425 BCE"
           }
         },
@@ -22423,9 +27979,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1424"
+            },
             "label": "1425 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1389"
+            },
             "label": "1390 BCE"
           }
         },
@@ -22450,9 +28012,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1424"
+            },
             "label": "1425 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1389"
+            },
             "label": "1390 BCE"
           }
         },
@@ -22477,9 +28045,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1389"
+            },
             "label": "1390 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1079"
+            },
             "label": "1080 BCE"
           }
         },
@@ -22504,9 +28078,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1389"
+            },
             "label": "1390 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1359"
+            },
             "label": "1360 BCE"
           }
         },
@@ -22531,9 +28111,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1359"
+            },
             "label": "1360 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 BCE"
           }
         },
@@ -22558,9 +28144,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1189"
+            },
             "label": "1190 BCE"
           }
         },
@@ -22585,9 +28177,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1189"
+            },
             "label": "1190 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1079"
+            },
             "label": "1080 BCE"
           }
         },
@@ -22612,9 +28210,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           }
         },
@@ -22639,9 +28243,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           }
         },
@@ -22666,9 +28276,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "1900 BCE"
           }
         },
@@ -22693,9 +28309,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "1900 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BCE"
           }
         },
@@ -22720,9 +28342,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           }
         },
@@ -22747,9 +28375,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           }
         },
@@ -22774,9 +28408,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "1900 BCE"
           }
         },
@@ -22801,9 +28441,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "1900 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BCE"
           }
         },
@@ -22828,9 +28474,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           }
         },
@@ -22855,9 +28507,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           }
         },
@@ -22882,9 +28540,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "1900 BCE"
           }
         },
@@ -22909,9 +28573,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "1900 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "1800 BCE"
           }
         },
@@ -22936,9 +28606,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "1800 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BCE"
           }
         },
@@ -22963,9 +28639,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           }
         },
@@ -22990,9 +28672,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1079"
+            },
             "label": "1080 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 BCE"
           }
         },
@@ -23017,9 +28705,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1079"
+            },
             "label": "1080 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 BCE"
           }
         }
@@ -23061,9 +28755,17 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "-0666",
+              "latestYear": "-0633"
+            },
             "label": "mid 7th century B.C."
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0599",
+              "latestYear": "-0566"
+            },
             "label": "beginning of the 6th century B.C."
           }
         },
@@ -23089,9 +28791,17 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "-0599",
+              "latestYear": "-0566"
+            },
             "label": "beginning of the 6th century B.C."
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0499",
+              "latestYear": "-0466"
+            },
             "label": "beginning of the 5th century B.C."
           }
         },
@@ -23117,9 +28827,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 B.C."
           }
         }
@@ -23164,9 +28880,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-1679"
+            },
             "label": "c. 1680 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 B.C."
           }
         },
@@ -23188,9 +28910,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "c. 1600 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "1400 B.C."
           }
         },
@@ -23212,9 +28940,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "c. 1400 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 B.C."
           }
         },
@@ -23236,9 +28970,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "c. 1300 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1179"
+            },
             "label": "1180 B.C."
           }
         },
@@ -23260,9 +29000,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-1179"
+            },
             "label": "c. 1180 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1059"
+            },
             "label": "1060 B.C."
           }
         },
@@ -23288,9 +29034,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-2049"
+            },
             "label": "c. 2050 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1679"
+            },
             "label": "1680 B.C."
           }
         },
@@ -23315,9 +29067,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-348000"
+            },
             "label": "ca. 350000 BP"
           },
           "stop": {
+            "in": {
+              "year": "-9000"
+            },
             "label": "11000 BP"
           }
         },
@@ -23339,9 +29097,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-7500"
+            },
             "label": "ca. 9500 BP"
           },
           "stop": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "8000 BP"
           }
         },
@@ -23363,9 +29127,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-5999"
+            },
             "label": "ca. 6000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 B.C."
           }
         },
@@ -23387,9 +29157,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "ca. 3100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2649"
+            },
             "label": "ca. 2650 B.C."
           }
         },
@@ -23411,9 +29187,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-2649"
+            },
             "label": "ca. 2650 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "2200 B.C."
           }
         },
@@ -23435,9 +29217,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "ca. 2200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2049"
+            },
             "label": "2050 B.C."
           }
         },
@@ -23459,9 +29247,17 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "earliestYear": "-1699",
+              "latestYear": "-1600"
+            },
             "label": "seventeenth century B.C."
           },
           "stop": {
+            "in": {
+              "earliestYear": "-1499",
+              "latestYear": "-1400"
+            },
             "label": "fifteenth century B.C."
           }
         },
@@ -23483,9 +29279,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "ca. 1100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           }
         },
@@ -23511,9 +29313,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-1059"
+            },
             "label": "ca. 1060 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           }
         },
@@ -23538,9 +29346,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "ca. 900 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "700 B.C."
           }
         },
@@ -23565,9 +29379,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "ca. 700 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "480 B.C."
           }
         },
@@ -23592,9 +29412,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "480 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0322"
+            },
             "label": "323 B.C."
           }
         },
@@ -23619,9 +29445,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-0322"
+            },
             "label": "323 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "31 B.C."
           }
         },
@@ -23646,9 +29478,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "31 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "ca. 400 A.D."
           }
         },
@@ -23673,9 +29511,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0700"
+            },
             "label": "700 A.D."
           }
         },
@@ -23700,9 +29544,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0600"
+            },
             "label": "600 A.D."
           }
         },
@@ -23724,9 +29574,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "0600"
+            },
             "label": "600 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0900"
+            },
             "label": "900 A.D."
           }
         },
@@ -23748,9 +29604,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "0900"
+            },
             "label": "A.D. 900"
           },
           "stop": {
+            "in": {
+              "year": "1204"
+            },
             "label": "A.D. 1204"
           }
         },
@@ -23772,9 +29634,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "1205"
+            },
             "label": "A.D. 1205"
           },
           "stop": {
+            "in": {
+              "year": "1430"
+            },
             "label": "A.D. 1430"
           }
         },
@@ -23799,9 +29667,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "1204"
+            },
             "label": "1204 A.D. "
           },
           "stop": {
+            "in": {
+              "year": "1430"
+            },
             "label": "1430 A.D."
           }
         },
@@ -23826,9 +29700,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "1261"
+            },
             "label": "1261 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1453"
+            },
             "label": "1453 A.D."
           }
         },
@@ -23854,9 +29734,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "1460"
+            },
             "label": "1460 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1684"
+            },
             "label": "1684 A.D."
           }
         },
@@ -23878,9 +29764,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "1686"
+            },
             "label": "1686 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1715"
+            },
             "label": "1715 A.D."
           }
         },
@@ -23905,9 +29797,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "1715"
+            },
             "label": "1715 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1827"
+            },
             "label": "1827 A.D."
           }
         },
@@ -23929,9 +29827,15 @@
           ],
           "spatialCoverageDescription": "ancient Pylos",
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800 A.D."
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950 A.D."
           }
         }
@@ -23972,9 +29876,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           }
         },
@@ -23995,9 +29905,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 B.C."
           }
         },
@@ -24018,9 +29934,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "1400 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 B.C."
           }
         }
@@ -24068,9 +29990,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "1800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0669"
+            },
             "label": "670 B.C."
           }
         },
@@ -24091,9 +30019,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0069"
+            },
             "label": "69 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0096"
+            },
             "label": "96 A.D."
           }
         },
@@ -24122,9 +30056,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0149"
+            },
             "label": "150 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0054"
+            },
             "label": "55 B.C."
           }
         },
@@ -24149,9 +30089,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0749"
+            },
             "label": "750 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0449"
+            },
             "label": "450 B.C."
           }
         },
@@ -24172,9 +30118,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0096"
+            },
             "label": "96 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0192"
+            },
             "label": "192 A.D."
           }
         },
@@ -24207,9 +30159,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0669"
+            },
             "label": "670 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0054"
+            },
             "label": "55 B.C."
           }
         },
@@ -24230,9 +30188,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0043"
+            },
             "label": "43 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0069"
+            },
             "label": "69 A.D."
           }
         },
@@ -24257,9 +30221,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0449"
+            },
             "label": "450 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0054"
+            },
             "label": "55 B.C."
           }
         },
@@ -24288,9 +30258,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0043"
+            },
             "label": "43 A.D."
           },
           "stop": {
+            "in": {
+              "year": "0410"
+            },
             "label": "410 A.D."
           }
         }
@@ -24324,9 +30300,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0322"
+            },
             "label": "323 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0240"
+            },
             "label": "241 B.C."
           }
         },
@@ -24343,9 +30325,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0322"
+            },
             "label": "323 B.C."
           }
         }
@@ -24402,9 +30390,15 @@
           ],
           "spatialCoverageDescription": "Palestine and Neighboring Areas (Mesopotamia), Southern Levant",
           "start": {
+            "in": {
+              "year": "-0538"
+            },
             "label": "539 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0331"
+            },
             "label": "332 B.C.E."
           }
         },
@@ -24439,9 +30433,15 @@
           ],
           "spatialCoverageDescription": "Palestine and Neighboring Areas (Mesopotamia), Southern Levant",
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1649"
+            },
             "label": "1650 B.C.E."
           }
         },
@@ -24475,9 +30475,15 @@
           ],
           "spatialCoverageDescription": "Palestine and Neighboring Areas (Mesopotamia), Southern Levant",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0585"
+            },
             "label": "586 B.C.E."
           }
         },
@@ -24507,9 +30513,15 @@
           ],
           "spatialCoverageDescription": "Palestine and Neighboring Areas (Mesopotamia), Southern Levant",
           "start": {
+            "in": {
+              "year": "-0321"
+            },
             "label": "322 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0061"
+            },
             "label": "62 B.C.E."
           }
         },
@@ -24539,9 +30551,15 @@
           ],
           "spatialCoverageDescription": "Palestine and Neighboring Areas (Mesopotamia), Southern Levant",
           "start": {
+            "in": {
+              "year": "-0062"
+            },
             "label": "63 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "0325"
+            },
             "label": "C.E. 325"
           }
         },
@@ -24571,9 +30589,15 @@
           ],
           "spatialCoverageDescription": "Palestine and Neighboring Areas (Mesopotamia), Southern Levant",
           "start": {
+            "in": {
+              "year": "0325"
+            },
             "label": "C.E. 325"
           },
           "stop": {
+            "in": {
+              "year": "0636"
+            },
             "label": "C.E. 636"
           }
         }
@@ -24613,9 +30637,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0056"
+            },
             "label": "56"
           },
           "stop": {
+            "in": {
+              "year": "0000"
+            },
             "label": "0"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E137%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24637,9 +30667,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0150"
+            },
             "label": "150"
           },
           "stop": {
+            "in": {
+              "year": "0056"
+            },
             "label": "56"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E136%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24662,9 +30698,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2480"
+            },
             "label": "2480"
           },
           "stop": {
+            "in": {
+              "year": "2336"
+            },
             "label": "2336"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E13%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24686,9 +30728,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "7000"
+            },
             "label": "7000"
           },
           "stop": {
+            "in": {
+              "year": "5300"
+            },
             "label": "5300"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E38%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24710,9 +30758,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "5300"
+            },
             "label": "5300"
           },
           "stop": {
+            "in": {
+              "year": "4300"
+            },
             "label": "4300"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E39%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24734,9 +30788,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "4300"
+            },
             "label": "4300"
           },
           "stop": {
+            "in": {
+              "year": "3000"
+            },
             "label": "3000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E40%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24758,9 +30818,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3000"
+            },
             "label": "3000"
           },
           "stop": {
+            "in": {
+              "year": "2350"
+            },
             "label": "2350"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E41%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24782,9 +30848,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2350"
+            },
             "label": "2350"
           },
           "stop": {
+            "in": {
+              "year": "2001"
+            },
             "label": "2001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E42%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24806,9 +30878,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2001"
+            },
             "label": "2001"
           },
           "stop": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E43%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24830,9 +30908,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "stop": {
+            "in": {
+              "year": "1400"
+            },
             "label": "1400"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E44%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24854,9 +30938,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1400"
+            },
             "label": "1400"
           },
           "stop": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E45%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24878,9 +30968,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0508"
+            },
             "label": "508"
           },
           "stop": {
+            "in": {
+              "year": "0211"
+            },
             "label": "211"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E46%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24902,9 +30998,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0211"
+            },
             "label": "211"
           },
           "stop": {
+            "in": {
+              "year": "0000"
+            },
             "label": "0"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E47%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24927,9 +31029,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2600"
+            },
             "label": "2600"
           },
           "stop": {
+            "in": {
+              "year": "2480"
+            },
             "label": "2480"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E12%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24947,9 +31055,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "602000"
+            },
             "label": "602000"
           },
           "stop": {
+            "in": {
+              "year": "152000"
+            },
             "label": "152000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E80%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24967,9 +31081,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "152000"
+            },
             "label": "152000"
           },
           "stop": {
+            "in": {
+              "year": "42000"
+            },
             "label": "42000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E81%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -24987,9 +31107,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "42000"
+            },
             "label": "42000"
           },
           "stop": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E82%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25007,9 +31133,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "stop": {
+            "in": {
+              "year": "8300"
+            },
             "label": "8300"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E83%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25027,9 +31159,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "8300"
+            },
             "label": "8300"
           },
           "stop": {
+            "in": {
+              "year": "6900"
+            },
             "label": "6900"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E84%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25047,9 +31185,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "6900"
+            },
             "label": "6900"
           },
           "stop": {
+            "in": {
+              "year": "5800"
+            },
             "label": "5800"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E85%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25067,9 +31211,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "5800"
+            },
             "label": "5800"
           },
           "stop": {
+            "in": {
+              "year": "5500"
+            },
             "label": "5500"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E86%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25087,9 +31237,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "5500"
+            },
             "label": "5500"
           },
           "stop": {
+            "in": {
+              "year": "3900"
+            },
             "label": "3900"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E87%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25107,9 +31263,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3900"
+            },
             "label": "3900"
           },
           "stop": {
+            "in": {
+              "year": "3600"
+            },
             "label": "3600"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E88%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25127,9 +31289,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3600"
+            },
             "label": "3600"
           },
           "stop": {
+            "in": {
+              "year": "3000"
+            },
             "label": "3000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E89%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25151,9 +31319,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2800"
+            },
             "label": "2800"
           },
           "stop": {
+            "in": {
+              "year": "2600"
+            },
             "label": "2600"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E11%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25171,9 +31345,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3000"
+            },
             "label": "3000"
           },
           "stop": {
+            "in": {
+              "year": "2500"
+            },
             "label": "2500"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E90%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25191,9 +31371,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2500"
+            },
             "label": "2500"
           },
           "stop": {
+            "in": {
+              "year": "2001"
+            },
             "label": "2001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E91%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25211,9 +31397,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2001"
+            },
             "label": "2001"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E92%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25231,9 +31423,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1524"
+            },
             "label": "1524"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E93%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25251,9 +31449,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "stop": {
+            "in": {
+              "year": "1300"
+            },
             "label": "1300"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E94%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25271,9 +31475,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1725"
+            },
             "label": "1725"
           },
           "stop": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E95%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25291,9 +31501,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1524"
+            },
             "label": "1524"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E96%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25311,9 +31527,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "0604"
+            },
             "label": "604"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E97%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25331,9 +31553,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0604"
+            },
             "label": "604"
           },
           "stop": {
+            "in": {
+              "year": "0122"
+            },
             "label": "122"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E98%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25351,9 +31579,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0200"
+            },
             "label": "200"
           },
           "stop": {
+            "in": {
+              "year": "0082"
+            },
             "label": "82"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E99%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25375,9 +31609,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3100"
+            },
             "label": "3100"
           },
           "stop": {
+            "in": {
+              "year": "2800"
+            },
             "label": "2800"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E10%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25395,9 +31635,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1999"
+            },
             "label": "1999"
           },
           "stop": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E176%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25415,9 +31661,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E177%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25435,9 +31687,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1435"
+            },
             "label": "1435"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E178%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25455,9 +31713,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1435"
+            },
             "label": "1435"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E179%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25479,9 +31743,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "0611"
+            },
             "label": "611"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E180%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25499,9 +31769,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0611"
+            },
             "label": "611"
           },
           "stop": {
+            "in": {
+              "year": "0150"
+            },
             "label": "150"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E181%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25519,9 +31795,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0150"
+            },
             "label": "150"
           },
           "stop": {
+            "in": {
+              "year": "0056"
+            },
             "label": "56"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E182%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25539,9 +31821,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0056"
+            },
             "label": "56"
           },
           "stop": {
+            "in": {
+              "year": "0000"
+            },
             "label": "0"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E183%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25559,9 +31847,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2168"
+            },
             "label": "2168"
           },
           "stop": {
+            "in": {
+              "year": "2001"
+            },
             "label": "2001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E175%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25579,9 +31873,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2336"
+            },
             "label": "2336"
           },
           "stop": {
+            "in": {
+              "year": "2168"
+            },
             "label": "2168"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E174%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25603,9 +31903,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3500"
+            },
             "label": "3500"
           },
           "stop": {
+            "in": {
+              "year": "3100"
+            },
             "label": "3100"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E9%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25627,9 +31933,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2480"
+            },
             "label": "2480"
           },
           "stop": {
+            "in": {
+              "year": "2336"
+            },
             "label": "2336"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E173%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25651,9 +31963,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2600"
+            },
             "label": "2600"
           },
           "stop": {
+            "in": {
+              "year": "2480"
+            },
             "label": "2480"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E172%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25671,9 +31989,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2800"
+            },
             "label": "2800"
           },
           "stop": {
+            "in": {
+              "year": "2600"
+            },
             "label": "2600"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E171%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25691,9 +32015,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3100"
+            },
             "label": "3100"
           },
           "stop": {
+            "in": {
+              "year": "2800"
+            },
             "label": "2800"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E170%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25711,9 +32041,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3500"
+            },
             "label": "3500"
           },
           "stop": {
+            "in": {
+              "year": "3100"
+            },
             "label": "3100"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E169%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25731,9 +32067,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3800"
+            },
             "label": "3800"
           },
           "stop": {
+            "in": {
+              "year": "3500"
+            },
             "label": "3500"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E168%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25751,9 +32093,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "4100"
+            },
             "label": "4100"
           },
           "stop": {
+            "in": {
+              "year": "3800"
+            },
             "label": "3800"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E167%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25771,9 +32119,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "5100"
+            },
             "label": "5100"
           },
           "stop": {
+            "in": {
+              "year": "4100"
+            },
             "label": "4100"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E166%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25791,9 +32145,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "6100"
+            },
             "label": "6100"
           },
           "stop": {
+            "in": {
+              "year": "5060"
+            },
             "label": "5060"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E165%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25811,9 +32171,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "stop": {
+            "in": {
+              "year": "9000"
+            },
             "label": "9000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E164%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25835,9 +32201,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3800"
+            },
             "label": "3800"
           },
           "stop": {
+            "in": {
+              "year": "3500"
+            },
             "label": "3500"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E8%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25855,9 +32227,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "32000"
+            },
             "label": "32000"
           },
           "stop": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E163%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25875,9 +32253,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "102000"
+            },
             "label": "102000"
           },
           "stop": {
+            "in": {
+              "year": "32000"
+            },
             "label": "32000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E162%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25895,9 +32279,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "602000"
+            },
             "label": "602000"
           },
           "stop": {
+            "in": {
+              "year": "102000"
+            },
             "label": "102000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E161%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25915,9 +32305,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "151999"
+            },
             "label": "151999"
           },
           "stop": {
+            "in": {
+              "year": "42001"
+            },
             "label": "42001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E101%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25935,9 +32331,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "41999"
+            },
             "label": "41999"
           },
           "stop": {
+            "in": {
+              "year": "12001"
+            },
             "label": "12001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E102%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25955,9 +32357,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "11999"
+            },
             "label": "11999"
           },
           "stop": {
+            "in": {
+              "year": "7001"
+            },
             "label": "7001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E103%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25975,9 +32383,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "6999"
+            },
             "label": "6999"
           },
           "stop": {
+            "in": {
+              "year": "5301"
+            },
             "label": "5301"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E104%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -25995,9 +32409,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "5299"
+            },
             "label": "5299"
           },
           "stop": {
+            "in": {
+              "year": "4301"
+            },
             "label": "4301"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E105%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26015,9 +32435,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "4299"
+            },
             "label": "4299"
           },
           "stop": {
+            "in": {
+              "year": "3001"
+            },
             "label": "3001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E106%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26035,9 +32461,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2999"
+            },
             "label": "2999"
           },
           "stop": {
+            "in": {
+              "year": "2751"
+            },
             "label": "2751"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E107%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26059,9 +32491,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "4100"
+            },
             "label": "4100"
           },
           "stop": {
+            "in": {
+              "year": "3800"
+            },
             "label": "3800"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E7%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26079,9 +32517,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2749"
+            },
             "label": "2749"
           },
           "stop": {
+            "in": {
+              "year": "2581"
+            },
             "label": "2581"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E108%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26099,9 +32543,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2349"
+            },
             "label": "2349"
           },
           "stop": {
+            "in": {
+              "year": "1971"
+            },
             "label": "1971"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E109%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26119,9 +32569,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1969"
+            },
             "label": "1969"
           },
           "stop": {
+            "in": {
+              "year": "1601"
+            },
             "label": "1601"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E110%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26139,9 +32595,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1599"
+            },
             "label": "1599"
           },
           "stop": {
+            "in": {
+              "year": "1401"
+            },
             "label": "1401"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E111%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26159,9 +32621,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0499"
+            },
             "label": "499"
           },
           "stop": {
+            "in": {
+              "year": "0212"
+            },
             "label": "212"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E113%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26182,9 +32650,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0210"
+            },
             "label": "210"
           },
           "stop": {
+            "in": {
+              "year": "0000"
+            },
             "label": "0"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E114%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26202,9 +32676,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "602000"
+            },
             "label": "602000"
           },
           "stop": {
+            "in": {
+              "year": "152001"
+            },
             "label": "152001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E100%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26222,9 +32702,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1399"
+            },
             "label": "1399"
           },
           "stop": {
+            "in": {
+              "year": "0501"
+            },
             "label": "501"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E112%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26246,9 +32732,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "602000"
+            },
             "label": "602000"
           },
           "stop": {
+            "in": {
+              "year": "152000"
+            },
             "label": "152000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E115%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26270,9 +32762,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "151999"
+            },
             "label": "151999"
           },
           "stop": {
+            "in": {
+              "year": "42000"
+            },
             "label": "42000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E116%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26294,9 +32792,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "5100"
+            },
             "label": "5100"
           },
           "stop": {
+            "in": {
+              "year": "4100"
+            },
             "label": "4100"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E6%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26318,9 +32822,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "41999"
+            },
             "label": "41999"
           },
           "stop": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E117%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26342,9 +32852,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "11999"
+            },
             "label": "11999"
           },
           "stop": {
+            "in": {
+              "year": "7000"
+            },
             "label": "7000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E118%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26366,9 +32882,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "6999"
+            },
             "label": "6999"
           },
           "stop": {
+            "in": {
+              "year": "5300"
+            },
             "label": "5300"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E119%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26390,9 +32912,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "5299"
+            },
             "label": "5299"
           },
           "stop": {
+            "in": {
+              "year": "4300"
+            },
             "label": "4300"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E120%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26414,9 +32942,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "4299"
+            },
             "label": "4299"
           },
           "stop": {
+            "in": {
+              "year": "3000"
+            },
             "label": "3000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E121%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26438,9 +32972,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2999"
+            },
             "label": "2999"
           },
           "stop": {
+            "in": {
+              "year": "2000"
+            },
             "label": "2000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E122%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26462,9 +33002,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1999"
+            },
             "label": "1999"
           },
           "stop": {
+            "in": {
+              "year": "1600"
+            },
             "label": "1600"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E124%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26486,9 +33032,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1599"
+            },
             "label": "1599"
           },
           "stop": {
+            "in": {
+              "year": "1400"
+            },
             "label": "1400"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E125%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26507,9 +33059,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1399"
+            },
             "label": "1399"
           },
           "stop": {
+            "in": {
+              "year": "0521"
+            },
             "label": "521"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E126%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26531,9 +33089,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0520"
+            },
             "label": "520"
           },
           "stop": {
+            "in": {
+              "year": "0211"
+            },
             "label": "211"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E128%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26555,9 +33119,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "6100"
+            },
             "label": "6100"
           },
           "stop": {
+            "in": {
+              "year": "5060"
+            },
             "label": "5060"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E5%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26579,9 +33149,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0210"
+            },
             "label": "210"
           },
           "stop": {
+            "in": {
+              "year": "0000"
+            },
             "label": "0"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E129%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26603,9 +33179,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-999999"
+            },
             "label": "1000000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-149999"
+            },
             "label": "150000 BC"
           }
         },
@@ -26626,9 +33208,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-149999"
+            },
             "label": "150000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-34999"
+            },
             "label": "35000 BC"
           }
         },
@@ -26649,9 +33237,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-34999"
+            },
             "label": "35000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-13499"
+            },
             "label": "13500 BC"
           }
         },
@@ -26672,9 +33266,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-13499"
+            },
             "label": "13500 BC"
           },
           "stop": {
+            "in": {
+              "year": "-9999"
+            },
             "label": "10000 BC"
           }
         },
@@ -26695,9 +33295,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9999"
+            },
             "label": "10000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-6999"
+            },
             "label": "7000 BC"
           }
         },
@@ -26718,9 +33324,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6999"
+            },
             "label": "7000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-5499"
+            },
             "label": "5500 BC"
           }
         },
@@ -26741,9 +33353,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5499"
+            },
             "label": "5500 BC"
           },
           "stop": {
+            "in": {
+              "year": "-3199"
+            },
             "label": "3200 BC"
           }
         },
@@ -26764,9 +33382,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3199"
+            },
             "label": "3200 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2299"
+            },
             "label": "2300 BC"
           }
         },
@@ -26787,9 +33411,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2299"
+            },
             "label": "2300 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "1800 BC"
           }
         },
@@ -26810,9 +33440,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "stop": {
+            "in": {
+              "year": "9000"
+            },
             "label": "9000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E4%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -26834,9 +33470,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "1800 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 BC"
           }
         },
@@ -26857,9 +33499,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 BC"
           }
         },
@@ -26880,9 +33528,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 BC"
           },
           "stop": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450 AD"
           }
         },
@@ -26903,9 +33557,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "700 BC"
           }
         },
@@ -26926,9 +33586,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0749"
+            },
             "label": "750 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0249"
+            },
             "label": "250 BC"
           }
         },
@@ -26949,9 +33615,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0299"
+            },
             "label": "300 BC"
           },
           "stop": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300 AD"
           }
         },
@@ -26972,9 +33644,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0299"
+            },
             "label": "300 BC"
           },
           "stop": {
+            "in": {
+              "year": "0050"
+            },
             "label": "50 AD"
           }
         },
@@ -26995,9 +33673,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0646"
+            },
             "label": "647 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 BC"
           }
         },
@@ -27018,9 +33702,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0329"
+            },
             "label": "330 BC"
           }
         },
@@ -27041,9 +33731,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0329"
+            },
             "label": "330 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0049"
+            },
             "label": "50 BC"
           }
         },
@@ -27064,9 +33760,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0611"
+            },
             "label": "611"
           },
           "stop": {
+            "in": {
+              "year": "0150"
+            },
             "label": "150"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E135%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27088,9 +33790,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "32000"
+            },
             "label": "32000"
           },
           "stop": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E3%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27112,9 +33820,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0049"
+            },
             "label": "50 BC"
           },
           "stop": {
+            "in": {
+              "year": "0280"
+            },
             "label": "280 AD"
           }
         },
@@ -27135,9 +33849,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0049"
+            },
             "label": "50 BC"
           },
           "stop": {
+            "in": {
+              "year": "0175"
+            },
             "label": "175 AD"
           }
         },
@@ -27158,9 +33878,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0175"
+            },
             "label": "175 AD"
           },
           "stop": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450 AD"
           }
         },
@@ -27181,9 +33907,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0250"
+            },
             "label": "250 AD"
           },
           "stop": {
+            "in": {
+              "year": "0375"
+            },
             "label": "375 AD"
           }
         },
@@ -27204,9 +33936,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0375"
+            },
             "label": "375 AD"
           },
           "stop": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450 AD"
           }
         },
@@ -27227,9 +33965,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0280"
+            },
             "label": "280 AD"
           },
           "stop": {
+            "in": {
+              "year": "0530"
+            },
             "label": "530 AD"
           }
         },
@@ -27250,9 +33994,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0450"
+            },
             "label": "450 AD"
           },
           "stop": {
+            "in": {
+              "year": "0880"
+            },
             "label": "880 AD"
           }
         },
@@ -27273,9 +34023,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0880"
+            },
             "label": "880 AD"
           },
           "stop": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250 AD"
           }
         },
@@ -27296,9 +34052,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250 AD"
           },
           "stop": {
+            "in": {
+              "year": "1569"
+            },
             "label": "1569 AD"
           }
         },
@@ -27319,9 +34081,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1450"
+            },
             "label": "1450 AD"
           },
           "stop": {
+            "in": {
+              "year": "1775"
+            },
             "label": "1775 AD"
           }
         },
@@ -27342,9 +34110,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "102000"
+            },
             "label": "102000"
           },
           "stop": {
+            "in": {
+              "year": "32000"
+            },
             "label": "32000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E2%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27366,9 +34140,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1569"
+            },
             "label": "1569 AD"
           },
           "stop": {
+            "in": {
+              "year": "1914"
+            },
             "label": "1914 AD"
           }
         },
@@ -27389,9 +34169,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1914"
+            },
             "label": "1914 AD"
           },
           "stop": {
+            "in": {
+              "year": "2000"
+            },
             "label": "2000 AD"
           }
         },
@@ -27412,9 +34198,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "602000"
+            },
             "label": "602000"
           },
           "stop": {
+            "in": {
+              "year": "102000"
+            },
             "label": "102000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E1%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27432,9 +34224,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "602000"
+            },
             "label": "602000"
           },
           "stop": {
+            "in": {
+              "year": "152000"
+            },
             "label": "152000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E16%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27452,9 +34250,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "152000"
+            },
             "label": "152000"
           },
           "stop": {
+            "in": {
+              "year": "42000"
+            },
             "label": "42000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E17%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27472,9 +34276,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "42000"
+            },
             "label": "42000"
           },
           "stop": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E18%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27492,9 +34302,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "stop": {
+            "in": {
+              "year": "8300"
+            },
             "label": "8300"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E19%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27512,9 +34328,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "8300"
+            },
             "label": "8300"
           },
           "stop": {
+            "in": {
+              "year": "6900"
+            },
             "label": "6900"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E20%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27532,9 +34354,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "6900"
+            },
             "label": "6900"
           },
           "stop": {
+            "in": {
+              "year": "5800"
+            },
             "label": "5800"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E21%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27552,9 +34380,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "5800"
+            },
             "label": "5800"
           },
           "stop": {
+            "in": {
+              "year": "5500"
+            },
             "label": "5500"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E22%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27577,9 +34411,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "0611"
+            },
             "label": "611"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E134%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27597,9 +34437,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "5500"
+            },
             "label": "5500"
           },
           "stop": {
+            "in": {
+              "year": "3900"
+            },
             "label": "3900"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E23%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27617,9 +34463,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3900"
+            },
             "label": "3900"
           },
           "stop": {
+            "in": {
+              "year": "3600"
+            },
             "label": "3600"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E24%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27637,9 +34489,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3600"
+            },
             "label": "3600"
           },
           "stop": {
+            "in": {
+              "year": "3000"
+            },
             "label": "3000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E25%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27657,9 +34515,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3000"
+            },
             "label": "3000"
           },
           "stop": {
+            "in": {
+              "year": "2500"
+            },
             "label": "2500"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E26%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27677,9 +34541,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2500"
+            },
             "label": "2500"
           },
           "stop": {
+            "in": {
+              "year": "2001"
+            },
             "label": "2001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E27%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27697,9 +34567,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2001"
+            },
             "label": "2001"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E28%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27717,9 +34593,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1524"
+            },
             "label": "1524"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E29%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27737,9 +34619,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1524"
+            },
             "label": "1524"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E30%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27757,9 +34645,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "0604"
+            },
             "label": "604"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E31%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27777,9 +34671,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0604"
+            },
             "label": "604"
           },
           "stop": {
+            "in": {
+              "year": "0122"
+            },
             "label": "122"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E32%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27801,9 +34701,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1435"
+            },
             "label": "1435"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E133%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27821,9 +34727,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0122"
+            },
             "label": "122"
           },
           "stop": {
+            "in": {
+              "year": "0000"
+            },
             "label": "0"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E33%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27841,9 +34753,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "151999"
+            },
             "label": "151999"
           },
           "stop": {
+            "in": {
+              "year": "42001"
+            },
             "label": "42001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E49%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27861,9 +34779,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "41999"
+            },
             "label": "41999"
           },
           "stop": {
+            "in": {
+              "year": "12001"
+            },
             "label": "12001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E50%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27881,9 +34805,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "11999"
+            },
             "label": "11999"
           },
           "stop": {
+            "in": {
+              "year": "7001"
+            },
             "label": "7001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E51%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27901,9 +34831,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "6999"
+            },
             "label": "6999"
           },
           "stop": {
+            "in": {
+              "year": "5301"
+            },
             "label": "5301"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E52%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27921,9 +34857,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "5299"
+            },
             "label": "5299"
           },
           "stop": {
+            "in": {
+              "year": "4301"
+            },
             "label": "4301"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E53%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27941,9 +34883,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "4299"
+            },
             "label": "4299"
           },
           "stop": {
+            "in": {
+              "year": "3001"
+            },
             "label": "3001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E54%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27961,9 +34909,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2999"
+            },
             "label": "2999"
           },
           "stop": {
+            "in": {
+              "year": "2751"
+            },
             "label": "2751"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E55%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -27981,9 +34935,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2749"
+            },
             "label": "2749"
           },
           "stop": {
+            "in": {
+              "year": "2581"
+            },
             "label": "2581"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E56%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28001,9 +34961,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2579"
+            },
             "label": "2579"
           },
           "stop": {
+            "in": {
+              "year": "2481"
+            },
             "label": "2481"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E57%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28025,9 +34991,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1435"
+            },
             "label": "1435"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E132%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28045,9 +35017,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2479"
+            },
             "label": "2479"
           },
           "stop": {
+            "in": {
+              "year": "2351"
+            },
             "label": "2351"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E58%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28065,9 +35043,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2349"
+            },
             "label": "2349"
           },
           "stop": {
+            "in": {
+              "year": "1971"
+            },
             "label": "1971"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E59%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28085,9 +35069,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1969"
+            },
             "label": "1969"
           },
           "stop": {
+            "in": {
+              "year": "1601"
+            },
             "label": "1601"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E60%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28105,9 +35095,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1599"
+            },
             "label": "1599"
           },
           "stop": {
+            "in": {
+              "year": "1401"
+            },
             "label": "1401"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E61%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28125,9 +35121,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1399"
+            },
             "label": "1399"
           },
           "stop": {
+            "in": {
+              "year": "0501"
+            },
             "label": "501"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E62%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28145,9 +35147,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0499"
+            },
             "label": "499"
           },
           "stop": {
+            "in": {
+              "year": "0212"
+            },
             "label": "212"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E63%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28165,9 +35173,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0210"
+            },
             "label": "210"
           },
           "stop": {
+            "in": {
+              "year": "0000"
+            },
             "label": "0"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E64%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28185,9 +35199,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "602000"
+            },
             "label": "602000"
           },
           "stop": {
+            "in": {
+              "year": "152001"
+            },
             "label": "152001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E48%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28205,9 +35225,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1999"
+            },
             "label": "1999"
           },
           "stop": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E153%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28225,9 +35251,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E154%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28249,9 +35281,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E131%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28269,9 +35307,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1435"
+            },
             "label": "1435"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E155%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28289,9 +35333,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1435"
+            },
             "label": "1435"
           },
           "stop": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E156%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28309,9 +35359,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1000"
+            },
             "label": "1000"
           },
           "stop": {
+            "in": {
+              "year": "0611"
+            },
             "label": "611"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E157%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28329,9 +35385,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0611"
+            },
             "label": "611"
           },
           "stop": {
+            "in": {
+              "year": "0150"
+            },
             "label": "150"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E158%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28349,9 +35411,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0150"
+            },
             "label": "150"
           },
           "stop": {
+            "in": {
+              "year": "0056"
+            },
             "label": "56"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E159%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28369,9 +35437,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0056"
+            },
             "label": "56"
           },
           "stop": {
+            "in": {
+              "year": "0000"
+            },
             "label": "0"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E160%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28389,9 +35463,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2168"
+            },
             "label": "2168"
           },
           "stop": {
+            "in": {
+              "year": "2001"
+            },
             "label": "2001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E152%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28409,9 +35489,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2336"
+            },
             "label": "2336"
           },
           "stop": {
+            "in": {
+              "year": "2168"
+            },
             "label": "2168"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E151%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28433,9 +35519,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2480"
+            },
             "label": "2480"
           },
           "stop": {
+            "in": {
+              "year": "2336"
+            },
             "label": "2336"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E150%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28457,9 +35549,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2600"
+            },
             "label": "2600"
           },
           "stop": {
+            "in": {
+              "year": "2480"
+            },
             "label": "2480"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E149%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28481,9 +35579,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1999"
+            },
             "label": "1999"
           },
           "stop": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E130%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28501,9 +35605,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2800"
+            },
             "label": "2800"
           },
           "stop": {
+            "in": {
+              "year": "2600"
+            },
             "label": "2600"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E148%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28521,9 +35631,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3100"
+            },
             "label": "3100"
           },
           "stop": {
+            "in": {
+              "year": "2800"
+            },
             "label": "2800"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E147%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28541,9 +35657,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3500"
+            },
             "label": "3500"
           },
           "stop": {
+            "in": {
+              "year": "3100"
+            },
             "label": "3100"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E146%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28561,9 +35683,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3800"
+            },
             "label": "3800"
           },
           "stop": {
+            "in": {
+              "year": "3500"
+            },
             "label": "3500"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E145%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28581,9 +35709,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "4100"
+            },
             "label": "4100"
           },
           "stop": {
+            "in": {
+              "year": "3800"
+            },
             "label": "3800"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E144%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28601,9 +35735,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "5100"
+            },
             "label": "5100"
           },
           "stop": {
+            "in": {
+              "year": "4100"
+            },
             "label": "4100"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E143%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28621,9 +35761,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "6100"
+            },
             "label": "6100"
           },
           "stop": {
+            "in": {
+              "year": "5060"
+            },
             "label": "5060"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E142%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28641,9 +35787,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "stop": {
+            "in": {
+              "year": "9000"
+            },
             "label": "9000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E141%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28661,9 +35813,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "32000"
+            },
             "label": "32000"
           },
           "stop": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E140%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28681,9 +35839,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "102000"
+            },
             "label": "102000"
           },
           "stop": {
+            "in": {
+              "year": "32000"
+            },
             "label": "32000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E139%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28705,9 +35869,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2168"
+            },
             "label": "2168"
           },
           "stop": {
+            "in": {
+              "year": "2001"
+            },
             "label": "2001"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E15%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28725,9 +35895,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "602000"
+            },
             "label": "602000"
           },
           "stop": {
+            "in": {
+              "year": "102000"
+            },
             "label": "102000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E138%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28745,9 +35921,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "452000"
+            },
             "label": "452000"
           },
           "stop": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E65%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28765,9 +35947,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "stop": {
+            "in": {
+              "year": "9000"
+            },
             "label": "9000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E66%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28785,9 +35973,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "8400"
+            },
             "label": "8400"
           },
           "stop": {
+            "in": {
+              "year": "6500"
+            },
             "label": "6500"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E67%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28805,9 +35999,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "6500"
+            },
             "label": "6500"
           },
           "stop": {
+            "in": {
+              "year": "4200"
+            },
             "label": "4200"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E68%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28825,9 +36025,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "4200"
+            },
             "label": "4200"
           },
           "stop": {
+            "in": {
+              "year": "3200"
+            },
             "label": "3200"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E69%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28845,9 +36051,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3200"
+            },
             "label": "3200"
           },
           "stop": {
+            "in": {
+              "year": "3000"
+            },
             "label": "3000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E70%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28865,9 +36077,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "3000"
+            },
             "label": "3000"
           },
           "stop": {
+            "in": {
+              "year": "2600"
+            },
             "label": "2600"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E71%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28885,9 +36103,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2600"
+            },
             "label": "2600"
           },
           "stop": {
+            "in": {
+              "year": "2500"
+            },
             "label": "2500"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E72%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28905,9 +36129,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2500"
+            },
             "label": "2500"
           },
           "stop": {
+            "in": {
+              "year": "2350"
+            },
             "label": "2350"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E73%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28929,9 +36159,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2336"
+            },
             "label": "2336"
           },
           "stop": {
+            "in": {
+              "year": "2168"
+            },
             "label": "2168"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E14%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28949,9 +36185,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "2350"
+            },
             "label": "2350"
           },
           "stop": {
+            "in": {
+              "year": "1970"
+            },
             "label": "1970"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E74%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28969,9 +36211,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1970"
+            },
             "label": "1970"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E75%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -28989,9 +36237,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1400"
+            },
             "label": "1400"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E76%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -29009,9 +36263,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1400"
+            },
             "label": "1400"
           },
           "stop": {
+            "in": {
+              "year": "0600"
+            },
             "label": "600"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E77%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -29029,9 +36289,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0629"
+            },
             "label": "629"
           },
           "stop": {
+            "in": {
+              "year": "0088"
+            },
             "label": "88"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E78%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -29049,9 +36315,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0088"
+            },
             "label": "88"
           },
           "stop": {
+            "in": {
+              "year": "0000"
+            },
             "label": "0"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E79%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -29073,9 +36345,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "602000"
+            },
             "label": "602000"
           },
           "stop": {
+            "in": {
+              "year": "152000"
+            },
             "label": "152000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E34%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -29097,9 +36375,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "152000"
+            },
             "label": "152000"
           },
           "stop": {
+            "in": {
+              "year": "42000"
+            },
             "label": "42000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E35%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -29121,9 +36405,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "42000"
+            },
             "label": "42000"
           },
           "stop": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E36%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -29145,9 +36435,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "12000"
+            },
             "label": "12000"
           },
           "stop": {
+            "in": {
+              "year": "7000"
+            },
             "label": "7000"
           },
           "url": "http%3A%2F%2Fwww.fastionline.org%2Fcgi-bin%2Fmapserv%3Fmap%3D%2Fvar%2Fwww%2Fhtml%2Ffasti-vhost-docroot%2Fconfig%2Ffasti.map%26VERSION%3D1.0.0%26SERVICE%3DWFS%26REQUEST%3DGetFeature%26TYPENAME%3Dperiods%26FILTER%3D%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C%2FPropertyName%3E%3CLiteral%3E37%3C%2FLiteral%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E"
@@ -29185,9 +36481,15 @@
           ],
           "spatialCoverageDescription": "Ras Shamra",
           "start": {
+            "in": {
+              "year": "-7499"
+            },
             "label": "Ca. 7500 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-6999"
+            },
             "label": "Ca. 7000 B.C.E."
           }
         },
@@ -29205,9 +36507,15 @@
           ],
           "spatialCoverageDescription": "Ras Shamra",
           "start": {
+            "in": {
+              "year": "-6999"
+            },
             "label": "Ca. 7000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-5999"
+            },
             "label": "Ca. 6000 B.C.E."
           }
         },
@@ -29228,9 +36536,16 @@
           ],
           "spatialCoverageDescription": "Ras Shamra",
           "start": {
+            "in": {
+              "year": "-5999"
+            },
             "label": "Ca. 6000 B.C.E."
           },
           "stop": {
+            "in": {
+              "earliestYear": "-3999",
+              "latestYear": "-3000"
+            },
             "label": "4th millennium B.C.E."
           }
         },
@@ -29251,9 +36566,17 @@
           ],
           "spatialCoverageDescription": "Ras Shamra",
           "start": {
+            "in": {
+              "earliestYear": "-3999",
+              "latestYear": "-3000"
+            },
             "label": "4th millennium B.C.E."
           },
           "stop": {
+            "in": {
+              "earliestYear": "-3999",
+              "latestYear": "-3000"
+            },
             "label": "4th millennium B.C.E."
           }
         },
@@ -29271,9 +36594,15 @@
           ],
           "spatialCoverageDescription": "Ras Shamra",
           "start": {
+            "in": {
+              "year": "-2999"
+            },
             "label": "Ca. 3000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "Ca. 2200 B.C.E."
           }
         },
@@ -29291,9 +36620,16 @@
           ],
           "spatialCoverageDescription": "Ras Shamra",
           "start": {
+            "in": {
+              "earliestYear": "-1999",
+              "latestYear": "-1666"
+            },
             "label": "Beginning of 2nd millennium B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1649"
+            },
             "label": "Ca. 1650 B.C.E."
           }
         },
@@ -29311,9 +36647,16 @@
           ],
           "spatialCoverageDescription": "Ras Shamra",
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "Ca. 1600 B.C.E."
           },
           "stop": {
+            "in": {
+              "earliestYear": "-1189",
+              "latestYear": "-0084"
+            },
             "label": "Ca. 1190/85 B.C.E."
           }
         },
@@ -29331,9 +36674,17 @@
           ],
           "spatialCoverageDescription": "Ras Shamra",
           "start": {
+            "in": {
+              "earliestYear": "-0499",
+              "latestYear": "-0400"
+            },
             "label": "5th century B.C.E."
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0399",
+              "latestYear": "-0300"
+            },
             "label": "4th century B.C.E."
           }
         },
@@ -29351,9 +36702,15 @@
           ],
           "spatialCoverageDescription": "Ras Shamra",
           "start": {
+            "in": {
+              "year": "-0099"
+            },
             "label": "100 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "0000"
+            },
             "label": "1 B.C.E."
           }
         }
@@ -29391,9 +36748,15 @@
           ],
           "spatialCoverageDescription": "Uruk",
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "2900 B.C."
           }
         },
@@ -29412,9 +36775,15 @@
           ],
           "spatialCoverageDescription": "Uruk",
           "start": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3199"
+            },
             "label": "3200 B.C."
           }
         },
@@ -29433,9 +36802,15 @@
           ],
           "spatialCoverageDescription": "Uruk",
           "start": {
+            "in": {
+              "year": "-3199"
+            },
             "label": "3200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 B.C."
           }
         }
@@ -29481,9 +36856,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0749"
+            },
             "label": "c. 750 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "600 BCE"
           }
         },
@@ -29504,9 +36885,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "c. 600 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0474"
+            },
             "label": "475 BCE"
           }
         },
@@ -29523,9 +36910,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2499"
+            },
             "label": "c. 2500 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1049"
+            },
             "label": "1050 BCE"
           }
         },
@@ -29546,9 +36939,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0474"
+            },
             "label": "c. 475 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 BCE"
           }
         },
@@ -29569,9 +36968,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "c. 400 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0324"
+            },
             "label": "325 BCE"
           }
         },
@@ -29592,9 +36997,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2499"
+            },
             "label": "c. 2500 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2074"
+            },
             "label": "2075 BCE"
           }
         },
@@ -29615,9 +37026,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2074"
+            },
             "label": "c. 2075 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           }
         },
@@ -29638,9 +37055,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "c. 2000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "1900 BCE"
           }
         },
@@ -29661,9 +37084,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1049"
+            },
             "label": "c. 1050 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0949"
+            },
             "label": "950 BCE"
           }
         },
@@ -29684,9 +37113,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0949"
+            },
             "label": "c. 950 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0849"
+            },
             "label": "850 BCE"
           }
         },
@@ -29707,9 +37142,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0849"
+            },
             "label": "c. 850 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0749"
+            },
             "label": "750 BCE"
           }
         },
@@ -29726,9 +37167,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0324"
+            },
             "label": "c. 325 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0149"
+            },
             "label": "150 BCE"
           }
         },
@@ -29745,9 +37192,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0149"
+            },
             "label": "c. 150 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0049"
+            },
             "label": "50 BCE"
           }
         },
@@ -29768,9 +37221,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1649"
+            },
             "label": "c. 1650 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1574"
+            },
             "label": "1575 BCE"
           }
         },
@@ -29791,9 +37250,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1574"
+            },
             "label": "c. 1575 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1474"
+            },
             "label": "1475 BCE"
           }
         },
@@ -29814,9 +37279,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1474"
+            },
             "label": "c. 1475 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "1400 BCE"
           }
         },
@@ -29837,9 +37308,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "c. 1400 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1324"
+            },
             "label": "1325 BCE"
           }
         },
@@ -29860,9 +37337,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1324"
+            },
             "label": "c. 1325 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1224"
+            },
             "label": "1225 BCE"
           }
         },
@@ -29883,9 +37366,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1224"
+            },
             "label": "c. 1225 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1189"
+            },
             "label": "1190 BCE"
           }
         },
@@ -29906,9 +37395,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1189"
+            },
             "label": "c. 1190 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1149"
+            },
             "label": "1150 BCE"
           }
         },
@@ -29929,9 +37424,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1149"
+            },
             "label": "c. 1150 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1049"
+            },
             "label": "1050 BCE"
           }
         },
@@ -29952,9 +37453,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "c. 1900 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "1800 BCE"
           }
         },
@@ -29975,9 +37482,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "c. 1800 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1724"
+            },
             "label": "1725 BCE"
           }
         },
@@ -29998,9 +37511,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1724"
+            },
             "label": "c. 1725 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1649"
+            },
             "label": "1650 BCE"
           }
         },
@@ -30017,9 +37536,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1049"
+            },
             "label": "c. 1050 BCE"
           },
           "stop": {
+            "in": {
+              "year": "0250"
+            },
             "label": "250 CE"
           }
         },
@@ -30036,9 +37561,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0049"
+            },
             "label": "c. 50 BCE"
           },
           "stop": {
+            "in": {
+              "year": "0150"
+            },
             "label": "150 CE"
           }
         },
@@ -30055,9 +37586,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0150"
+            },
             "label": "c. 150 CE"
           },
           "stop": {
+            "in": {
+              "year": "0250"
+            },
             "label": "250 CE"
           }
         },
@@ -30078,9 +37615,16 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "-2599",
+              "latestYear": "-2499"
+            },
             "label": "c. 2600/2500 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2299"
+            },
             "label": "2300 BCE"
           }
         },
@@ -30097,9 +37641,16 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-8799"
+            },
             "label": "c. 8800 BCE"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-6999",
+              "latestYear": "-6499"
+            },
             "label": "7000/6500 BCE"
           }
         },
@@ -30116,9 +37667,17 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "-6999",
+              "latestYear": "-6499"
+            },
             "label": "c. 7000/6500 BCE"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-5699",
+              "latestYear": "-5499"
+            },
             "label": "5700/5500 BCE"
           }
         },
@@ -30135,9 +37694,16 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "-3999",
+              "latestYear": "-3899"
+            },
             "label": "c. 4000/3900 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-2499"
+            },
             "label": "2500 BCE"
           }
         }
@@ -30178,9 +37744,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0199"
+            },
             "label": "200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0079"
+            },
             "label": "80 B.C."
           }
         },
@@ -30201,9 +37773,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0029"
+            },
             "label": "30 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0062"
+            },
             "label": "62 A.D."
           }
         },
@@ -30224,9 +37802,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0079"
+            },
             "label": "80 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0029"
+            },
             "label": "30 B.C."
           }
         }
@@ -30267,9 +37851,15 @@
           ],
           "spatialCoverageDescription": "Rome",
           "start": {
+            "in": {
+              "year": "0069"
+            },
             "label": "AD 69"
           },
           "stop": {
+            "in": {
+              "year": "0096"
+            },
             "label": "AD 96"
           }
         },
@@ -30291,9 +37881,15 @@
           ],
           "spatialCoverageDescription": "Rome",
           "start": {
+            "in": {
+              "year": "0096"
+            },
             "label": "AD 96"
           },
           "stop": {
+            "in": {
+              "year": "0180"
+            },
             "label": "AD 180"
           }
         },
@@ -30318,9 +37914,15 @@
           ],
           "spatialCoverageDescription": "Rome",
           "start": {
+            "in": {
+              "year": "0193"
+            },
             "label": "AD 193"
           },
           "stop": {
+            "in": {
+              "year": "0238"
+            },
             "label": "AD 238"
           }
         }
@@ -30389,9 +37991,15 @@
           ],
           "spatialCoverageDescription": "Southern Levant",
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "-0550"
+            },
             "label": "-550"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Firon-age-southern-levant"
@@ -30468,9 +38076,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "stop": {
+            "in": {
+              "year": "1922"
+            },
             "label": "1922"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fkhedivate-egypt"
@@ -30511,9 +38125,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "1077"
+            },
             "label": "1077"
           },
           "stop": {
+            "in": {
+              "year": "1258"
+            },
             "label": "1258"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fkhwarezmian-middle-east"
@@ -30869,9 +38489,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "stop": {
+            "in": {
+              "year": "0640"
+            },
             "label": "640"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Flate-antique"
@@ -30948,9 +38574,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "stop": {
+            "in": {
+              "year": "0640"
+            },
             "label": "640"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Flate-antique-sasanian-middle-east"
@@ -30990,9 +38622,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "stop": {
+            "in": {
+              "year": "1450"
+            },
             "label": "1450"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Flate-antique-late-byzantine"
@@ -31029,9 +38667,15 @@
           ],
           "spatialCoverageDescription": "Southern Levant",
           "start": {
+            "in": {
+              "year": "-1400"
+            },
             "label": "-1400"
           },
           "stop": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Flate-bronze-age-southern-levant"
@@ -31079,9 +38723,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "stop": {
+            "in": {
+              "year": "1453"
+            },
             "label": "1453"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Flate-byzantine-ottoman-rise"
@@ -31106,9 +38756,15 @@
           ],
           "spatialCoverageDescription": "Mainland Greece",
           "start": {
+            "in": {
+              "year": "-1600"
+            },
             "label": "-1600"
           },
           "stop": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Flate-helladic"
@@ -31132,9 +38788,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1600"
+            },
             "label": "-1600"
           },
           "stop": {
+            "in": {
+              "year": "-0350"
+            },
             "label": "-350"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Flate-nubian"
@@ -31234,9 +38896,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1683"
+            },
             "label": "1683"
           },
           "stop": {
+            "in": {
+              "year": "1918"
+            },
             "label": "1918"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Flate-ottoman-empire"
@@ -31261,9 +38929,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-0664"
+            },
             "label": "-664"
           },
           "stop": {
+            "in": {
+              "year": "-0332"
+            },
             "label": "-332"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Flate-period-egypt"
@@ -31300,9 +38974,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1600"
+            },
             "label": "-1600"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Flater-2nd-millennium-bc-mesopotamia"
@@ -31327,9 +39007,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-0332"
+            },
             "label": "-332"
           },
           "stop": {
+            "in": {
+              "year": "-0304"
+            },
             "label": "-304"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmacedonian-egypt"
@@ -31354,9 +39040,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "1258"
+            },
             "label": "1258"
           },
           "stop": {
+            "in": {
+              "year": "1516"
+            },
             "label": "1516"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmamluk-middle-east"
@@ -31460,9 +39152,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0640"
+            },
             "label": "640"
           },
           "stop": {
+            "in": {
+              "year": "1453"
+            },
             "label": "1453"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmediaeval-byzantine"
@@ -31495,9 +39193,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-18000"
+            },
             "label": "-18000"
           },
           "stop": {
+            "in": {
+              "year": "-9500"
+            },
             "label": "-9500"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmesolithic-levant"
@@ -31534,9 +39238,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-18000"
+            },
             "label": "-18000"
           },
           "stop": {
+            "in": {
+              "year": "-9000"
+            },
             "label": "-9000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmesolithic-middle-east"
@@ -31565,9 +39275,15 @@
           ],
           "spatialCoverageDescription": "Anatolia",
           "start": {
+            "in": {
+              "year": "-1750"
+            },
             "label": "-1750"
           },
           "stop": {
+            "in": {
+              "year": "-1450"
+            },
             "label": "-1450"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmiddle-bronze-age-anatolia"
@@ -31600,9 +39316,15 @@
           ],
           "spatialCoverageDescription": "Southern Levant",
           "start": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "stop": {
+            "in": {
+              "year": "-1400"
+            },
             "label": "-1400"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmiddle-bronze-age-southern-levant"
@@ -31639,9 +39361,15 @@
           ],
           "spatialCoverageDescription": "Iran",
           "start": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "stop": {
+            "in": {
+              "year": "-0650"
+            },
             "label": "-650"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmiddle-bronze-early-iron-age-iran"
@@ -31709,9 +39437,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0850"
+            },
             "label": "850"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmiddle-byzantine"
@@ -31743,9 +39477,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0850"
+            },
             "label": "-850"
           },
           "stop": {
+            "in": {
+              "year": "-0750"
+            },
             "label": "-750"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmiddle-geometric"
@@ -31778,9 +39518,15 @@
           ],
           "spatialCoverageDescription": "Anatolia",
           "start": {
+            "in": {
+              "year": "-1450"
+            },
             "label": "-1450"
           },
           "stop": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmiddle-hittite-anatolia"
@@ -31809,9 +39555,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-2010"
+            },
             "label": "-2010"
           },
           "stop": {
+            "in": {
+              "year": "-1640"
+            },
             "label": "-1640"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmiddle-kingdom-egypt"
@@ -31836,9 +39588,15 @@
           ],
           "spatialCoverageDescription": "Crete",
           "start": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "stop": {
+            "in": {
+              "year": "-1600"
+            },
             "label": "-1600"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmiddleminoan"
@@ -31862,9 +39620,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2300"
+            },
             "label": "-2300"
           },
           "stop": {
+            "in": {
+              "year": "-1600"
+            },
             "label": "-1600"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmiddle-nubian"
@@ -31901,9 +39665,15 @@
           ],
           "spatialCoverageDescription": "Anatolia",
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "-0500"
+            },
             "label": "-500"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmiddle-late-iron-age-anatolia"
@@ -32223,9 +39993,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "2100"
+            },
             "label": "2100"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmodern"
@@ -32330,9 +40106,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "1918"
+            },
             "label": "1918"
           },
           "stop": {
+            "in": {
+              "year": "2000"
+            },
             "label": "2000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmodern-middle-east"
@@ -32393,9 +40175,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "1258"
+            },
             "label": "1258"
           },
           "stop": {
+            "in": {
+              "year": "1501"
+            },
             "label": "1501"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fmongol-middle-east"
@@ -32456,9 +40244,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-0720"
+            },
             "label": "-720"
           },
           "stop": {
+            "in": {
+              "year": "-0540"
+            },
             "label": "-540"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fneo-assyrian-babylonian-middle-east"
@@ -32483,9 +40277,15 @@
           ],
           "spatialCoverageDescription": "Northern Levant",
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fneo-hittite-northern-levant"
@@ -32514,9 +40314,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fneolithic-egypt"
@@ -32549,9 +40355,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-9000"
+            },
             "label": "-9000"
           },
           "stop": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fneolithic-middle-east"
@@ -32576,9 +40388,15 @@
           ],
           "spatialCoverageDescription": "British Isles",
           "start": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "stop": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fneolithic-british"
@@ -32611,9 +40429,15 @@
           ],
           "spatialCoverageDescription": "Eastern Mediterranean",
           "start": {
+            "in": {
+              "year": "-10000"
+            },
             "label": "-10000"
           },
           "stop": {
+            "in": {
+              "year": "-3300"
+            },
             "label": "-3300"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fneolithic-eastern-med"
@@ -32638,9 +40462,15 @@
           ],
           "spatialCoverageDescription": "Malta",
           "start": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "stop": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fneolithic-malta"
@@ -32673,9 +40503,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-1548"
+            },
             "label": "-1548"
           },
           "stop": {
+            "in": {
+              "year": "-1086"
+            },
             "label": "-1086"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fnew-kingdom-egypt"
@@ -32716,9 +40552,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "stop": {
+            "in": {
+              "year": "-1600"
+            },
             "label": "-1600"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fold-babylonian-assyrian-mesopotamia"
@@ -32743,9 +40585,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-2670"
+            },
             "label": "-2670"
           },
           "stop": {
+            "in": {
+              "year": "-2168"
+            },
             "label": "-2168"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fold-kingdom-egypt"
@@ -32769,9 +40617,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3800"
+            },
             "label": "-3800"
           },
           "stop": {
+            "in": {
+              "year": "-2300"
+            },
             "label": "-2300"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fold-nubian"
@@ -32852,9 +40706,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "1950"
+            },
             "label": "1950"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fottoman-decline-mandate-middle-east"
@@ -32926,9 +40786,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1513"
+            },
             "label": "1513"
           },
           "stop": {
+            "in": {
+              "year": "1918"
+            },
             "label": "1918"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fottoman-empire"
@@ -32972,9 +40838,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1300"
+            },
             "label": "1300"
           },
           "stop": {
+            "in": {
+              "year": "1453"
+            },
             "label": "1453"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fottoman-rise"
@@ -33027,9 +40899,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-2600000"
+            },
             "label": "-2600000"
           },
           "stop": {
+            "in": {
+              "year": "-18000"
+            },
             "label": "-18000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fpaleolithic-middle-east"
@@ -33054,9 +40932,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-0140"
+            },
             "label": "-140"
           },
           "stop": {
+            "in": {
+              "year": "0226"
+            },
             "label": "226"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fparthian-middle-east"
@@ -33097,9 +40981,15 @@
           ],
           "spatialCoverageDescription": "Caucasus",
           "start": {
+            "in": {
+              "year": "0600"
+            },
             "label": "600"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fpersian-medieval-caucasus"
@@ -33144,9 +41034,15 @@
           ],
           "spatialCoverageDescription": "Caucasus",
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1918"
+            },
             "label": "1918"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fperso-ottoman-russian-caucasus"
@@ -33195,9 +41091,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fpottery-neolithic-middle-east"
@@ -33222,9 +41124,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "stop": {
+            "in": {
+              "year": "-2950"
+            },
             "label": "-2950"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fpredynastic-egypt"
@@ -33253,9 +41161,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-9000"
+            },
             "label": "-9000"
           },
           "stop": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fpre-pottery-neolithic-middle-east"
@@ -33319,9 +41233,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0500"
+            },
             "label": "500"
           },
           "stop": {
+            "in": {
+              "year": "0650"
+            },
             "label": "650"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fproto-byzantine"
@@ -33346,9 +41266,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-0304"
+            },
             "label": "-304"
           },
           "stop": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "-30"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fptolemaic-egypt"
@@ -33389,9 +41315,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-0304"
+            },
             "label": "-304"
           },
           "stop": {
+            "in": {
+              "year": "0640"
+            },
             "label": "640"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fptolemaic-roman-egypt"
@@ -33464,9 +41396,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "-30"
           },
           "stop": {
+            "in": {
+              "year": "0226"
+            },
             "label": "226"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Froman-early-empire-parthian-middle-east"
@@ -33566,9 +41504,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "-30"
           },
           "stop": {
+            "in": {
+              "year": "0640"
+            },
             "label": "640"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Froman-early-empire-late-antique"
@@ -33637,9 +41581,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-0140"
+            },
             "label": "-140"
           },
           "stop": {
+            "in": {
+              "year": "0640"
+            },
             "label": "640"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Froman-middle-east"
@@ -34012,9 +41962,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "-30"
           },
           "stop": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Froman"
@@ -34047,9 +42003,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-0140"
+            },
             "label": "-140"
           },
           "stop": {
+            "in": {
+              "year": "0850"
+            },
             "label": "850"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Froman-early-byzantine-middle-east"
@@ -34086,9 +42048,15 @@
           ],
           "spatialCoverageDescription": "Anatolia",
           "start": {
+            "in": {
+              "year": "1077"
+            },
             "label": "1077"
           },
           "stop": {
+            "in": {
+              "year": "1307"
+            },
             "label": "1307"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Frum-crusader-anatolia"
@@ -34133,9 +42101,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "1501"
+            },
             "label": "1501"
           },
           "stop": {
+            "in": {
+              "year": "1725"
+            },
             "label": "1725"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fsafavid-middle-east"
@@ -34200,9 +42174,15 @@
           ],
           "spatialCoverageDescription": "Iran",
           "start": {
+            "in": {
+              "year": "0819"
+            },
             "label": "819"
           },
           "stop": {
+            "in": {
+              "year": "1186"
+            },
             "label": "1186"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fsamanid-ghaznavid-iran"
@@ -34227,9 +42207,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "0262"
+            },
             "label": "262"
           },
           "stop": {
+            "in": {
+              "year": "0700"
+            },
             "label": "700"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fsassanian-middle-east"
@@ -34258,9 +42244,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-1640"
+            },
             "label": "-1640"
           },
           "stop": {
+            "in": {
+              "year": "-1548"
+            },
             "label": "-1548"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fsecond-intermediate-period-egypt"
@@ -34301,9 +42293,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "1037"
+            },
             "label": "1037"
           },
           "stop": {
+            "in": {
+              "year": "1258"
+            },
             "label": "1258"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fseljuq-khwarezmian-middle-east"
@@ -34332,9 +42330,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-1086"
+            },
             "label": "-1086"
           },
           "stop": {
+            "in": {
+              "year": "-0664"
+            },
             "label": "-664"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fthird-intermediate-period-egypt"
@@ -34395,9 +42399,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "1370"
+            },
             "label": "1370"
           },
           "stop": {
+            "in": {
+              "year": "1501"
+            },
             "label": "1501"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Ftimurid-middle-east"
@@ -34434,9 +42444,15 @@
           ],
           "spatialCoverageDescription": "Southern Levant",
           "start": {
+            "in": {
+              "year": "-2100"
+            },
             "label": "-2100"
           },
           "stop": {
+            "in": {
+              "year": "-1900"
+            },
             "label": "-1900"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Ftransition-early-middle-bronze-age-southern-levant"
@@ -34512,9 +42528,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0284"
+            },
             "label": "284"
           },
           "stop": {
+            "in": {
+              "year": "0337"
+            },
             "label": "337"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Ftransition-roman-early-empire-late-antique"
@@ -34543,9 +42565,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-6500"
+            },
             "label": "-6500"
           },
           "stop": {
+            "in": {
+              "year": "-3800"
+            },
             "label": "-3800"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fubaid"
@@ -34582,9 +42610,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-5500"
+            },
             "label": "-5500"
           },
           "stop": {
+            "in": {
+              "year": "-2600"
+            },
             "label": "-2600"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fubaid-early-dynastic-ii-mesopotamia"
@@ -34616,9 +42650,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0661"
+            },
             "label": "661"
           },
           "stop": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fummayad"
@@ -34647,9 +42687,15 @@
           ],
           "spatialCoverageDescription": "Eastern Anatolia",
           "start": {
+            "in": {
+              "year": "-0900"
+            },
             "label": "-900"
           },
           "stop": {
+            "in": {
+              "year": "-0600"
+            },
             "label": "-600"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Furartian-eastern-anatolia"
@@ -34742,9 +42788,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "-1199"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2F1200-bc-middle-east"
@@ -34769,9 +42821,15 @@
           ],
           "spatialCoverageDescription": "Eastern Mediterranean",
           "start": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "stop": {
+            "in": {
+              "year": "1300"
+            },
             "label": "1300"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2F13th-century-ad-eastern-mediterranean"
@@ -34872,9 +42930,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2F1500-ad-middle-east"
@@ -34942,9 +43006,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2F2nd-millenium-bce"
@@ -34977,9 +43047,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2F2nd-millennium-bc-egypt"
@@ -35028,9 +43104,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2F2nd-millennium-bc-levant"
@@ -35095,9 +43177,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2F3rd-millennium-bc"
@@ -35145,9 +43233,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "stop": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2F4th-millenium-bce"
@@ -35228,9 +43322,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "stop": {
+            "in": {
+              "year": "0940"
+            },
             "label": "940"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fabassid-middle-east"
@@ -35363,9 +43463,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-0540"
+            },
             "label": "-540"
           },
           "stop": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "-30"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fachaemenid-roman-republic-middle-east"
@@ -35398,9 +43504,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2335"
+            },
             "label": "-2335"
           },
           "stop": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fakkadian-ur-iii-mesopotamia"
@@ -35568,9 +43680,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0750"
+            },
             "label": "-750"
           },
           "stop": {
+            "in": {
+              "year": "-0550"
+            },
             "label": "-550"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Farchaic"
@@ -35595,9 +43713,15 @@
           ],
           "spatialCoverageDescription": "Britain",
           "start": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "stop": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fbronze-age-britain"
@@ -35622,9 +43746,15 @@
           ],
           "spatialCoverageDescription": "Malta",
           "start": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "stop": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fbronze-age-malta"
@@ -35709,9 +43839,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "0632"
+            },
             "label": "632"
           },
           "stop": {
+            "in": {
+              "year": "0750"
+            },
             "label": "750"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fcaliphate-umayyad-middle-east"
@@ -35740,9 +43876,15 @@
           ],
           "spatialCoverageDescription": "Iran",
           "start": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "stop": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fchalcolithic-iran"
@@ -35779,9 +43921,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-6200"
+            },
             "label": "-6200"
           },
           "stop": {
+            "in": {
+              "year": "-3750"
+            },
             "label": "-3750"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fchalcolithic-mesopotamia"
@@ -36033,9 +44181,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0550"
+            },
             "label": "-550"
           },
           "stop": {
+            "in": {
+              "year": "-0330"
+            },
             "label": "-330"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fclassical"
@@ -36076,9 +44230,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "1800"
+            },
             "label": "1800"
           },
           "stop": {
+            "in": {
+              "year": "2000"
+            },
             "label": "2000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fcolonial-modern-middle-east"
@@ -36123,9 +44283,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "1081"
+            },
             "label": "1081"
           },
           "stop": {
+            "in": {
+              "year": "1204"
+            },
             "label": "1204"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fcrusader-byzantine-seljuq-middle-east"
@@ -36182,9 +44348,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "1099"
+            },
             "label": "1099"
           },
           "stop": {
+            "in": {
+              "year": "1291"
+            },
             "label": "1291"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fcrusader-seljuq-ayyubid-levant"
@@ -36209,9 +44381,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "1099"
+            },
             "label": "1099"
           },
           "stop": {
+            "in": {
+              "year": "1750"
+            },
             "label": "1750"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fcrusader-ottoman-levant"
@@ -36236,9 +44414,15 @@
           ],
           "spatialCoverageDescription": "Anatolia",
           "start": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "stop": {
+            "in": {
+              "year": "-1750"
+            },
             "label": "-1750"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fearly-bronze-age-anatolia"
@@ -36275,9 +44459,15 @@
           ],
           "spatialCoverageDescription": "Southern Levant",
           "start": {
+            "in": {
+              "year": "-3300"
+            },
             "label": "-3300"
           },
           "stop": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fearly-bronze-age-southern-levant"
@@ -36341,9 +44531,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0650"
+            },
             "label": "650"
           },
           "stop": {
+            "in": {
+              "year": "0850"
+            },
             "label": "850"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fearly-byzantine"
@@ -36384,9 +44580,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2950"
+            },
             "label": "-2950"
           },
           "stop": {
+            "in": {
+              "year": "-2350"
+            },
             "label": "-2350"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fearly-dynastic-mesopotamia"
@@ -36422,9 +44624,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0900"
+            },
             "label": "-900"
           },
           "stop": {
+            "in": {
+              "year": "-0850"
+            },
             "label": "-850"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fearly-geometric"
@@ -36465,9 +44673,15 @@
           ],
           "spatialCoverageDescription": "Anatolia",
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fearly-iron-age-anatolia"
@@ -36512,9 +44726,15 @@
           ],
           "spatialCoverageDescription": "Caucasus",
           "start": {
+            "in": {
+              "year": "0850"
+            },
             "label": "850"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fearly-medieval-caucasus"
@@ -36598,9 +44818,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1453"
+            },
             "label": "1453"
           },
           "stop": {
+            "in": {
+              "year": "1683"
+            },
             "label": "1683"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fearly-ottoman-empire"
@@ -36625,9 +44851,15 @@
           ],
           "spatialCoverageDescription": "Iran",
           "start": {
+            "in": {
+              "year": "-2500"
+            },
             "label": "-2500"
           },
           "stop": {
+            "in": {
+              "year": "-1500"
+            },
             "label": "-1500"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fearly-middle-bronze-age-iran"
@@ -36672,9 +44904,15 @@
           ],
           "spatialCoverageDescription": "Levant",
           "start": {
+            "in": {
+              "year": "-1344"
+            },
             "label": "-1344"
           },
           "stop": {
+            "in": {
+              "year": "-1212"
+            },
             "label": "-1212"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fegyptian-hittite-levant"
@@ -36707,9 +44945,15 @@
           ],
           "spatialCoverageDescription": "Iran",
           "start": {
+            "in": {
+              "year": "-3200"
+            },
             "label": "-3200"
           },
           "stop": {
+            "in": {
+              "year": "-0540"
+            },
             "label": "-540"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Felamite-western-iran"
@@ -36734,9 +44978,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "0950"
+            },
             "label": "950"
           },
           "stop": {
+            "in": {
+              "year": "1150"
+            },
             "label": "1150"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Ffatimid-middle-east"
@@ -36761,9 +45011,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-2168"
+            },
             "label": "-2168"
           },
           "stop": {
+            "in": {
+              "year": "-2010"
+            },
             "label": "-2010"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Ffirst-intermediate-period-egypt"
@@ -37088,9 +45344,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0330"
+            },
             "label": "-330"
           },
           "stop": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "-30"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fhellenistic-republican"
@@ -37163,9 +45425,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-0330"
+            },
             "label": "-330"
           },
           "stop": {
+            "in": {
+              "year": "-0140"
+            },
             "label": "-140"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fhellenistic-middle-east"
@@ -37190,9 +45458,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "-0330"
+            },
             "label": "-330"
           },
           "stop": {
+            "in": {
+              "year": "0226"
+            },
             "label": "226"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fhellenistic-parthian-middle-east"
@@ -37284,9 +45558,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0330"
+            },
             "label": "-330"
           },
           "stop": {
+            "in": {
+              "year": "0300"
+            },
             "label": "300"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Fhellenistic-roman-early-empire"
@@ -37355,9 +45635,15 @@
           ],
           "spatialCoverageDescription": "Middle East",
           "start": {
+            "in": {
+              "year": "1258"
+            },
             "label": "1258"
           },
           "stop": {
+            "in": {
+              "year": "1335"
+            },
             "label": "1335"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Filkhanate-middle-east"
@@ -37386,9 +45672,15 @@
           ],
           "spatialCoverageDescription": "Britain",
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "0100"
+            },
             "label": "100"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Firon-age-britain"
@@ -37413,9 +45705,15 @@
           ],
           "spatialCoverageDescription": "Italy",
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "-0900"
+            },
             "label": "-900"
           },
           "url": "http%3A%2F%2Fpleiades.stoa.org%2Fvocabularies%2Ftime-periods%2Firon-age-italy-latial-culture-i-1000-900-bc"
@@ -37505,9 +45803,16 @@
           ],
           "spatialCoverageDescription": "Land of Israel",
           "start": {
+            "in": {
+              "earliestYear": "-1999",
+              "latestYear": "-1666"
+            },
             "label": "beginning of the second millennium B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C.E."
           }
         },
@@ -37549,9 +45854,15 @@
           ],
           "spatialCoverageDescription": "Land of Israel",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-0585"
+            },
             "label": "586 B.C.E."
           }
         },
@@ -37593,9 +45904,15 @@
           ],
           "spatialCoverageDescription": "Land of Israel",
           "start": {
+            "in": {
+              "year": "-3249"
+            },
             "label": "3250 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-2499"
+            },
             "label": "2500 B.C.E."
           }
         },
@@ -37637,9 +45954,15 @@
           ],
           "spatialCoverageDescription": "Land of Israel",
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C.E."
           },
           "stop": {
+            "in": {
+              "year": "-1249"
+            },
             "label": "1250 B.C.E."
           }
         }
@@ -37811,9 +46134,15 @@
           ],
           "spatialCoverageDescription": "Spain",
           "start": {
+            "in": {
+              "year": "-0132"
+            },
             "label": "133 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0026"
+            },
             "label": "27 B.C."
           }
         }
@@ -37862,9 +46191,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-2500000"
+            },
             "label": "-2500000"
           },
           "stop": {
+            "in": {
+              "year": "-2700"
+            },
             "label": "-2700"
           }
         },
@@ -37894,9 +46229,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-2500000"
+            },
             "label": "-2500000"
           },
           "stop": {
+            "in": {
+              "year": "-7000"
+            },
             "label": "-7000"
           }
         },
@@ -37926,9 +46267,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-2500000"
+            },
             "label": "-2500000"
           },
           "stop": {
+            "in": {
+              "year": "-200000"
+            },
             "label": "-200000"
           }
         },
@@ -37958,9 +46305,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-200000"
+            },
             "label": "-200000"
           },
           "stop": {
+            "in": {
+              "year": "-50000"
+            },
             "label": "-50000"
           }
         },
@@ -37990,9 +46343,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-0050"
+            },
             "label": "-50"
           },
           "stop": {
+            "in": {
+              "year": "-7000"
+            },
             "label": "-7000"
           }
         },
@@ -38022,9 +46381,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-7000"
+            },
             "label": "-7000"
           },
           "stop": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           }
         },
@@ -38055,9 +46420,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "stop": {
+            "in": {
+              "year": "-2300"
+            },
             "label": "-2300"
           }
         },
@@ -38087,9 +46458,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "stop": {
+            "in": {
+              "year": "-2700"
+            },
             "label": "-2700"
           }
         },
@@ -38119,9 +46496,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-2700"
+            },
             "label": "-2700"
           },
           "stop": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           }
         },
@@ -38151,9 +46534,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-2700"
+            },
             "label": "-2700"
           },
           "stop": {
+            "in": {
+              "year": "-2300"
+            },
             "label": "-2300"
           }
         },
@@ -38183,9 +46572,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-2300"
+            },
             "label": "-2300"
           },
           "stop": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           }
         },
@@ -38215,9 +46610,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-2300"
+            },
             "label": "-2300"
           },
           "stop": {
+            "in": {
+              "year": "-1700"
+            },
             "label": "-1700"
           }
         },
@@ -38247,9 +46648,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-1700"
+            },
             "label": "-1700"
           },
           "stop": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           }
         },
@@ -38279,9 +46686,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           }
         },
@@ -38311,9 +46724,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "-0050"
+            },
             "label": "-50"
           }
         },
@@ -38343,9 +46762,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-0800"
+            },
             "label": "-800"
           },
           "stop": {
+            "in": {
+              "year": "-0400"
+            },
             "label": "-400"
           }
         },
@@ -38375,9 +46800,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-0400"
+            },
             "label": "-400"
           },
           "stop": {
+            "in": {
+              "year": "-0050"
+            },
             "label": "-50"
           }
         },
@@ -38408,9 +46839,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-0050"
+            },
             "label": "-50"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           }
         },
@@ -38441,9 +46878,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-0050"
+            },
             "label": "-50"
           },
           "stop": {
+            "in": {
+              "year": "0200"
+            },
             "label": "200"
           }
         },
@@ -38473,9 +46916,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "-0050"
+            },
             "label": "-50"
           },
           "stop": {
+            "in": {
+              "year": "0200"
+            },
             "label": "200"
           }
         },
@@ -38505,9 +46954,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "0200"
+            },
             "label": "200"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           }
         },
@@ -38537,9 +46992,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           }
         },
@@ -38569,9 +47030,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400"
           },
           "stop": {
+            "in": {
+              "year": "0700"
+            },
             "label": "700"
           }
         },
@@ -38601,9 +47068,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "0700"
+            },
             "label": "700"
           },
           "stop": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           }
         },
@@ -38633,9 +47106,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "1200"
+            },
             "label": "1200"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           }
         },
@@ -38665,9 +47144,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           }
         },
@@ -38697,9 +47182,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500"
           },
           "stop": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           }
         },
@@ -38729,9 +47220,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "1700"
+            },
             "label": "1700"
           },
           "stop": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           }
         },
@@ -38761,9 +47258,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "2100"
+            },
             "label": "2100"
           }
         },
@@ -38793,9 +47296,15 @@
           ],
           "spatialCoverageDescription": "Galicia and neighbouring areas in NW Spain",
           "start": {
+            "in": {
+              "year": "1900"
+            },
             "label": "1900"
           },
           "stop": {
+            "in": {
+              "year": "2100"
+            },
             "label": "2100"
           }
         }
@@ -38835,9 +47344,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-11999"
+            },
             "label": "12000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p100"
@@ -38860,9 +47375,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-11999"
+            },
             "label": "12000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p110"
@@ -38885,9 +47406,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-11999"
+            },
             "label": "12000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-9499"
+            },
             "label": "9500 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p111"
@@ -38910,9 +47437,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-9499"
+            },
             "label": "9500 BC"
           },
           "stop": {
+            "in": {
+              "year": "-6799"
+            },
             "label": "6800 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p112"
@@ -38935,9 +47468,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-6799"
+            },
             "label": "6800 BC"
           },
           "stop": {
+            "in": {
+              "year": "-5499"
+            },
             "label": "5500 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p113"
@@ -38960,9 +47499,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5499"
+            },
             "label": "5500 BC"
           },
           "stop": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p114"
@@ -38985,9 +47530,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p120"
@@ -39010,9 +47561,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p121"
@@ -39035,9 +47592,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3299"
+            },
             "label": "3300 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2299"
+            },
             "label": "2300 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p122"
@@ -39060,9 +47623,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2299"
+            },
             "label": "2300 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p123"
@@ -39085,9 +47654,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p200"
@@ -39110,9 +47685,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p210"
@@ -39135,9 +47716,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p211"
@@ -39160,9 +47747,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p212"
@@ -39185,9 +47778,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p213"
@@ -39210,9 +47809,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p220"
@@ -39235,9 +47840,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p221"
@@ -39260,9 +47871,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "700 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p222"
@@ -39285,9 +47902,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "700 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 BC"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p223"
@@ -39310,9 +47933,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 BC"
           },
           "stop": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p300"
@@ -39335,9 +47964,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 BC"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p310"
@@ -39361,9 +47996,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 BC"
           },
           "stop": {
+            "in": {
+              "year": "0000"
+            },
             "label": "0 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p311"
@@ -39387,9 +48028,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0000"
+            },
             "label": "0 AD"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p312"
@@ -39412,9 +48059,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400 AD"
           },
           "stop": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p320"
@@ -39437,9 +48090,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0400"
+            },
             "label": "400 AD"
           },
           "stop": {
+            "in": {
+              "year": "0550"
+            },
             "label": "550 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p321"
@@ -39462,9 +48121,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0550"
+            },
             "label": "550 AD"
           },
           "stop": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p322"
@@ -39487,9 +48152,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0800"
+            },
             "label": "800 AD"
           },
           "stop": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p323"
@@ -39512,9 +48183,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100 AD"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p400"
@@ -39537,9 +48214,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100 AD"
           },
           "stop": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p410"
@@ -39562,9 +48245,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1250"
+            },
             "label": "1250 AD"
           },
           "stop": {
+            "in": {
+              "year": "1350"
+            },
             "label": "1350 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p420"
@@ -39587,9 +48276,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1350"
+            },
             "label": "1350 AD"
           },
           "stop": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p430"
@@ -39612,9 +48307,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1500"
+            },
             "label": "1500 AD"
           },
           "stop": {
+            "in": {
+              "year": "2100"
+            },
             "label": "2100 AD"
           },
           "url": "http%3A%2F%2Fmis.historiska.se%2Frdf%2Fperiod%23p500"
@@ -39654,9 +48355,15 @@
           ],
           "spatialCoverageDescription": "Lydia",
           "start": {
+            "in": {
+              "year": "-0546"
+            },
             "label": "547 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0333"
+            },
             "label": "334 BCE"
           }
         },
@@ -39678,9 +48385,15 @@
           ],
           "spatialCoverageDescription": "Lydia",
           "start": {
+            "in": {
+              "year": "-0679"
+            },
             "label": "680 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0546"
+            },
             "label": "547 BCE"
           }
         },
@@ -39702,9 +48415,15 @@
           ],
           "spatialCoverageDescription": "Lydia",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0679"
+            },
             "label": "680 BCE"
           }
         },
@@ -39722,9 +48441,15 @@
           ],
           "spatialCoverageDescription": "Lydia",
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "ca. 1600 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 BCE"
           }
         }
@@ -39765,9 +48490,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2999"
+            },
             "label": "c. 3000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BCE"
           }
         },
@@ -39789,9 +48520,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2999"
+            },
             "label": "c. 3000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 BCE"
           }
         },
@@ -39817,9 +48554,15 @@
           ],
           "spatialCoverageDescription": "Mycenae, Crete, Greece",
           "start": {
+            "in": {
+              "year": "-2999"
+            },
             "label": "3000 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "1000 BCE"
           }
         },
@@ -39844,9 +48587,15 @@
           ],
           "spatialCoverageDescription": "Crete",
           "start": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "c. 1900 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BCE"
           }
         },
@@ -39871,9 +48620,15 @@
           ],
           "spatialCoverageDescription": "Crete",
           "start": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "c. 1700 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1449"
+            },
             "label": "1450 BCE"
           }
         },
@@ -39895,9 +48650,15 @@
           ],
           "spatialCoverageDescription": "Crete",
           "start": {
+            "in": {
+              "year": "-1449"
+            },
             "label": "c. 1450 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 BCE"
           }
         },
@@ -39926,9 +48687,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1049"
+            },
             "label": "c. 1050 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 BCE"
           }
         },
@@ -39957,9 +48724,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "c. 900 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "700 BCE"
           }
         },
@@ -39988,9 +48761,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "c. 700 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "600 BCE"
           }
         },
@@ -40019,9 +48798,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "c. 600 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "480 BCE"
           }
         },
@@ -40050,9 +48835,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "c. 480 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0449"
+            },
             "label": "450 BCE"
           }
         },
@@ -40081,9 +48872,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0449"
+            },
             "label": "c. 450 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 BCE"
           }
         },
@@ -40112,9 +48909,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "c. 400 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0322"
+            },
             "label": "323 BCE"
           }
         },
@@ -40144,9 +48947,16 @@
           ],
           "spatialCoverageDescription": "Ancient Greece, Macedonia, Egypt, Asia Minor",
           "start": {
+            "in": {
+              "year": "-0322"
+            },
             "label": "323 BCE"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0030",
+              "latestYear": "-0029"
+            },
             "label": "31/30 BCE"
           }
         },
@@ -40168,9 +48978,15 @@
           ],
           "spatialCoverageDescription": "Italian peninsula, Etruria",
           "start": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "c. 700 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0508"
+            },
             "label": "509 BCE"
           }
         },
@@ -40204,9 +49020,15 @@
           ],
           "spatialCoverageDescription": "Persia, Syria, Phoenicia, Asia Minor",
           "start": {
+            "in": {
+              "year": "-0558"
+            },
             "label": "c. 559 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0330"
+            },
             "label": "331 BCE"
           }
         },
@@ -40240,9 +49062,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0508"
+            },
             "label": "c. 509 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0026"
+            },
             "label": "27 BCE"
           }
         },
@@ -40300,9 +49128,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0026"
+            },
             "label": "27 BCE"
           },
           "stop": {
+            "in": {
+              "year": "0395"
+            },
             "label": "395 CE"
           }
         },
@@ -40360,9 +49194,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0026"
+            },
             "label": "27 BCE"
           },
           "stop": {
+            "in": {
+              "year": "0096"
+            },
             "label": "96 CE"
           }
         },
@@ -40420,9 +49260,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0096"
+            },
             "label": "96 CE"
           },
           "stop": {
+            "in": {
+              "year": "0192"
+            },
             "label": "192 CE"
           }
         },
@@ -40480,9 +49326,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0192"
+            },
             "label": "192 CE"
           },
           "stop": {
+            "in": {
+              "year": "0476"
+            },
             "label": "476 CE"
           }
         },
@@ -40527,9 +49379,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0525"
+            },
             "label": "526 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0725"
+            },
             "label": "726 BCE"
           }
         },
@@ -40571,9 +49429,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0725"
+            },
             "label": "726 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0842"
+            },
             "label": "843 BCE"
           }
         },
@@ -40618,9 +49482,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0842"
+            },
             "label": "843 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1203"
+            },
             "label": "1204 BCE"
           }
         },
@@ -40665,9 +49535,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1260"
+            },
             "label": "1261 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-1452"
+            },
             "label": "1453 BCE"
           }
         },
@@ -40698,9 +49574,16 @@
           ],
           "spatialCoverageDescription": "Canaan, Judaea",
           "start": {
+            "in": {
+              "year": "-0099"
+            },
             "label": "100 BCE"
           },
           "stop": {
+            "in": {
+              "earliestYear": "0501",
+              "latestYear": "0600"
+            },
             "label": "6th century CE"
           }
         },
@@ -40731,9 +49614,15 @@
           ],
           "spatialCoverageDescription": "Canaan, Judaea",
           "start": {
+            "in": {
+              "year": "0313"
+            },
             "label": "313 CE"
           },
           "stop": {
+            "in": {
+              "year": "0476"
+            },
             "label": "476 CE"
           }
         },
@@ -40782,9 +49671,15 @@
           ],
           "spatialCoverageDescription": "South Asia",
           "start": {
+            "in": {
+              "year": "-1749"
+            },
             "label": "c. 1750 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0321"
+            },
             "label": "322 BCE"
           }
         },
@@ -40833,9 +49728,15 @@
           ],
           "spatialCoverageDescription": "South Asia",
           "start": {
+            "in": {
+              "year": "-0321"
+            },
             "label": "c. 322 BCE"
           },
           "stop": {
+            "in": {
+              "year": "-0184"
+            },
             "label": "185 BCE"
           }
         },
@@ -40881,9 +49782,15 @@
           ],
           "spatialCoverageDescription": "South Asia",
           "start": {
+            "in": {
+              "year": "-0184"
+            },
             "label": "185 BCE"
           },
           "stop": {
+            "in": {
+              "year": "0050"
+            },
             "label": "50 CE"
           }
         },
@@ -40932,9 +49839,15 @@
           ],
           "spatialCoverageDescription": "South Asia",
           "start": {
+            "in": {
+              "year": "-0029"
+            },
             "label": "c. 30 BCE"
           },
           "stop": {
+            "in": {
+              "year": "0433"
+            },
             "label": "433 CE"
           }
         },
@@ -40983,9 +49896,15 @@
           ],
           "spatialCoverageDescription": "South Asia",
           "start": {
+            "in": {
+              "year": "0320"
+            },
             "label": "c. 320 CE"
           },
           "stop": {
+            "in": {
+              "year": "0486"
+            },
             "label": "486 CE"
           }
         },
@@ -41023,9 +49942,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0768"
+            },
             "label": "c. 768 CE"
           },
           "stop": {
+            "in": {
+              "year": "0887"
+            },
             "label": "887 CE"
           }
         },
@@ -41063,9 +49988,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0919"
+            },
             "label": "c. 919 CE"
           },
           "stop": {
+            "in": {
+              "year": "1024"
+            },
             "label": "1024 CE"
           }
         },
@@ -41106,9 +50037,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "1056"
+            },
             "label": "1056 CE"
           },
           "stop": {
+            "in": {
+              "year": "1189"
+            },
             "label": "1189 CE"
           }
         }
@@ -41153,9 +50090,15 @@
           ],
           "spatialCoverageDescription": "pre-Roman Italy",
           "start": {
+            "in": {
+              "year": "-0615"
+            },
             "label": "616 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0508"
+            },
             "label": "509 B.C."
           }
         }
@@ -41200,9 +50143,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0733"
+            },
             "label": "734 B.C."
           }
         },
@@ -41223,9 +50172,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2499"
+            },
             "label": "2500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 B.C."
           }
         },
@@ -41246,9 +50201,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2499"
+            },
             "label": "2500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 B.C."
           }
         },
@@ -41269,9 +50230,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2499"
+            },
             "label": "2500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C."
           }
         },
@@ -41292,9 +50259,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 B.C."
           }
         },
@@ -41315,9 +50288,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0733"
+            },
             "label": "734 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0649"
+            },
             "label": "650 B.C."
           }
         },
@@ -41342,9 +50321,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0733"
+            },
             "label": "734 B.C."
           }
         },
@@ -41365,9 +50350,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0733"
+            },
             "label": "734 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0449"
+            },
             "label": "450 B.C."
           }
         },
@@ -41388,9 +50379,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           }
         },
@@ -41411,9 +50408,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2999"
+            },
             "label": "3000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2499"
+            },
             "label": "2500 B.C."
           }
         },
@@ -41434,9 +50437,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C."
           }
         },
@@ -41457,9 +50466,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           }
         },
@@ -41480,9 +50495,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C."
           }
         }
@@ -41516,9 +50537,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "0647"
+            },
             "label": "647"
           },
           "stop": {
+            "in": {
+              "year": "0965"
+            },
             "label": "965"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41537,9 +50564,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "1878"
+            },
             "label": "1878"
           },
           "stop": {
+            "in": {
+              "year": "1960"
+            },
             "label": "1960"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41561,9 +50594,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "0330"
+            },
             "label": "330"
           },
           "stop": {
+            "in": {
+              "year": "0641"
+            },
             "label": "641"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41597,9 +50636,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "0324"
+            },
             "label": "324"
           },
           "stop": {
+            "in": {
+              "year": "0638"
+            },
             "label": "638"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41621,9 +50666,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "0324"
+            },
             "label": "324"
           },
           "stop": {
+            "in": {
+              "year": "1453"
+            },
             "label": "1453"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41642,9 +50693,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-4600"
+            },
             "label": "-4600"
           },
           "stop": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41663,9 +50720,15 @@
           ],
           "spatialCoverageDescription": "Israel",
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41684,9 +50747,15 @@
           ],
           "spatialCoverageDescription": "Jordan",
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41705,9 +50774,15 @@
           ],
           "spatialCoverageDescription": "Lebanon",
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41726,9 +50801,15 @@
           ],
           "spatialCoverageDescription": "Syria",
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41747,9 +50828,15 @@
           ],
           "spatialCoverageDescription": "Israel",
           "start": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "stop": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41768,9 +50855,15 @@
           ],
           "spatialCoverageDescription": "Jordan",
           "start": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "stop": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41789,9 +50882,15 @@
           ],
           "spatialCoverageDescription": "Lebanon",
           "start": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "stop": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41810,9 +50909,15 @@
           ],
           "spatialCoverageDescription": "Syria",
           "start": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "stop": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41843,9 +50948,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "stop": {
+            "in": {
+              "year": "-3500"
+            },
             "label": "-3500"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41864,9 +50975,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-6400"
+            },
             "label": "-6400"
           },
           "stop": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41885,9 +51002,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-0750"
+            },
             "label": "-750"
           },
           "stop": {
+            "in": {
+              "year": "-0600"
+            },
             "label": "-600"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41906,9 +51029,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-0600"
+            },
             "label": "-600"
           },
           "stop": {
+            "in": {
+              "year": "-0480"
+            },
             "label": "-480"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41927,9 +51056,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-0480"
+            },
             "label": "-480"
           },
           "stop": {
+            "in": {
+              "year": "-0400"
+            },
             "label": "-400"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41948,9 +51083,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-0400"
+            },
             "label": "-400"
           },
           "stop": {
+            "in": {
+              "year": "-0310"
+            },
             "label": "-310"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41972,9 +51113,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-1050"
+            },
             "label": "-1050"
           },
           "stop": {
+            "in": {
+              "year": "-0950"
+            },
             "label": "-950"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -41996,9 +51143,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-0950"
+            },
             "label": "-950"
           },
           "stop": {
+            "in": {
+              "year": "-0900"
+            },
             "label": "-900"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42020,9 +51173,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-0900"
+            },
             "label": "-900"
           },
           "stop": {
+            "in": {
+              "year": "-0750"
+            },
             "label": "-750"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42044,9 +51203,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42080,9 +51245,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-3500"
+            },
             "label": "-3500"
           },
           "stop": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42116,9 +51287,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-3000"
+            },
             "label": "-3000"
           },
           "stop": {
+            "in": {
+              "year": "-2700"
+            },
             "label": "-2700"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42152,9 +51329,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-2700"
+            },
             "label": "-2700"
           },
           "stop": {
+            "in": {
+              "year": "-2200"
+            },
             "label": "-2200"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42188,9 +51371,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-2200"
+            },
             "label": "-2200"
           },
           "stop": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42209,9 +51398,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "0330"
+            },
             "label": "330"
           },
           "stop": {
+            "in": {
+              "year": "0647"
+            },
             "label": "647"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42230,9 +51425,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-4000"
+            },
             "label": "-4000"
           },
           "stop": {
+            "in": {
+              "year": "-3400"
+            },
             "label": "-3400"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42254,9 +51455,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-2300"
+            },
             "label": "-2300"
           },
           "stop": {
+            "in": {
+              "year": "-1950"
+            },
             "label": "-1950"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42278,9 +51485,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-3150"
+            },
             "label": "-3150"
           },
           "stop": {
+            "in": {
+              "year": "-2663"
+            },
             "label": "-2663"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42306,9 +51519,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan",
           "start": {
+            "in": {
+              "year": "-0332"
+            },
             "label": "-332"
           },
           "stop": {
+            "in": {
+              "year": "-0167"
+            },
             "label": "-167"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42334,9 +51553,15 @@
           ],
           "spatialCoverageDescription": "Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-0332"
+            },
             "label": "-332"
           },
           "stop": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42358,9 +51583,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-0333"
+            },
             "label": "-333"
           },
           "stop": {
+            "in": {
+              "year": "-0235"
+            },
             "label": "-235"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42382,9 +51613,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "0641"
+            },
             "label": "641"
           },
           "stop": {
+            "in": {
+              "year": "1100"
+            },
             "label": "1100"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42418,9 +51655,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "0638"
+            },
             "label": "638"
           },
           "stop": {
+            "in": {
+              "year": "1099"
+            },
             "label": "1099"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42442,9 +51685,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-0031"
+            },
             "label": "-31"
           },
           "stop": {
+            "in": {
+              "year": "0135"
+            },
             "label": "135"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42470,9 +51719,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan",
           "start": {
+            "in": {
+              "year": "-0063"
+            },
             "label": "-63"
           },
           "stop": {
+            "in": {
+              "year": "0132"
+            },
             "label": "132"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42498,9 +51753,15 @@
           ],
           "spatialCoverageDescription": "Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-0063"
+            },
             "label": "-63"
           },
           "stop": {
+            "in": {
+              "year": "0138"
+            },
             "label": "138"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42522,9 +51783,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-0031"
+            },
             "label": "-31"
           },
           "stop": {
+            "in": {
+              "year": "0138"
+            },
             "label": "138"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42558,9 +51825,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "1291"
+            },
             "label": "1291"
           },
           "stop": {
+            "in": {
+              "year": "1516"
+            },
             "label": "1516"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42579,9 +51852,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-2181"
+            },
             "label": "-2181"
           },
           "stop": {
+            "in": {
+              "year": "-2040"
+            },
             "label": "-2040"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42600,9 +51879,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "1191"
+            },
             "label": "1191"
           },
           "stop": {
+            "in": {
+              "year": "1489"
+            },
             "label": "1489"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42636,9 +51921,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "1099"
+            },
             "label": "1099"
           },
           "stop": {
+            "in": {
+              "year": "1291"
+            },
             "label": "1291"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42664,9 +51955,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan",
           "start": {
+            "in": {
+              "year": "-0167"
+            },
             "label": "-167"
           },
           "stop": {
+            "in": {
+              "year": "-0037"
+            },
             "label": "-37"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42685,9 +51982,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-0310"
+            },
             "label": "-310"
           },
           "stop": {
+            "in": {
+              "year": "-0150"
+            },
             "label": "-150"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42706,9 +52009,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-0150"
+            },
             "label": "-150"
           },
           "stop": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "-30"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42730,9 +52039,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-0332"
+            },
             "label": "-332"
           },
           "stop": {
+            "in": {
+              "year": "-0031"
+            },
             "label": "-31"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42758,9 +52073,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan",
           "start": {
+            "in": {
+              "year": "-0037"
+            },
             "label": "-37"
           },
           "stop": {
+            "in": {
+              "year": "0070"
+            },
             "label": "70"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42794,9 +52115,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-2200"
+            },
             "label": "-2200"
           },
           "stop": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42818,9 +52145,15 @@
           ],
           "spatialCoverageDescription": "Jordan",
           "start": {
+            "in": {
+              "year": "-2200"
+            },
             "label": "-2200"
           },
           "stop": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42842,9 +52175,15 @@
           ],
           "spatialCoverageDescription": "Lebanon",
           "start": {
+            "in": {
+              "year": "-2200"
+            },
             "label": "-2200"
           },
           "stop": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42866,9 +52205,15 @@
           ],
           "spatialCoverageDescription": "Syria",
           "start": {
+            "in": {
+              "year": "-2200"
+            },
             "label": "-2200"
           },
           "stop": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42902,9 +52247,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42926,9 +52277,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "-0850"
+            },
             "label": "-850"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42950,9 +52307,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-0850"
+            },
             "label": "-850"
           },
           "stop": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -42986,9 +52349,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-1000"
+            },
             "label": "-1000"
           },
           "stop": {
+            "in": {
+              "year": "-0900"
+            },
             "label": "-900"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43022,9 +52391,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-0900"
+            },
             "label": "-900"
           },
           "stop": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43058,9 +52433,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "-0586"
+            },
             "label": "-586"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43082,9 +52463,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-0700"
+            },
             "label": "-700"
           },
           "stop": {
+            "in": {
+              "year": "-0547"
+            },
             "label": "-547"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43106,9 +52493,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-1600"
+            },
             "label": "-1600"
           },
           "stop": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43142,9 +52535,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-1500"
+            },
             "label": "-1500"
           },
           "stop": {
+            "in": {
+              "year": "-1400"
+            },
             "label": "-1400"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43178,9 +52577,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-1400"
+            },
             "label": "-1400"
           },
           "stop": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43199,9 +52604,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "0965"
+            },
             "label": "965"
           },
           "stop": {
+            "in": {
+              "year": "1191"
+            },
             "label": "1191"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43220,9 +52631,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-2700"
+            },
             "label": "-2700"
           },
           "stop": {
+            "in": {
+              "year": "-2400"
+            },
             "label": "-2400"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43244,9 +52661,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-1450"
+            },
             "label": "-1450"
           },
           "stop": {
+            "in": {
+              "year": "-1325"
+            },
             "label": "-1325"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43268,9 +52691,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-1325"
+            },
             "label": "-1325"
           },
           "stop": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43292,9 +52721,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-1200"
+            },
             "label": "-1200"
           },
           "stop": {
+            "in": {
+              "year": "-1050"
+            },
             "label": "-1050"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43320,9 +52755,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan",
           "start": {
+            "in": {
+              "year": "-0167"
+            },
             "label": "-167"
           },
           "stop": {
+            "in": {
+              "year": "-0063"
+            },
             "label": "-63"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43348,9 +52789,15 @@
           ],
           "spatialCoverageDescription": "Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-0200"
+            },
             "label": "-200"
           },
           "stop": {
+            "in": {
+              "year": "-0063"
+            },
             "label": "-63"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43372,9 +52819,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-0187"
+            },
             "label": "-187"
           },
           "stop": {
+            "in": {
+              "year": "-0133"
+            },
             "label": "-133"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43396,9 +52849,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-0525"
+            },
             "label": "-525"
           },
           "stop": {
+            "in": {
+              "year": "-0332"
+            },
             "label": "-332"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43420,9 +52879,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "0250"
+            },
             "label": "250"
           },
           "stop": {
+            "in": {
+              "year": "0330"
+            },
             "label": "330"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43448,9 +52913,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan",
           "start": {
+            "in": {
+              "year": "0132"
+            },
             "label": "132"
           },
           "stop": {
+            "in": {
+              "year": "0324"
+            },
             "label": "324"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43480,9 +52951,15 @@
           ],
           "spatialCoverageDescription": "Turkey, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "0250"
+            },
             "label": "250"
           },
           "stop": {
+            "in": {
+              "year": "0324"
+            },
             "label": "324"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43516,9 +52993,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "1291"
+            },
             "label": "1291"
           },
           "stop": {
+            "in": {
+              "year": "1516"
+            },
             "label": "1516"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43540,9 +53023,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "stop": {
+            "in": {
+              "year": "-1600"
+            },
             "label": "-1600"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43576,9 +53065,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-2000"
+            },
             "label": "-2000"
           },
           "stop": {
+            "in": {
+              "year": "-1800"
+            },
             "label": "-1800"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43612,9 +53107,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-1800"
+            },
             "label": "-1800"
           },
           "stop": {
+            "in": {
+              "year": "-1650"
+            },
             "label": "-1650"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43648,9 +53149,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-1650"
+            },
             "label": "-1650"
           },
           "stop": {
+            "in": {
+              "year": "-1500"
+            },
             "label": "-1500"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43669,9 +53176,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-3600"
+            },
             "label": "-3600"
           },
           "stop": {
+            "in": {
+              "year": "-2700"
+            },
             "label": "-2700"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43693,9 +53206,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-1950"
+            },
             "label": "-1950"
           },
           "stop": {
+            "in": {
+              "year": "-1750"
+            },
             "label": "-1750"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43717,9 +53236,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-1750"
+            },
             "label": "-1750"
           },
           "stop": {
+            "in": {
+              "year": "-1450"
+            },
             "label": "-1450"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43741,9 +53266,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-0235"
+            },
             "label": "-235"
           },
           "stop": {
+            "in": {
+              "year": "-0187"
+            },
             "label": "-187"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43765,9 +53296,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-2040"
+            },
             "label": "-2040"
           },
           "stop": {
+            "in": {
+              "year": "-1782"
+            },
             "label": "-1782"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43789,9 +53326,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "0135"
+            },
             "label": "135"
           },
           "stop": {
+            "in": {
+              "year": "0250"
+            },
             "label": "250"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43817,9 +53360,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan",
           "start": {
+            "in": {
+              "year": "0132"
+            },
             "label": "132"
           },
           "stop": {
+            "in": {
+              "year": "0250"
+            },
             "label": "250"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43849,9 +53398,15 @@
           ],
           "spatialCoverageDescription": "Turkey, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "0138"
+            },
             "label": "138"
           },
           "stop": {
+            "in": {
+              "year": "0250"
+            },
             "label": "250"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43885,9 +53440,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-0586"
+            },
             "label": "-586"
           },
           "stop": {
+            "in": {
+              "year": "-0539"
+            },
             "label": "-539"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43909,9 +53470,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-1570"
+            },
             "label": "-1570"
           },
           "stop": {
+            "in": {
+              "year": "-1070"
+            },
             "label": "-1070"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43933,9 +53500,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-2663"
+            },
             "label": "-2663"
           },
           "stop": {
+            "in": {
+              "year": "-2181"
+            },
             "label": "-2181"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43954,9 +53527,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "1571"
+            },
             "label": "1571"
           },
           "stop": {
+            "in": {
+              "year": "1878"
+            },
             "label": "1878"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -43990,9 +53569,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "1516"
+            },
             "label": "1516"
           },
           "stop": {
+            "in": {
+              "year": "1917"
+            },
             "label": "1917"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44014,9 +53599,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "1453"
+            },
             "label": "1453"
           },
           "stop": {
+            "in": {
+              "year": "1922"
+            },
             "label": "1922"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44047,9 +53638,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-0539"
+            },
             "label": "-539"
           },
           "stop": {
+            "in": {
+              "year": "-0332"
+            },
             "label": "-332"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44068,9 +53665,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-0547"
+            },
             "label": "-547"
           },
           "stop": {
+            "in": {
+              "year": "-0333"
+            },
             "label": "-333"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44089,9 +53692,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-2400"
+            },
             "label": "-2400"
           },
           "stop": {
+            "in": {
+              "year": "-2300"
+            },
             "label": "-2300"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44110,9 +53719,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-6900"
+            },
             "label": "-6900"
           },
           "stop": {
+            "in": {
+              "year": "-6400"
+            },
             "label": "-6400"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44143,9 +53758,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44176,9 +53797,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "-5000"
+            },
             "label": "-5000"
           },
           "stop": {
+            "in": {
+              "year": "-4500"
+            },
             "label": "-4500"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44197,9 +53824,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-6000"
+            },
             "label": "-6000"
           },
           "stop": {
+            "in": {
+              "year": "-3150"
+            },
             "label": "-3150"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44218,9 +53851,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "-30"
           },
           "stop": {
+            "in": {
+              "year": "0330"
+            },
             "label": "330"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44239,9 +53878,15 @@
           ],
           "spatialCoverageDescription": "Turkey",
           "start": {
+            "in": {
+              "year": "-0133"
+            },
             "label": "-133"
           },
           "stop": {
+            "in": {
+              "year": "-0031"
+            },
             "label": "-31"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44260,9 +53905,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-1782"
+            },
             "label": "-1782"
           },
           "stop": {
+            "in": {
+              "year": "-1570"
+            },
             "label": "-1570"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44281,9 +53932,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-1069"
+            },
             "label": "-1069"
           },
           "stop": {
+            "in": {
+              "year": "-0525"
+            },
             "label": "-525"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44317,9 +53974,15 @@
           ],
           "spatialCoverageDescription": "Israel, Jordan, Lebanon, Syria",
           "start": {
+            "in": {
+              "year": "0638"
+            },
             "label": "638"
           },
           "stop": {
+            "in": {
+              "year": "1099"
+            },
             "label": "1099"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44338,9 +54001,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "1489"
+            },
             "label": "1489"
           },
           "stop": {
+            "in": {
+              "year": "1571"
+            },
             "label": "1571"
           },
           "url": "http%3A%2F%2Fwww.levantineceramics.org%2Fperiods"
@@ -44379,9 +54048,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3199"
+            },
             "label": "3200? BC"
           },
           "stop": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "2200? BC"
           }
         },
@@ -44402,9 +54077,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "2200 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "1900 BC"
           }
         },
@@ -44425,9 +54106,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "1900 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 BC"
           }
         },
@@ -44448,9 +54135,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1149"
+            },
             "label": "1150 BC"
           }
         },
@@ -44471,9 +54164,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1149"
+            },
             "label": "1150 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0849"
+            },
             "label": "850 BC"
           }
         },
@@ -44491,9 +54190,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "2200 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0849"
+            },
             "label": "850 BC"
           }
         },
@@ -44514,9 +54219,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0849"
+            },
             "label": "850 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0509"
+            },
             "label": "510 BC"
           }
         },
@@ -44537,9 +54248,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0849"
+            },
             "label": "850 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0729"
+            },
             "label": "730 BC"
           }
         },
@@ -44560,9 +54277,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0729"
+            },
             "label": "730 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0579"
+            },
             "label": "580 BC"
           }
         },
@@ -44583,9 +54306,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0579"
+            },
             "label": "580 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0509"
+            },
             "label": "510 BC"
           }
         },
@@ -44603,9 +54332,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0509"
+            },
             "label": "510 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0476"
+            },
             "label": "476 AD"
           }
         },
@@ -44626,9 +54361,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0237"
+            },
             "label": "238 BC"
           },
           "stop": {
+            "in": {
+              "year": "0000"
+            },
             "label": "1 BC"
           }
         },
@@ -44649,9 +54390,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0001"
+            },
             "label": "1 AD"
           },
           "stop": {
+            "in": {
+              "year": "0476"
+            },
             "label": "476 AD"
           }
         }
@@ -44708,9 +54455,15 @@
           ],
           "spatialCoverageDescription": "Ur, Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1739"
+            },
             "label": "1740 B.C."
           }
         },
@@ -44737,9 +54490,15 @@
           ],
           "spatialCoverageDescription": "Ur, Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2333"
+            },
             "label": "2334 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2153"
+            },
             "label": "2154 B.C."
           }
         },
@@ -44799,9 +54558,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2649"
+            },
             "label": "2650 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2549"
+            },
             "label": "2550 B.C."
           }
         }
@@ -44845,9 +54610,15 @@
           ],
           "spatialCoverageDescription": "Ancient Egypt",
           "start": {
+            "in": {
+              "year": "-4999"
+            },
             "label": "5000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2919"
+            },
             "label": "2920 BC"
           }
         },
@@ -44869,9 +54640,15 @@
           ],
           "spatialCoverageDescription": "Ancient Egypt",
           "start": {
+            "in": {
+              "year": "-2919"
+            },
             "label": "2920 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2648"
+            },
             "label": "2649 BC"
           }
         },
@@ -44893,9 +54670,15 @@
           ],
           "spatialCoverageDescription": "Ancient Egypt",
           "start": {
+            "in": {
+              "year": "-2648"
+            },
             "label": "2649 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2133"
+            },
             "label": "2134 BC"
           }
         },
@@ -44919,9 +54702,15 @@
           ],
           "spatialCoverageDescription": "Ancient Egypt",
           "start": {
+            "in": {
+              "year": "-2133"
+            },
             "label": "2134 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2039"
+            },
             "label": "2040 BC"
           }
         },
@@ -44944,9 +54733,15 @@
           ],
           "spatialCoverageDescription": "Ancient Egypt",
           "start": {
+            "in": {
+              "year": "-2039"
+            },
             "label": "2040 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1639"
+            },
             "label": "1640 BC"
           }
         },
@@ -44969,9 +54764,15 @@
           ],
           "spatialCoverageDescription": "Ancient Egypt",
           "start": {
+            "in": {
+              "year": "-1639"
+            },
             "label": "1640 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1531"
+            },
             "label": "1532 BC"
           }
         },
@@ -44993,9 +54794,15 @@
           ],
           "spatialCoverageDescription": "Ancient Egypt",
           "start": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1069"
+            },
             "label": "1070 BC"
           }
         },
@@ -45018,9 +54825,15 @@
           ],
           "spatialCoverageDescription": "Ancient Egypt",
           "start": {
+            "in": {
+              "year": "-1069"
+            },
             "label": "1070 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0711"
+            },
             "label": "712 BC"
           }
         },
@@ -45042,9 +54855,15 @@
           ],
           "spatialCoverageDescription": "Ancient Egypt",
           "start": {
+            "in": {
+              "year": "-0711"
+            },
             "label": "712 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0331"
+            },
             "label": "332 BC"
           }
         },
@@ -45066,9 +54885,15 @@
           ],
           "spatialCoverageDescription": "Ancient Egypt",
           "start": {
+            "in": {
+              "year": "-0331"
+            },
             "label": "332 BC"
           },
           "stop": {
+            "in": {
+              "year": "0395"
+            },
             "label": "AD 395"
           }
         },
@@ -45090,9 +54915,15 @@
           ],
           "spatialCoverageDescription": "Ancient Egypt",
           "start": {
+            "in": {
+              "year": "-0029"
+            },
             "label": "30 BC"
           },
           "stop": {
+            "in": {
+              "year": "0395"
+            },
             "label": "AD 395"
           }
         }
@@ -45129,9 +54960,15 @@
           ],
           "spatialCoverageDescription": "Catalan area",
           "start": {
+            "in": {
+              "year": "-0524"
+            },
             "label": "525 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 BC"
           }
         },
@@ -45153,9 +54990,15 @@
           ],
           "spatialCoverageDescription": "Catalan area",
           "start": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0199"
+            },
             "label": "200 BC"
           }
         }
@@ -45191,9 +55034,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2499"
+            },
             "label": "c. 2500 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BC"
           }
         },
@@ -45211,9 +55060,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "c. 2000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 BC"
           }
         },
@@ -45231,9 +55086,16 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "c. 1500 BC"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-1199",
+              "latestYear": "-1100"
+            },
             "label": "12th century BC"
           }
         },
@@ -45250,9 +55112,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1179"
+            },
             "label": "1180 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0949"
+            },
             "label": "c. 950 BC"
           }
         },
@@ -45269,9 +55137,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0949"
+            },
             "label": "c. 950 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 BC"
           }
         },
@@ -45289,9 +55163,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "c. 900 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 BC"
           }
         },
@@ -45309,9 +55189,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 BC"
           }
         },
@@ -45328,9 +55214,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "c. 800 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0539"
+            },
             "label": "540 BC"
           }
         },
@@ -45347,9 +55239,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0539"
+            },
             "label": "c. 540 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0329"
+            },
             "label": "330 BC"
           }
         },
@@ -45367,9 +55265,16 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0329"
+            },
             "label": "c. 330 BC"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0266",
+              "latestYear": "-0233"
+            },
             "label": "mid 3rd century BC"
           }
         },
@@ -45387,9 +55292,17 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "-0266",
+              "latestYear": "-0233"
+            },
             "label": "mid 3rd century BC"
           },
           "stop": {
+            "in": {
+              "earliestYear": "-0166",
+              "latestYear": "-0133"
+            },
             "label": "mid 2nd century BC"
           }
         },
@@ -45407,9 +55320,17 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "0001",
+              "latestYear": "0034"
+            },
             "label": "Early 1st century AD"
           },
           "stop": {
+            "in": {
+              "earliestYear": "0401",
+              "latestYear": "0500"
+            },
             "label": "5th century AD"
           }
         },
@@ -45427,9 +55348,17 @@
             }
           ],
           "start": {
+            "in": {
+              "earliestYear": "1201",
+              "latestYear": "1300"
+            },
             "label": "13th century AD"
           },
           "stop": {
+            "in": {
+              "earliestYear": "1301",
+              "latestYear": "1400"
+            },
             "label": "14th century AD"
           }
         }
@@ -45467,9 +55396,15 @@
           ],
           "spatialCoverageDescription": "Iberia",
           "start": {
+            "in": {
+              "year": "-0629"
+            },
             "label": "630 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 B.C."
           }
         }
@@ -45507,9 +55442,15 @@
           ],
           "spatialCoverageDescription": "Ur",
           "start": {
+            "in": {
+              "year": "-4499"
+            },
             "label": "4500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 B.C."
           }
         },
@@ -45531,9 +55472,15 @@
           ],
           "spatialCoverageDescription": "Ur",
           "start": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "ca. 3500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 B.C."
           }
         },
@@ -45551,9 +55498,15 @@
           ],
           "spatialCoverageDescription": "Ur",
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "ca. 3100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "2900 B.C."
           }
         },
@@ -45571,9 +55524,15 @@
           ],
           "spatialCoverageDescription": "Ur",
           "start": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "ca. 2900 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2369"
+            },
             "label": "2370 B.C."
           }
         },
@@ -45591,9 +55550,15 @@
           ],
           "spatialCoverageDescription": "Ur",
           "start": {
+            "in": {
+              "year": "-2369"
+            },
             "label": "ca. 2370 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2229"
+            },
             "label": "2230 B.C."
           }
         },
@@ -45611,9 +55576,15 @@
           ],
           "spatialCoverageDescription": "Ur",
           "start": {
+            "in": {
+              "year": "-2112"
+            },
             "label": "ca. 2113 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2005"
+            },
             "label": "2006 B.C."
           }
         },
@@ -45631,9 +55602,15 @@
           ],
           "spatialCoverageDescription": "Ur",
           "start": {
+            "in": {
+              "year": "-2019"
+            },
             "label": "ca. 2020 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 B.C."
           }
         },
@@ -45651,9 +55628,15 @@
           ],
           "spatialCoverageDescription": "Ur",
           "start": {
+            "in": {
+              "year": "-0625"
+            },
             "label": "626 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0538"
+            },
             "label": "539 B.C."
           }
         }
@@ -45708,9 +55691,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2349"
+            },
             "label": "ca. 2350 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2149"
+            },
             "label": "2150 BC"
           }
         },
@@ -45740,9 +55729,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2124"
+            },
             "label": "ca. 2125 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BC"
           }
         },
@@ -45772,9 +55767,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "2900 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2333"
+            },
             "label": "2334 BC"
           }
         },
@@ -45809,9 +55810,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2149"
+            },
             "label": "ca. 2150 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BC"
           }
         },
@@ -45841,9 +55848,15 @@
           ],
           "spatialCoverageDescription": "Indus Valley",
           "start": {
+            "in": {
+              "year": "-2599"
+            },
             "label": "ca. 2600 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1899"
+            },
             "label": "1900 BC"
           }
         },
@@ -45865,9 +55878,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-4999"
+            },
             "label": "ca. 5000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-3049"
+            },
             "label": "3050 BC"
           }
         },
@@ -45893,9 +55912,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-3049"
+            },
             "label": "ca. 3050 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2674"
+            },
             "label": "2675 BC"
           }
         },
@@ -45917,9 +55942,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-2674"
+            },
             "label": "ca. 2675 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2189"
+            },
             "label": "2190 BC"
           }
         },
@@ -45941,9 +55972,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-2189"
+            },
             "label": "ca. 2190 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2059"
+            },
             "label": "2060 BC"
           }
         },
@@ -45965,9 +56002,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-2059"
+            },
             "label": "ca. 2060 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1794"
+            },
             "label": "1795 BC"
           }
         },
@@ -45989,9 +56032,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-1794"
+            },
             "label": "ca. 1795 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 BC"
           }
         },
@@ -46013,9 +56062,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "ca. 1550 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1069"
+            },
             "label": "1070 BC"
           }
         },
@@ -46037,9 +56092,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-1069"
+            },
             "label": "ca. 1070 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0714"
+            },
             "label": "715 BC"
           }
         },
@@ -46061,9 +56122,15 @@
           ],
           "spatialCoverageDescription": "Egypt",
           "start": {
+            "in": {
+              "year": "-0759"
+            },
             "label": "760 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0331"
+            },
             "label": "332 BC"
           }
         },
@@ -46090,9 +56157,15 @@
           ],
           "spatialCoverageDescription": "Crete",
           "start": {
+            "in": {
+              "year": "-1929"
+            },
             "label": "ca. 1930 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 BC"
           }
         },
@@ -46119,9 +56192,15 @@
           ],
           "spatialCoverageDescription": "Crete",
           "start": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "ca. 1700 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1449"
+            },
             "label": "1450 BC"
           }
         },
@@ -46143,9 +56222,15 @@
           ],
           "spatialCoverageDescription": "Crete",
           "start": {
+            "in": {
+              "year": "-1449"
+            },
             "label": "ca. 1450 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "1400 BC"
           }
         },
@@ -46168,9 +56253,15 @@
           ],
           "spatialCoverageDescription": "Crete",
           "start": {
+            "in": {
+              "year": "-1424"
+            },
             "label": "ca. 1425 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1049"
+            },
             "label": "1050 BC"
           }
         },
@@ -46192,9 +56283,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "ca. 1500 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "1400 BC"
           }
         },
@@ -46216,9 +56313,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "ca. 1400 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1339"
+            },
             "label": "1340 BC"
           }
         },
@@ -46240,9 +56343,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-1339"
+            },
             "label": "ca. 1340 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1184"
+            },
             "label": "1185 BC"
           }
         },
@@ -46264,9 +56373,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-1184"
+            },
             "label": "ca. 1185 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1049"
+            },
             "label": "1050 BC"
           }
         },
@@ -46288,9 +56403,15 @@
           ],
           "spatialCoverageDescription": "Troy",
           "start": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "ca. 2900 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2399"
+            },
             "label": "2400 BC"
           }
         },
@@ -46312,9 +56433,15 @@
           ],
           "spatialCoverageDescription": "Troy",
           "start": {
+            "in": {
+              "year": "-2399"
+            },
             "label": "ca. 2400 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2099"
+            },
             "label": "2100 BC"
           }
         },
@@ -46336,9 +56463,15 @@
           ],
           "spatialCoverageDescription": "Troy",
           "start": {
+            "in": {
+              "year": "-2099"
+            },
             "label": "ca. 2100 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "1800 BC"
           }
         },
@@ -46360,9 +56493,15 @@
           ],
           "spatialCoverageDescription": "Troy",
           "start": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "ca. 1800 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 BC"
           }
         },
@@ -46384,9 +56523,15 @@
           ],
           "spatialCoverageDescription": "Troy",
           "start": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "ca. 1300 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1259"
+            },
             "label": "1260 BC"
           }
         },
@@ -46408,9 +56553,15 @@
           ],
           "spatialCoverageDescription": "Troy",
           "start": {
+            "in": {
+              "year": "-1259"
+            },
             "label": "ca. 1260 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1189"
+            },
             "label": "1190 BC"
           }
         },
@@ -46432,9 +56583,15 @@
           ],
           "spatialCoverageDescription": "Troy",
           "start": {
+            "in": {
+              "year": "-1189"
+            },
             "label": "ca. 1190 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 BC"
           }
         },
@@ -46460,9 +56617,15 @@
           ],
           "spatialCoverageDescription": "Anatolia",
           "start": {
+            "in": {
+              "year": "-1349"
+            },
             "label": "ca. 1350 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 BC"
           }
         },
@@ -46496,9 +56659,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "ca. 2000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1759"
+            },
             "label": "1760 BC"
           }
         },
@@ -46524,9 +56693,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1529"
+            },
             "label": "ca. 1530 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1149"
+            },
             "label": "1150 BC"
           }
         },
@@ -46552,9 +56727,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-1649"
+            },
             "label": "ca. 1650 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1049"
+            },
             "label": "1050 BC"
           }
         },
@@ -46576,9 +56757,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-1649"
+            },
             "label": "ca. 1650 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1474"
+            },
             "label": "1475 BC"
           }
         },
@@ -46600,9 +56787,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-1474"
+            },
             "label": "ca. 1475 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1224"
+            },
             "label": "1225 BC"
           }
         },
@@ -46624,9 +56817,15 @@
           ],
           "spatialCoverageDescription": "Cyprus",
           "start": {
+            "in": {
+              "year": "-1224"
+            },
             "label": "ca. 1225 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1049"
+            },
             "label": "1050 BC"
           }
         },
@@ -46652,9 +56851,15 @@
           ],
           "spatialCoverageDescription": "Anatolia",
           "start": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "ca. 1400 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1349"
+            },
             "label": "1350 BC"
           }
         },
@@ -46708,6 +56913,10 @@
           ],
           "spatialCoverageDescription": "Mespotamia, Anatolia, the Levant, Persia",
           "start": {
+            "in": {
+              "earliestYear": "-0999",
+              "latestYear": "-0900"
+            },
             "label": "tenth century BC"
           },
           "stop": {
@@ -46736,9 +56945,15 @@
           ],
           "spatialCoverageDescription": "northern Mesopotamia or Assyria (= today's north Iraq and north-east Syria)",
           "start": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "ca. 1000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0611"
+            },
             "label": "612 BC"
           }
         },
@@ -46792,9 +57007,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia, the Levant",
           "start": {
+            "in": {
+              "year": "-0611"
+            },
             "label": "612 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0538"
+            },
             "label": "539 BC"
           }
         },
@@ -46820,9 +57041,15 @@
           ],
           "spatialCoverageDescription": "Persia",
           "start": {
+            "in": {
+              "year": "-0549"
+            },
             "label": "550 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0329"
+            },
             "label": "330 BC"
           }
         },
@@ -46868,9 +57095,15 @@
           ],
           "spatialCoverageDescription": "Near East",
           "start": {
+            "in": {
+              "year": "-8549"
+            },
             "label": "ca. 8550 BC"
           },
           "stop": {
+            "in": {
+              "year": "-4999"
+            },
             "label": "5000 BC"
           }
         },
@@ -46896,9 +57129,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "ca. 2000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1529"
+            },
             "label": "1530 BC"
           }
         },
@@ -46920,9 +57159,15 @@
           ],
           "spatialCoverageDescription": "Anatolia",
           "start": {
+            "in": {
+              "year": "-1574"
+            },
             "label": "ca. 1575 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1399"
+            },
             "label": "1400 BC"
           }
         },
@@ -46956,9 +57201,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "ca. 3500 BC"
           },
           "stop": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "2900 BC"
           }
         },
@@ -46988,9 +57239,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-4999"
+            },
             "label": "ca. 5000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 BC"
           }
         },
@@ -47020,9 +57277,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2099"
+            },
             "label": "ca. 2100 BC"
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 BC"
           }
         },
@@ -47068,9 +57331,15 @@
           ],
           "spatialCoverageDescription": "Near East",
           "start": {
+            "in": {
+              "year": "-4999"
+            },
             "label": "ca. 5000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 BC"
           }
         },
@@ -47097,9 +57366,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "ca. 1000 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 BC"
           }
         },
@@ -47126,9 +57401,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "ca. 900 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "700 BC"
           }
         },
@@ -47159,9 +57440,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-0724"
+            },
             "label": "ca. 725 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "600 BC"
           }
         },
@@ -47188,9 +57475,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "ca. 600 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0478"
+            },
             "label": "479 BC"
           }
         },
@@ -47217,9 +57510,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-0478"
+            },
             "label": "ca. 479 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0322"
+            },
             "label": "323 BC"
           }
         },
@@ -47246,9 +57545,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-0322"
+            },
             "label": "ca. 323 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "31 BC"
           }
         },
@@ -47271,9 +57576,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "ca. 480 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0449"
+            },
             "label": "450 BC"
           }
         },
@@ -47296,9 +57607,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-0449"
+            },
             "label": "ca. 450 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "400 BC"
           }
         },
@@ -47325,9 +57642,15 @@
           ],
           "spatialCoverageDescription": "Greece",
           "start": {
+            "in": {
+              "year": "-0399"
+            },
             "label": "ca. 400 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0322"
+            },
             "label": "323 BC"
           }
         },
@@ -47352,9 +57675,15 @@
           ],
           "spatialCoverageDescription": "Rome",
           "start": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "ca. 600 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0508"
+            },
             "label": "509 BC"
           }
         },
@@ -47376,9 +57705,15 @@
           ],
           "spatialCoverageDescription": "Rome",
           "start": {
+            "in": {
+              "year": "-0508"
+            },
             "label": "ca. 509 BC"
           },
           "stop": {
+            "in": {
+              "year": "-0026"
+            },
             "label": "27 BC"
           }
         },
@@ -47400,9 +57735,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0014"
+            },
             "label": "AD 14"
           },
           "stop": {
+            "in": {
+              "year": "0069"
+            },
             "label": "AD 69"
           }
         },
@@ -47424,9 +57765,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0069"
+            },
             "label": "AD 69"
           },
           "stop": {
+            "in": {
+              "year": "0096"
+            },
             "label": "AD 96"
           }
         },
@@ -47448,9 +57795,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0096"
+            },
             "label": "AD 96"
           },
           "stop": {
+            "in": {
+              "year": "0193"
+            },
             "label": "AD 193"
           }
         },
@@ -47472,9 +57825,15 @@
           ],
           "spatialCoverageDescription": "Roman Empire",
           "start": {
+            "in": {
+              "year": "0193"
+            },
             "label": "AD 193"
           },
           "stop": {
+            "in": {
+              "year": "0235"
+            },
             "label": "AD 235"
           }
         }
@@ -47508,9 +57867,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0699"
+            },
             "label": "700 B.C."
           }
         }
@@ -47581,9 +57946,15 @@
           ],
           "spatialCoverageDescription": "Greater Armenia",
           "start": {
+            "in": {
+              "year": "-0611"
+            },
             "label": "612 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0549"
+            },
             "label": "550 B.C."
           }
         },
@@ -47632,9 +58003,15 @@
           ],
           "spatialCoverageDescription": "Greater Armenia",
           "start": {
+            "in": {
+              "year": "-0694"
+            },
             "label": "695 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0300"
+            },
             "label": "301 B.C."
           }
         },
@@ -47683,9 +58060,15 @@
           ],
           "spatialCoverageDescription": "Greater Armenia",
           "start": {
+            "in": {
+              "year": "-0199"
+            },
             "label": "200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "0014"
+            },
             "label": "A.D. 14"
           }
         },
@@ -47731,9 +58114,15 @@
           ],
           "spatialCoverageDescription": "Greater Armenia",
           "start": {
+            "in": {
+              "year": "-0300"
+            },
             "label": "301 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0083"
+            },
             "label": "84 B.C."
           }
         },
@@ -47779,9 +58168,15 @@
           ],
           "spatialCoverageDescription": "Greater Armenia",
           "start": {
+            "in": {
+              "year": "0066"
+            },
             "label": "A.D. 66"
           },
           "stop": {
+            "in": {
+              "year": "0400"
+            },
             "label": "A.D. 400"
           }
         },
@@ -47830,9 +58225,15 @@
           ],
           "spatialCoverageDescription": "Greater Armenia",
           "start": {
+            "in": {
+              "year": "0885"
+            },
             "label": "A.D. 885"
           },
           "stop": {
+            "in": {
+              "year": "1045"
+            },
             "label": "A.D. 1045"
           }
         },
@@ -47881,9 +58282,15 @@
           ],
           "spatialCoverageDescription": "Greater Armenia",
           "start": {
+            "in": {
+              "year": "0063"
+            },
             "label": "A.D. 63"
           },
           "stop": {
+            "in": {
+              "year": "0428"
+            },
             "label": "A.D. 428"
           }
         },
@@ -47932,9 +58339,15 @@
           ],
           "spatialCoverageDescription": "Greater Armenia",
           "start": {
+            "in": {
+              "year": "0428"
+            },
             "label": "A.D. 428"
           },
           "stop": {
+            "in": {
+              "year": "0580"
+            },
             "label": "A.D. 580"
           }
         },
@@ -47980,9 +58393,15 @@
           ],
           "spatialCoverageDescription": "Greater Armenia",
           "start": {
+            "in": {
+              "year": "0750"
+            },
             "label": "A.D. 750"
           },
           "stop": {
+            "in": {
+              "year": "0772"
+            },
             "label": "A.D. 772"
           }
         },
@@ -48028,9 +58447,15 @@
           ],
           "spatialCoverageDescription": "Greater Armenia",
           "start": {
+            "in": {
+              "year": "0653"
+            },
             "label": "A.D. 653"
           },
           "stop": {
+            "in": {
+              "year": "1150"
+            },
             "label": "A.D. 1150"
           }
         }
@@ -48068,9 +58493,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2599"
+            },
             "label": "2600 B.C."
           }
         },
@@ -48091,9 +58522,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2599"
+            },
             "label": "2600 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2129"
+            },
             "label": "2130 B.C."
           }
         },
@@ -48114,9 +58551,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2129"
+            },
             "label": "2130 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2039"
+            },
             "label": "2040 B.C."
           }
         },
@@ -48138,9 +58581,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2039"
+            },
             "label": "2040 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1639"
+            },
             "label": "1640 B.C."
           }
         },
@@ -48165,9 +58614,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1639"
+            },
             "label": "1640 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1531"
+            },
             "label": "1532 B.C."
           }
         },
@@ -48188,9 +58643,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1549"
+            },
             "label": "1550 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1069"
+            },
             "label": "1070 B.C."
           }
         },
@@ -48214,9 +58675,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1059"
+            },
             "label": "1060 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0663"
+            },
             "label": "664 B.C."
           }
         },
@@ -48238,9 +58705,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2999"
+            },
             "label": "3000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0999"
+            },
             "label": "c.1000 B.C."
           }
         },
@@ -48262,9 +58735,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1849"
+            },
             "label": "1850 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C."
           }
         },
@@ -48319,9 +58798,15 @@
           ],
           "spatialCoverageDescription": "Euphrates, Cyprus, southern Anatolia, Palestine, Syria, Egypt",
           "start": {
+            "in": {
+              "year": "-1299"
+            },
             "label": "1300 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0604"
+            },
             "label": "605 B.C."
           }
         },
@@ -48354,9 +58839,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0923"
+            },
             "label": "c.924 B.C."
           }
         },
@@ -48378,9 +58869,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 B.C."
           }
         },
@@ -48402,9 +58899,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1424"
+            },
             "label": "1425 B.C."
           }
         },
@@ -48426,9 +58929,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-2199"
+            },
             "label": "2200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 B.C."
           }
         },
@@ -48450,9 +58959,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0799"
+            },
             "label": "800 B.C."
           }
         },
@@ -48473,9 +58988,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0729"
+            },
             "label": "730 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0629"
+            },
             "label": "630 B.C."
           }
         },
@@ -48496,9 +59017,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0619"
+            },
             "label": "620 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "480 B.C."
           }
         },
@@ -48520,9 +59047,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0479"
+            },
             "label": "480 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0403"
+            },
             "label": "404 B.C."
           }
         },
@@ -48544,9 +59077,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-0335"
+            },
             "label": "336 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0030"
+            },
             "label": "31 B.C."
           }
         },
@@ -48569,9 +59108,15 @@
           ],
           "spatialCoverageDescription": "Etruria",
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0759"
+            },
             "label": "760 B.C."
           }
         },
@@ -48593,6 +59138,9 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0565"
+            },
             "label": "565 A.D."
           },
           "stop": {
@@ -48640,9 +59188,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0307"
+            },
             "label": "AD 307"
           },
           "stop": {
+            "in": {
+              "year": "0337"
+            },
             "label": "AD 337"
           }
         },
@@ -48671,9 +59225,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0235"
+            },
             "label": "AD 235"
           },
           "stop": {
+            "in": {
+              "year": "0284"
+            },
             "label": "AD 284"
           }
         },
@@ -48702,9 +59262,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "0284"
+            },
             "label": "AD 284"
           },
           "stop": {
+            "in": {
+              "year": "0312"
+            },
             "label": "AD 312"
           }
         }
@@ -48761,9 +59327,15 @@
           ],
           "spatialCoverageDescription": "Elam",
           "start": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 B.C."
           }
         },
@@ -48798,9 +59370,15 @@
           ],
           "spatialCoverageDescription": "Elam",
           "start": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 B.C."
           }
         },
@@ -48830,9 +59408,15 @@
           ],
           "spatialCoverageDescription": "Elam",
           "start": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 B.C."
           }
         },
@@ -48868,9 +59452,15 @@
           ],
           "spatialCoverageDescription": "Elam",
           "start": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2699"
+            },
             "label": "2700 B.C."
           }
         },
@@ -48901,9 +59491,15 @@
           ],
           "spatialCoverageDescription": "Elam",
           "start": {
+            "in": {
+              "year": "-2699"
+            },
             "label": "2700 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 B.C."
           }
         },
@@ -48933,9 +59529,15 @@
           ],
           "spatialCoverageDescription": "Elam",
           "start": {
+            "in": {
+              "year": "-1499"
+            },
             "label": "1500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           }
         },
@@ -48965,9 +59567,15 @@
           ],
           "spatialCoverageDescription": "Elam",
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "600 B.C."
           }
         },
@@ -48997,9 +59605,15 @@
           ],
           "spatialCoverageDescription": "Elam",
           "start": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "600 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0549"
+            },
             "label": "550 B.C."
           }
         },
@@ -49029,9 +59643,15 @@
           ],
           "spatialCoverageDescription": "Elam",
           "start": {
+            "in": {
+              "year": "-0549"
+            },
             "label": "550 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0299"
+            },
             "label": "300 B.C."
           }
         },
@@ -49061,9 +59681,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "2900 B.C."
           }
         },
@@ -49093,9 +59719,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "2900 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C."
           }
         },
@@ -49125,9 +59757,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1199"
+            },
             "label": "1200 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0299"
+            },
             "label": "300 B.C."
           }
         },
@@ -49157,9 +59795,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-3999"
+            },
             "label": "4000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 B.C."
           }
         },
@@ -49189,9 +59833,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-3499"
+            },
             "label": "3500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 B.C."
           }
         },
@@ -49221,9 +59871,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-3099"
+            },
             "label": "3100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "2900 B.C."
           }
         },
@@ -49253,9 +59909,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2899"
+            },
             "label": "2900 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2749"
+            },
             "label": "2750 B.C."
           }
         },
@@ -49285,9 +59947,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2749"
+            },
             "label": "2750 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2599"
+            },
             "label": "2600 B.C."
           }
         },
@@ -49317,9 +59985,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2599"
+            },
             "label": "2600 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2333"
+            },
             "label": "2334 B.C."
           }
         },
@@ -49349,9 +60023,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2333"
+            },
             "label": "2334 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-2099"
+            },
             "label": "2100 B.C."
           }
         },
@@ -49381,9 +60061,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-2099"
+            },
             "label": "2100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C."
           }
         },
@@ -49413,9 +60099,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1999"
+            },
             "label": "2000 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "1800 B.C."
           }
         },
@@ -49445,9 +60137,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1799"
+            },
             "label": "1800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1699"
+            },
             "label": "1700 B.C."
           }
         },
@@ -49477,9 +60175,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1599"
+            },
             "label": "1600 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 B.C."
           }
         },
@@ -49509,9 +60213,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-1099"
+            },
             "label": "1100 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           }
         },
@@ -49541,9 +60251,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-0899"
+            },
             "label": "900 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "600 B.C."
           }
         },
@@ -49573,9 +60289,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-0599"
+            },
             "label": "600 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 B.C."
           }
         },
@@ -49605,9 +60327,15 @@
           ],
           "spatialCoverageDescription": "Mesopotamia",
           "start": {
+            "in": {
+              "year": "-0499"
+            },
             "label": "500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-0299"
+            },
             "label": "300 B.C."
           }
         }
@@ -49659,9 +60387,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-4499"
+            },
             "label": "4500 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-3199"
+            },
             "label": "3200 B.C."
           }
         },
@@ -49679,9 +60413,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5299"
+            },
             "label": "5300 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-4499"
+            },
             "label": "4500 B.C."
           }
         },
@@ -49699,9 +60439,15 @@
             }
           ],
           "start": {
+            "in": {
+              "year": "-5799"
+            },
             "label": "5800 B.C."
           },
           "stop": {
+            "in": {
+              "year": "-5299"
+            },
             "label": "5300 B.C."
           }
         }


### PR DESCRIPTION
Includes ranges; omits problem periods where start is after stop, or
where the date wasn't parseable for whatever reason.
