### PR TITLE
Change label localization

### DIFF
--- a/data.json
+++ b/data.json
@@ -5,7 +5,8 @@
     "PeriodDefinition": "http://www.w3.org/2004/02/skos/core#Concept",
     "abstract": "http://purl.org/dc/terms/abstract",
     "alternateLabel": {
-      "@id": "http://www.w3.org/2004/02/skos/core#altLabel",
+      "@container": "@language",
+      "@id": "http://www.w3.org/2004/02/skos/core#altLabel"
     },
     "contributors": "http://purl.org/dc/terms/contributor",
     "creators": "http://purl.org/dc/terms/creator",

--- a/data.json
+++ b/data.json
@@ -28,7 +28,7 @@
     },
     "label": "http://www.w3.org/2004/02/skos/core#prefLabel",
     "latestYear": "periodo:latestYear",
-    "localizedLabel": {
+    "originalLabel": {
       "@container": "@language",
       "@id": "http://www.w3.org/2004/02/skos/core#altLabel"
     },
@@ -80,7 +80,7 @@
           "editorialNote": "\"Etruscans\" entry.",
           "id": "p0244q7v2hf",
           "label": "Etruscan",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Etruscan"
           },
           "spatialCoverage": [
@@ -131,7 +131,7 @@
         "p02sht94cwr": {
           "id": "p02sht94cwr",
           "label": "Jemdet Nasr",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Jemdet Nasr"
           },
           "note": "See also Charvat 2002",
@@ -159,7 +159,7 @@
         "p02sht9fzvs": {
           "id": "p02sht9fzvs",
           "label": "Early Uruk",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Uruk"
           },
           "note": "See also Liverani 2006",
@@ -187,7 +187,7 @@
         "p02sht9wp3g": {
           "id": "p02sht9wp3g",
           "label": "Late Uruk",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Uruk"
           },
           "note": "See also Liverani 2006",
@@ -241,7 +241,7 @@
         "p03377fkhrv": {
           "id": "p03377fkhrv",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -267,7 +267,7 @@
         "p03377ft59d": {
           "id": "p03377ft59d",
           "label": "Late Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Iron Age"
           },
           "spatialCoverage": [
@@ -316,7 +316,7 @@
         "p03tqbzrjp5": {
           "id": "p03tqbzrjp5",
           "label": "Late Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Empire"
           },
           "source": {
@@ -342,7 +342,7 @@
           "editorialNote": "added post-GeoDia",
           "id": "p03tqbzvh6x",
           "label": "Hellenistic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic"
           },
           "source": {
@@ -390,7 +390,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd23gj",
           "label": "Mesolithic Middle East (18000-9000 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic Middle East (18000-9000 BC)"
           },
           "note": "Epipaleolithic-Protoneolithic ME",
@@ -438,7 +438,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd25c5",
           "label": "Mongol Middle East (AD 1258-1501)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mongol Middle East (AD 1258-1501)"
           },
           "note": "ME, Central Asia",
@@ -510,7 +510,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd29mn",
           "label": "Urartian Eastern Anatolia (900-600 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Urartian Eastern Anatolia (900-600 BC)"
           },
           "note": "eastern Anatolia",
@@ -550,7 +550,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd2cfk",
           "label": "Ottoman Rise (AD 1300-1453)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ottoman Rise (AD 1300-1453)"
           },
           "note": "ends with the conquest of Constantinople",
@@ -605,7 +605,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd2rhh",
           "label": "Khwarezmian Middle East (AD 1077-1258)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Khwarezmian Middle East (AD 1077-1258)"
           },
           "note": "Khwarezmid",
@@ -657,7 +657,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd389m",
           "label": "Classical (Greco-Roman; 550 BC-330 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classical (Greco-Roman; 550 BC-330 BC)"
           },
           "note": "The Classical period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 550 and end in the year 330 before the birth of Christ.",
@@ -920,7 +920,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd47fw",
           "label": "Late Period Egypt (664-332)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Period Egypt (664-332)"
           },
           "note": "The Late Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
@@ -956,7 +956,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd4mmt",
           "label": "2nd Millenium BCE",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "2nd Millenium BCE"
           },
           "note": "The second millenium BCE as defined at http://en.wikipedia.org/wiki/2nd_millennium_BC",
@@ -1035,7 +1035,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd4n95",
           "label": "Samanid-Ghaznavid Iran (AD 819-1186)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Samanid-Ghaznavid Iran (AD 819-1186)"
           },
           "note": "Iran",
@@ -1111,7 +1111,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd4rpp",
           "label": "Hellenistic Middle East (330-140 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic Middle East (330-140 BC)"
           },
           "note": "Macedonian-Seleucid/Ptolemaic/Attalid/Greco-Bactrian",
@@ -1195,7 +1195,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd5222",
           "label": "Crusader-Ottoman Levant (AD 1099-1750)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Crusader-Ottoman Levant (AD 1099-1750)"
           },
           "note": "Crusader-Seljuq-Ayyubid-Mamluk-Ottoman Levant",
@@ -1233,7 +1233,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd55sw",
           "label": "Hellenistic Greek, Roman Republic (330 BC-30 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic Greek, Roman Republic (330 BC-30 BC)"
           },
           "note": "The Hellenistic period in Greek history and the middle-to-late Republican period in Roman history. For the purposes of Pleiades, this period is said to begin in the year 330 and end in the year 30 before the birth of Christ.",
@@ -1568,7 +1568,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd5dbn",
           "label": "Late Bronze Age Southern Levant (1400-1200 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age Southern Levant (1400-1200 BC)"
           },
           "note": "southern Levant",
@@ -1616,7 +1616,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd5mwr",
           "label": "Transition Early-Middle Bronze Age Southern Levant (2100-1900 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Transition Early-Middle Bronze Age Southern Levant (2100-1900 BC)"
           },
           "note": "southern Levant",
@@ -1664,7 +1664,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd5v96",
           "label": "Transition Roman Early Empire-Late Antique (AD 284-337)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Transition Roman Early Empire-Late Antique (AD 284-337)"
           },
           "note": "Mediterranean",
@@ -1751,7 +1751,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd69hp",
           "label": "Khedivate Egypt (AD 1800-1922)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Khedivate Egypt (AD 1800-1922)"
           },
           "note": "Muhammed Ali-Khedivate Egypt, Alawiyya Egypt, Anglo-Egyptian",
@@ -1839,7 +1839,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd6hw5",
           "label": "Egyptian/Hittite Levant (1344-1212 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Egyptian/Hittite Levant (1344-1212 BC)"
           },
           "note": "Levant",
@@ -1895,7 +1895,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd6nrz",
           "label": "Iron Age Britain (ca. 800 BC/BCE - ca. 100 AD/CE)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age Britain (ca. 800 BC/BCE - ca. 100 AD/CE)"
           },
           "note": "A long time period associated with Iron Age Britain.",
@@ -1935,7 +1935,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd6psm",
           "label": "Late Antique (AD 300-AD 640)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Antique (AD 300-AD 640)"
           },
           "note": "The Late Antique period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 300 and to end in the year 640 after the birth of Christ.",
@@ -2302,7 +2302,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd6vvr",
           "label": "Middle Byzantine (AD 850-1200)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Byzantine (AD 850-1200)"
           },
           "note": "Middle Byzantine period in areas where such designations are appropriate.",
@@ -2381,7 +2381,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd7s5r",
           "label": "Perso-Ottoman-Russian Caucasus (AD 1500-1918)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Perso-Ottoman-Russian Caucasus (AD 1500-1918)"
           },
           "note": "Safavid-Qajar-Ottoman Empire-Russian Empire Caucasus",
@@ -2437,7 +2437,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd825s",
           "label": "Hellenistic-Roman Early Empire (330 BC - AD 300)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic-Roman Early Empire (330 BC - AD 300)"
           },
           "note": "Mediterranean",
@@ -2540,7 +2540,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd82ps",
           "label": "Middle Bronze Age Anatolia (1750-1450 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age Anatolia (1750-1450 BC)"
           },
           "note": "Anatolia",
@@ -2580,7 +2580,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd83qf",
           "label": "Late Antique/Sasanian Middle East (AD 300-640)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Antique/Sasanian Middle East (AD 300-640)"
           },
           "note": "ME",
@@ -2668,7 +2668,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd93hp",
           "label": "Parthian Middle East (140 BC - AD 226)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Parthian Middle East (140 BC - AD 226)"
           },
           "note": "Arsacid ME",
@@ -2704,7 +2704,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd95m9",
           "label": "Ptolemaic Egypt (304-30 BCE/BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ptolemaic Egypt (304-30 BCE/BC)"
           },
           "note": "The Ptolemaic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
@@ -2740,7 +2740,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd97z7",
           "label": "Ottoman Empire (AD 1513-1918)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ottoman Empire (AD 1513-1918)"
           },
           "note": "ME, Balkan, Northern Africa",
@@ -2823,7 +2823,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd98jh",
           "label": "Early Medieval Caucasus (AD 850-1200)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Medieval Caucasus (AD 850-1200)"
           },
           "note": "Bagratid, Kingdom of Armenia/Kingdom of Georgia",
@@ -2879,7 +2879,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd9h8w",
           "label": "1500 AD Middle East (AD 1500-1500)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "1500 AD Middle East (AD 1500-1500)"
           },
           "note": "ME, Greece, Indus",
@@ -2991,7 +2991,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd9szx",
           "label": "Chalcolithic Iran (5000-2500 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Chalcolithic Iran (5000-2500 BC)"
           },
           "note": "Iran",
@@ -3031,7 +3031,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdbftw",
           "label": "Safavid Middle East (AD 1501-1725)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Safavid Middle East (AD 1501-1725)"
           },
           "note": "Eastern ME, Central Asia",
@@ -3087,7 +3087,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdbh6h",
           "label": "4th millenium BCE",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "4th millenium BCE"
           },
           "note": "The fourth millenium BCE as defined at http://en.wikipedia.org/wiki/4th_millennium_BC",
@@ -3146,7 +3146,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdbvmg",
           "label": "Akkadian-Ur III Mesopotamia (2335-2000 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Akkadian-Ur III Mesopotamia (2335-2000 BC)"
           },
           "note": "Akkadian-Neo-Sumerian Mesopotamia",
@@ -3190,7 +3190,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdc5xs",
           "label": "Middle Nubian (2300-1600 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Nubian (2300-1600 BC)"
           },
           "note": "C-Group-Kerma-Middle Nubian-Pan-Grave-MK",
@@ -3225,7 +3225,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdc6nf",
           "label": "Middle Bronze-Early Iron Age Iran (2000-650 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze-Early Iron Age Iran (2000-650 BC)"
           },
           "note": "Iran",
@@ -3273,7 +3273,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdccmk",
           "label": "Colonial-Modern Middle East (AD 1800-2000)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Colonial-Modern Middle East (AD 1800-2000)"
           },
           "note": "Late Ottoman-Colonial-Mandate Modern Middle east",
@@ -3325,7 +3325,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdcctk",
           "label": "Roman Early Empire-Late Antique (30 BC - AD 640)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Early Empire-Late Antique (30 BC - AD 640)"
           },
           "note": "Mediterranean",
@@ -3436,7 +3436,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdcdz7",
           "label": "Mediaeval/Byzantine (AD 641-AD 1453)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mediaeval/Byzantine (AD 641-AD 1453)"
           },
           "note": "The Mediaeval period in the West, or the period from the end of Late Antiquity (640) to the fall of Constantinople in the East (1453).",
@@ -3551,7 +3551,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdcmjz",
           "label": "Middle Hittite Anatolia (1450-1200 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Hittite Anatolia (1450-1200 BC)"
           },
           "note": "New Kingdom Hittite",
@@ -3595,7 +3595,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdcpjk",
           "label": "Proto-Byzantine (AD 500-650)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Proto-Byzantine (AD 500-650)"
           },
           "note": "Early Byzantine; includes Justinian I",
@@ -3670,7 +3670,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdd2st",
           "label": "Neolithic Egypt (6000-4500 BCE/BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic Egypt (6000-4500 BCE/BC)"
           },
           "note": "The Neolithic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
@@ -3710,7 +3710,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddb3j",
           "label": "New Kingdom Egypt (1548-1086)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "New Kingdom Egypt (1548-1086)"
           },
           "note": "The New Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
@@ -3754,7 +3754,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddbqj",
           "label": "Elamite Western Iran (3200-540 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Elamite Western Iran (3200-540 BC)"
           },
           "note": "Proto-Old-Middle-Neo-Elamite",
@@ -3798,7 +3798,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddc9t",
           "label": "Neolithic Period on Malta (ca. 5,000-2,500BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic Period on Malta (ca. 5,000-2,500BC)"
           },
           "note": "The neolithic or so-called \"New Stone Age\" as expressed in remains of physical culture on the island of Malta, where it appears to have lasted from around 5,000 to 2,500 BC",
@@ -3834,7 +3834,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddvwn",
           "label": "Achaemenid-Roman Republic Middle East (540-30 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Achaemenid-Roman Republic Middle East (540-30 BC)"
           },
           "note": "ME",
@@ -3978,7 +3978,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddwzm",
           "label": "Hellenistic-Parthian Middle East (330 BC - AD 226)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic-Parthian Middle East (330 BC - AD 226)"
           },
           "note": "Seleucid-Early Roman-Arsacid Middle East",
@@ -4014,7 +4014,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdf7wk",
           "label": "Early Ottoman Empire (AD 1453-1683)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Ottoman Empire (AD 1453-1683)"
           },
           "note": "ends with the siege of Vienna",
@@ -4109,7 +4109,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfbcg",
           "label": "Late Ottoman Empire (AD 1683-1918)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Ottoman Empire (AD 1683-1918)"
           },
           "note": "ME, Balkan, Northern Africa",
@@ -4220,7 +4220,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfd83",
           "label": "Bronze Age Britain (ca. 2500 - ca. 800 BC/BCE)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age Britain (ca. 2500 - ca. 800 BC/BCE)"
           },
           "note": "A long time period associated with Bronze Age Britain.",
@@ -4256,7 +4256,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfnrs",
           "label": "Late Nubian (1600-350 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Nubian (1600-350 BC)"
           },
           "note": "NK-Kushite-Meroitic",
@@ -4291,7 +4291,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfpqr",
           "label": "Later 2nd Millennium BC Mesopotamia (1600-1000 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Later 2nd Millennium BC Mesopotamia (1600-1000 BC)"
           },
           "note": "Middle Assyrian/Middle Babylonian/Kassite Mesopotamia, LBA-Early Iron Age Mesopotamia, incl. Sea Peoples",
@@ -4339,7 +4339,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfrrp",
           "label": "Mesolithic Levant (18000-9500 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic Levant (18000-9500 BC)"
           },
           "note": "Epipaleolithic-Protoneolithic Levant, Kebaran-Natufian",
@@ -4383,7 +4383,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdftkm",
           "label": "Ptolemaic-Roman Egypt (304 BC - AD 640)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ptolemaic-Roman Egypt (304 BC - AD 640)"
           },
           "note": "Egypt",
@@ -4435,7 +4435,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdg8s5",
           "label": "Crusader/Seljuq-Ayyubid Levant (AD 1099-1291)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Crusader/Seljuq-Ayyubid Levant (AD 1099-1291)"
           },
           "note": "Latin",
@@ -4503,7 +4503,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgh6j",
           "label": "Modern (AD 1700-Present)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern (AD 1700-Present)"
           },
           "note": "Our present, modern era.",
@@ -4834,7 +4834,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgmtf",
           "label": "Old Kingdom Egypt (2670-2168 BCE/BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Kingdom Egypt (2670-2168 BCE/BC)"
           },
           "note": "The Old Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
@@ -4870,7 +4870,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgn3q",
           "label": "Pre-Pottery Neolithic Middle East (9000-6000 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pre-Pottery Neolithic Middle East (9000-6000 BC)"
           },
           "note": "Aceramic Neolithic ME",
@@ -4910,7 +4910,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgpzc",
           "label": "Timurid Middle East (AD 1370-1501)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Timurid Middle East (AD 1370-1501)"
           },
           "note": "Eastern ME, Central Asia",
@@ -4982,7 +4982,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgq4n",
           "label": "Middle Kingdom Egypt (2010-1640 BCE/BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Kingdom Egypt (2010-1640 BCE/BC)"
           },
           "note": "The Middle Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
@@ -5022,7 +5022,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdh9h2",
           "label": "Ubaid-Early Dynastic II Mesopotamia (5500-2600 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ubaid-Early Dynastic II Mesopotamia (5500-2600 BC)"
           },
           "note": "Late Chalcolithic-ED II Mesopotamia, Ubaid-Uruk-Jemdet Nasr-ED Mesopotamia",
@@ -5070,7 +5070,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdhc9m",
           "label": "Early Bronze Age Southern Levant (3300-2000 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age Southern Levant (3300-2000 BC)"
           },
           "note": "southern Levant",
@@ -5118,7 +5118,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdhqrw",
           "label": "Roman Middle East (140 BC - AD 640)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Middle East (140 BC - AD 640)"
           },
           "note": "ME",
@@ -5198,7 +5198,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdj3g6",
           "label": "Caliphate-Umayyad Middle East (AD 632-750)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Caliphate-Umayyad Middle East (AD 632-750)"
           },
           "note": "Early Islamic, Rashidun-Umayyad (starts with death of Muhammed who only controlled Arabia)",
@@ -5294,7 +5294,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdj8bb",
           "label": "Seljuq-Khwarezmian Middle East (AD 1037-1258)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Seljuq-Khwarezmian Middle East (AD 1037-1258)"
           },
           "note": "ME",
@@ -5346,7 +5346,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjbp8",
           "label": "Early Byzantine (AD 650-850)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Byzantine (AD 650-850)"
           },
           "note": "Early Byzantine Period in areas where such designations are appropriate.",
@@ -5421,7 +5421,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjcqv",
           "label": "Middle Geometric (Greek; 850-750 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Geometric (Greek; 850-750 BC)"
           },
           "note": "The Middle Geometric period in ancient Greece, from 850-750 before the birth of Christ.",
@@ -5464,7 +5464,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjhsq",
           "label": "Pottery Neolithic Middle East (6000-4500 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pottery Neolithic Middle East (6000-4500 BC)"
           },
           "note": "ME",
@@ -5524,7 +5524,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjqsh",
           "label": "Bronze Age Malta (ca. 2,500-700 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age Malta (ca. 2,500-700 BC)"
           },
           "note": "The Bronze age as represented in the remains of physical culture from the island of Malta.",
@@ -5560,7 +5560,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjrcs",
           "label": "Middle-Late Iron Age Anatolia (700-500 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle-Late Iron Age Anatolia (700-500 BC)"
           },
           "note": "Anatolia",
@@ -5608,7 +5608,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjw3b",
           "label": "Neolithic Middle East (9000-4500 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic Middle East (9000-4500 BC)"
           },
           "note": "ME",
@@ -5652,7 +5652,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdk2k5",
           "label": "Iron Age Italy (Latial Culture I, 1000-900 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age Italy (Latial Culture I, 1000-900 BC)"
           },
           "note": "Latial I is concentrated around Rome, the Alban Hills, and the Monti della Tolfa.",
@@ -5688,7 +5688,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdk582",
           "label": "Ilkhanate Middle East (AD 1258-1335)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ilkhanate Middle East (AD 1258-1335)"
           },
           "note": "Ilkhanid, Hulagu, Early Mongol",
@@ -5768,7 +5768,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdm4tb",
           "label": "Early Iron Age Anatolia (1200-700 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iron Age Anatolia (1200-700 BC)"
           },
           "note": "incl. Mitanni",
@@ -5820,7 +5820,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdm62k",
           "label": "Old Nubian (3800-2300 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Nubian (3800-2300 BC)"
           },
           "note": "A-Group/Old Nubian-Middle Nubian-OK",
@@ -5855,7 +5855,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdmzfr",
           "label": "Third Intermediate Period Egypt (1086-664)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Third Intermediate Period Egypt (1086-664)"
           },
           "note": "The Third Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
@@ -5895,7 +5895,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnjq5",
           "label": "1200 BC Middle East",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "1200 BC Middle East"
           },
           "note": "ME, Greece",
@@ -5999,7 +5999,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnnpp",
           "label": "Ummayad Period (661-750CE)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ummayad Period (661-750CE)"
           },
           "note": "The period of the Umayyad Caliphate as defined by http://en.wikipedia.org/wiki/Umayyad_Caliphate",
@@ -6042,7 +6042,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnwd4",
           "label": "Archaic (Greco-Roman; 750-550 BCE/BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic (Greco-Roman; 750-550 BCE/BC)"
           },
           "note": "The Archaic period in Greek and Roman history. For the purposes of Pleiades, this period is seen to begin in the year 750 and end in the year 550 before the birth of Christ.",
@@ -6221,7 +6221,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnxfq",
           "label": "2nd Millennium BC Egypt (2000-1000 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "2nd Millennium BC Egypt (2000-1000 BC)"
           },
           "note": "Egypt",
@@ -6265,7 +6265,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnzgc",
           "label": "Early Bronze Age Anatolia (2000-1750 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age Anatolia (2000-1750 BC)"
           },
           "note": "Karum Anatolia",
@@ -6301,7 +6301,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdp535",
           "label": "Mamluk Middle East (AD 1258-1516)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mamluk Middle East (AD 1258-1516)"
           },
           "note": "Western ME",
@@ -6337,7 +6337,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpj3d",
           "label": "Neolithic Period (British Isles; 4,000-2,500 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic Period (British Isles; 4,000-2,500 BC)"
           },
           "note": "The Neolithic period in the British Isles, after Wikipedia, Neolithic British Isles, http://en.wikipedia.org/wiki/Neolithic_British_Isles.",
@@ -6373,7 +6373,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpjk3",
           "label": "Late Antique-Late Byzantine (AD 300-1450)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Antique-Late Byzantine (AD 300-1450)"
           },
           "note": "ME",
@@ -6424,7 +6424,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpqmv",
           "label": "2nd Millennium BC Levant (2000-1000 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "2nd Millennium BC Levant (2000-1000 BC)"
           },
           "note": "MBA Levant-LBA Levant-Iron Age I Levant (not sure as these are all taken from southern Levant periodisation)",
@@ -6484,7 +6484,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpxwb",
           "label": "Abassid Middle East (AD 750-940)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Abassid Middle East (AD 750-940)"
           },
           "note": "ME, northern Africa",
@@ -6576,7 +6576,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpzn9",
           "label": "Roman-Early Byzantine Middle East (140 BC - AD 850)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman-Early Byzantine Middle East (140 BC - AD 850)"
           },
           "note": "ME",
@@ -6620,7 +6620,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdq5md",
           "label": "Late Byzantine/Ottoman Rise (AD 1200-1453)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Byzantine/Ottoman Rise (AD 1200-1453)"
           },
           "note": "Aegean, Balkan & Anatolia",
@@ -6679,7 +6679,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdqq4g",
           "label": "Crusader/Byzantine/Seljuq Middle East (AD 1081-1204)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Crusader/Byzantine/Seljuq Middle East (AD 1081-1204)"
           },
           "note": "Latin/1st-4th Crusades-end of Middle Byzantine-Rum/Seljuq",
@@ -6735,7 +6735,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdqzgv",
           "label": "Middle Bronze Age Southern Levant (2000-1400 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age Southern Levant (2000-1400 BC)"
           },
           "note": "southern Levant",
@@ -6779,7 +6779,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdr3vd",
           "label": "Early Geometric (Greek; 900-850 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Geometric (Greek; 900-850 BC)"
           },
           "note": "The Early Geometric period in ancient Greece, from 900-850 before the birth of Christ.",
@@ -6826,7 +6826,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdr7sw",
           "label": "Old Babylonian/Assyrian Mesopotamia (2000-1600 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Babylonian/Assyrian Mesopotamia (2000-1600 BC)"
           },
           "note": "Mesopotamia",
@@ -6878,7 +6878,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrh3m",
           "label": "Ottoman Decline-Mandate Middle East (AD 1900-1950)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ottoman Decline-Mandate Middle East (AD 1900-1950)"
           },
           "note": "ME",
@@ -6970,7 +6970,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrkh7",
           "label": "Ubaid period in Mesopotamia (ca. 6500 to 3800 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ubaid period in Mesopotamia (ca. 6500 to 3800 BC)"
           },
           "note": "The prehistoric Ubaid period of Mesopotamia, as defined by Wikipedia following Carter, Robert A. and Philip, Graham Beyond the Ubaid: Transformation and Integration in the Late Prehistoric Societies of the Middle East (Studies in Ancient Oriental Civilization, Number 63) The Oriental Institute of the University of Chicago (2010) ISBN 978-1-885923-66-0 p.2, at http://oi.uchicago.edu/research/pubs/catalog/saoc/saoc63.html",
@@ -7010,7 +7010,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrtx9",
           "label": "Rum/Crusader Anatolia (AD 1077-1307)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Rum/Crusader Anatolia (AD 1077-1307)"
           },
           "note": "Seljuk-Latin States/Francocracy",
@@ -7058,7 +7058,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrv58",
           "label": "13th Century AD Eastern Mediterranean (AD 1200-1300)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "13th Century AD Eastern Mediterranean (AD 1200-1300)"
           },
           "note": "Late Byzantine-Ayyubid-Mamluk Western Middle East",
@@ -7094,7 +7094,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrx4h",
           "label": "Late Helladic (Mainland Greece; 1600-1200 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic (Mainland Greece; 1600-1200 BC)"
           },
           "note": "The Late Helladic period in the Greek mainland, after Preziosi and Hitchcock, Aegean Art and Architecture, Oxford History of Art, 1998.",
@@ -7130,7 +7130,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskds7zt",
           "label": "Modern Middle East (AD 1918-2000)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern Middle East (AD 1918-2000)"
           },
           "note": "ME",
@@ -7246,7 +7246,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskds845",
           "label": "Sassanian Middle East (AD 262-700)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Sassanian Middle East (AD 262-700)"
           },
           "note": "Sassanid",
@@ -7282,7 +7282,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdsdnb",
           "label": "Early Dynastic Mesopotamia (2950-2350 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic Mesopotamia (2950-2350 BC)"
           },
           "note": "Mesopotamia",
@@ -7334,7 +7334,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdtg2h",
           "label": "Middle Minoan (Crete; 2000-1600 BC/BCE)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Minoan (Crete; 2000-1600 BC/BCE)"
           },
           "note": "The Middle Minoan period on Crete, as defined in C. Shelmerdine, The Cambridge Companion to the Aegean Bronze Age (2008), p. 4, figure 1.1.",
@@ -7370,7 +7370,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdtn5z",
           "label": "Fatimid Middle East (AD 950-1150)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Fatimid Middle East (AD 950-1150)"
           },
           "note": "Western ME, northern Africa",
@@ -7406,7 +7406,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdtwrq",
           "label": "Chalcolithic Mesopotamia (6200-3750 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Chalcolithic Mesopotamia (6200-3750 BC)"
           },
           "note": "Copper Age Mesopotamia, Halaf-Ubaid-Early Uruk Mesopotamia",
@@ -7454,7 +7454,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdv8qb",
           "label": "Neo-Hittite Northern Levant (1200-700 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Hittite Northern Levant (1200-700 BC)"
           },
           "note": "Syro-Hittite Northern Levant",
@@ -7490,7 +7490,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdvds6",
           "label": "Persian-Medieval Caucasus (AD 600-1500)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Persian-Medieval Caucasus (AD 600-1500)"
           },
           "note": "Persian-Arabic-Early Medieval-Middle Medieval-Turco-Mongol/Late Medieval Caucasus",
@@ -7537,7 +7537,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdvwkb",
           "label": "3rd millennium BC",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "3rd millennium BC"
           },
           "note": "The 3rd millennium BC spans the Early to Middle Bronze Age. As described at http://en.wikipedia.org/wiki/3rd_millennium_BC.",
@@ -7616,7 +7616,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdw46d",
           "label": "Neolithic Period in the Eastern Mediterranean (ca. 10,000-3,300 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic Period in the Eastern Mediterranean (ca. 10,000-3,300 BC)"
           },
           "note": "The so-called \"Neolithic\" or \"New Stone Age\" period as defined in the Eastern portion of the Mediterranean basin, lasting roughly from 10,000 - 3,300 BC. See further: http://ancienthistory.about.com/od/artarchaeologyarchitect/g/neolithic.htm",
@@ -7660,7 +7660,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdwdtr",
           "label": "Early-Middle Bronze Age Iran (2500-1500 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early-Middle Bronze Age Iran (2500-1500 BC)"
           },
           "note": "Iran",
@@ -7696,7 +7696,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxgnx",
           "label": "Neo-Assyrian/Babylonian Middle East (720-540 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Assyrian/Babylonian Middle East (720-540 BC)"
           },
           "note": "ME",
@@ -7768,7 +7768,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxjnj",
           "label": "First Intermediate Period Egypt (2168-2010 BCE/BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "First Intermediate Period Egypt (2168-2010 BCE/BC)"
           },
           "note": "The First Intermediate Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
@@ -7804,7 +7804,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxnwr",
           "label": "Macedonian Egypt (332-304 BCE/BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Macedonian Egypt (332-304 BCE/BC)"
           },
           "note": "The Macedonian period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
@@ -7842,7 +7842,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxnzf",
           "label": "Roman, early Empire (30 BC-AD 300)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman, early Empire (30 BC-AD 300)"
           },
           "note": "The Roman period (i.e., the early Roman Empire) in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 30 before the birth of Christ and to end in the year 300 after the birth of Christ.",
@@ -8225,7 +8225,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxvtv",
           "label": "Iron Age Southern Levant",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age Southern Levant"
           },
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/iron-age-southern-levant",
@@ -8280,7 +8280,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxwnh",
           "label": "Roman Early Empire/Parthian Middle East (30 BC - AD 226)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Early Empire/Parthian Middle East (30 BC - AD 226)"
           },
           "note": "Early Roman/Parthian",
@@ -8364,7 +8364,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdz28z",
           "label": "Paleolithic Middle East (2600000-18000 BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Paleolithic Middle East (2600000-18000 BC)"
           },
           "note": "ME",
@@ -8428,7 +8428,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdzc7b",
           "label": "Predynastic Egypt (4500-2950 BCE/BC)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Predynastic Egypt (4500-2950 BCE/BC)"
           },
           "note": "The predynastic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
@@ -8464,7 +8464,7 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdzd99",
           "label": "Second Intermediate Period Egypt (1640-1548)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Second Intermediate Period Egypt (1640-1548)"
           },
           "note": "The Second Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
@@ -8546,7 +8546,7 @@
         "p047fhm2753": {
           "id": "p047fhm2753",
           "label": "Early Uruk",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Uruk"
           },
           "source": {
@@ -8585,7 +8585,7 @@
         "p047fhm2b8x": {
           "id": "p047fhm2b8x",
           "label": "Neo-Elamite II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Elamite II"
           },
           "source": {
@@ -8624,7 +8624,7 @@
         "p047fhm2cdk": {
           "id": "p047fhm2cdk",
           "label": "Jamdat Nasr",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Jamdat Nasr"
           },
           "source": {
@@ -8664,7 +8664,7 @@
           "editorialNote": "unsure why GeoDia listed this twice, both inaccurate to the text (2400-2200 B.C. & 2200-2000 B.C.).",
           "id": "p047fhm3bjv",
           "label": "Old Elamite",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Elamite"
           },
           "source": {
@@ -8709,7 +8709,7 @@
           "editorialNote": "unsure why listed in GeoDia with dates 3700-3500 B.C.",
           "id": "p047fhm4kqv",
           "label": "Susa II archaeological period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Susa II archaeological period"
           },
           "note": "Prehistoric Susa II, corresponds to Mesopotamian Ubaid period.",
@@ -8749,7 +8749,7 @@
         "p047fhm6724": {
           "id": "p047fhm6724",
           "label": "Middle Elamite",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Elamite"
           },
           "source": {
@@ -8788,7 +8788,7 @@
         "p047fhm6w33": {
           "id": "p047fhm6w33",
           "label": "Isin-Larsa",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Isin-Larsa"
           },
           "source": {
@@ -8833,7 +8833,7 @@
           "editorialNote": "GeoDia listed the two archaeological periods of Susa I (4200-3700 B.C.) and Susa II (3700-3500 B.C.).",
           "id": "p047fhm6zwb",
           "label": "Susa I archaeological period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Susa I archaeological period"
           },
           "note": "This period designates prehistoric Susa and corresponds to Ubaid period in Mesopotamia.",
@@ -8873,7 +8873,7 @@
         "p047fhm8f6q": {
           "id": "p047fhm8f6q",
           "label": "Isin II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Isin II"
           },
           "source": {
@@ -8912,7 +8912,7 @@
         "p047fhm8h4n": {
           "id": "p047fhm8h4n",
           "label": "Early Dynastic II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic II"
           },
           "source": {
@@ -8951,7 +8951,7 @@
         "p047fhm96xw": {
           "id": "p047fhm96xw",
           "label": "Neo-Babylonian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Babylonian"
           },
           "source": {
@@ -8990,7 +8990,7 @@
         "p047fhmbvkg": {
           "id": "p047fhmbvkg",
           "label": "Early Dynastic III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic III"
           },
           "source": {
@@ -9029,7 +9029,7 @@
         "p047fhmcj3d": {
           "id": "p047fhmcj3d",
           "label": "Prehistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Prehistoric"
           },
           "source": {
@@ -9068,7 +9068,7 @@
         "p047fhmd9qk": {
           "id": "p047fhmd9qk",
           "label": "Late Uruk",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Uruk"
           },
           "source": {
@@ -9107,7 +9107,7 @@
         "p047fhmdzd7": {
           "id": "p047fhmdzd7",
           "label": "Neo-Elamite I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Elamite I"
           },
           "source": {
@@ -9146,7 +9146,7 @@
         "p047fhmgbnq": {
           "id": "p047fhmgbnq",
           "label": "Chalcolithic Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Chalcolithic Age"
           },
           "source": {
@@ -9185,7 +9185,7 @@
         "p047fhmj72p": {
           "id": "p047fhmj72p",
           "label": "Ur III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ur III"
           },
           "source": {
@@ -9224,7 +9224,7 @@
         "p047fhmjvmc": {
           "id": "p047fhmjvmc",
           "label": "Achaemenid",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Achaemenid"
           },
           "source": {
@@ -9263,7 +9263,7 @@
         "p047fhmk34f": {
           "id": "p047fhmk34f",
           "label": "Old Babylonian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Babylonian"
           },
           "source": {
@@ -9302,7 +9302,7 @@
         "p047fhmn3c9": {
           "id": "p047fhmn3c9",
           "label": "Neo-Assyrian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Assyrian"
           },
           "source": {
@@ -9341,7 +9341,7 @@
         "p047fhmrstb": {
           "id": "p047fhmrstb",
           "label": "Achaemenid rule",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Achaemenid rule"
           },
           "source": {
@@ -9380,7 +9380,7 @@
         "p047fhmtmw2": {
           "id": "p047fhmtmw2",
           "label": "Early Dynastic I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic I"
           },
           "source": {
@@ -9419,7 +9419,7 @@
         "p047fhmwtjz": {
           "id": "p047fhmwtjz",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "source": {
@@ -9458,7 +9458,7 @@
         "p047fhmwx27": {
           "id": "p047fhmwx27",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "source": {
@@ -9504,7 +9504,7 @@
           "editorialNote": "Listed as historic period, not archaeological period.",
           "id": "p047fhmxww6",
           "label": "Protoliterate: Proto-Elamite",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Protoliterate: Proto-Elamite"
           },
           "note": "This period corresponds to Proto-Literate period in Mesopotamia.",
@@ -9544,7 +9544,7 @@
         "p047fhmz25b": {
           "id": "p047fhmz25b",
           "label": "Kassite",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Kassite"
           },
           "source": {
@@ -9583,7 +9583,7 @@
         "p047fhmzhs6": {
           "id": "p047fhmzhs6",
           "label": "Akkad",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Akkad"
           },
           "source": {
@@ -9662,7 +9662,7 @@
           },
           "id": "p05krdx2khc",
           "label": "Geometric Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Geometric Period"
           },
           "source": {
@@ -9693,7 +9693,7 @@
         "p05krdx2s4g": {
           "id": "p05krdx2s4g",
           "label": "Early Helladic I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Helladic I"
           },
           "source": {
@@ -9729,7 +9729,7 @@
           },
           "id": "p05krdx3c5h",
           "label": "Middle Helladic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Helladic"
           },
           "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
@@ -9766,7 +9766,7 @@
           },
           "id": "p05krdx4jg8",
           "label": "Hellenistic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic Period"
           },
           "source": {
@@ -9797,7 +9797,7 @@
         "p05krdx4q63": {
           "id": "p05krdx4q63",
           "label": "Middle Byzantine",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Byzantine"
           },
           "source": {
@@ -9833,7 +9833,7 @@
           },
           "id": "p05krdx596r",
           "label": "Archaic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic Period"
           },
           "source": {
@@ -9869,7 +9869,7 @@
           },
           "id": "p05krdx9f8n",
           "label": "Frankish Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Frankish Period"
           },
           "source": {
@@ -9900,7 +9900,7 @@
         "p05krdxb9jd": {
           "id": "p05krdxb9jd",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "source": {
@@ -9931,7 +9931,7 @@
         "p05krdxc69f": {
           "id": "p05krdxc69f",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "source": {
@@ -9962,7 +9962,7 @@
         "p05krdxcxzz": {
           "id": "p05krdxcxzz",
           "label": "Early Helladic II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Helladic II"
           },
           "source": {
@@ -9999,7 +9999,7 @@
           },
           "id": "p05krdxh5gt",
           "label": "Submycenaean and Early Iron Age or Dark Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Submycenaean and Early Iron Age or Dark Age"
           },
           "source": {
@@ -10030,7 +10030,7 @@
         "p05krdxhqpk": {
           "id": "p05krdxhqpk",
           "label": "Late Helladic IIIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIIB"
           },
           "source": {
@@ -10061,7 +10061,7 @@
         "p05krdxjp3v": {
           "id": "p05krdxjp3v",
           "label": "Late Helladic I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic I"
           },
           "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
@@ -10093,7 +10093,7 @@
         "p05krdxjwvz": {
           "id": "p05krdxjwvz",
           "label": "Dark Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Dark Age"
           },
           "source": {
@@ -10129,7 +10129,7 @@
           },
           "id": "p05krdxk56p",
           "label": "Late Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Roman Period"
           },
           "source": {
@@ -10160,7 +10160,7 @@
         "p05krdxk92j": {
           "id": "p05krdxk92j",
           "label": "Frankish Morea",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Frankish Morea"
           },
           "source": {
@@ -10196,7 +10196,7 @@
           },
           "id": "p05krdxktwz",
           "label": "Classical Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classical Period"
           },
           "source": {
@@ -10232,7 +10232,7 @@
           },
           "id": "p05krdxmbs4",
           "label": "Second Ottoman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Second Ottoman Period"
           },
           "source": {
@@ -10263,7 +10263,7 @@
         "p05krdxmkzt": {
           "id": "p05krdxmkzt",
           "label": "Dark Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Dark Age"
           },
           "source": {
@@ -10294,7 +10294,7 @@
         "p05krdxp8np": {
           "id": "p05krdxp8np",
           "label": "Early Helladic III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Helladic III"
           },
           "source": {
@@ -10325,7 +10325,7 @@
         "p05krdxpb2m": {
           "id": "p05krdxpb2m",
           "label": "Early Mycenaean",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Mycenaean"
           },
           "source": {
@@ -10358,7 +10358,7 @@
         "p05krdxqpbh": {
           "id": "p05krdxqpbh",
           "label": "Venetian Rule",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Venetian Rule"
           },
           "source": {
@@ -10394,7 +10394,7 @@
           },
           "id": "p05krdxs4dx",
           "label": "Late Byzantine Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Byzantine Period"
           },
           "source": {
@@ -10430,7 +10430,7 @@
           },
           "id": "p05krdxsdbn",
           "label": "Early Byzantine Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Byzantine Period"
           },
           "source": {
@@ -10467,7 +10467,7 @@
           },
           "id": "p05krdxst2j",
           "label": "First Ottoman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "First Ottoman Period"
           },
           "source": {
@@ -10498,7 +10498,7 @@
         "p05krdxwgcc": {
           "id": "p05krdxwgcc",
           "label": "Early Modern Era",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Modern Era"
           },
           "source": {
@@ -10534,7 +10534,7 @@
           },
           "id": "p05krdxx73v",
           "label": "Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Period"
           },
           "source": {
@@ -10565,7 +10565,7 @@
         "p05krdxx985": {
           "id": "p05krdxx985",
           "label": "Late Helladic IIIC",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIIC"
           },
           "source": {
@@ -10596,7 +10596,7 @@
         "p05krdxxt2k": {
           "id": "p05krdxxt2k",
           "label": "Late Helladic II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic II"
           },
           "source": {
@@ -10632,7 +10632,7 @@
           },
           "id": "p05krdxzrdk",
           "label": "Upper Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Upper Paleolithic"
           },
           "source": {
@@ -10663,7 +10663,7 @@
         "p05krdxzxzd": {
           "id": "p05krdxzxzd",
           "label": "Late Helladic IIIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIIA"
           },
           "source": {
@@ -10720,7 +10720,7 @@
           },
           "id": "p05xnzq8jrm",
           "label": "The Flavians",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "The Flavians"
           },
           "source": {
@@ -10756,7 +10756,7 @@
           },
           "id": "p05xnzq944b",
           "label": "The Severans",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "The Severans"
           },
           "source": {
@@ -10787,7 +10787,7 @@
         "p05xnzqf2tf": {
           "id": "p05xnzqf2tf",
           "label": "High Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "High Empire"
           },
           "source": {
@@ -10845,7 +10845,7 @@
         "p06ptzsnj58": {
           "id": "p06ptzsnj58",
           "label": "Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic"
           },
           "note": "Derived from Leptis Magna Forum Vetus excavations, \"level 4\"; absolute dates determined from Greek material (term. post quem: Late Proto-Corinthian). On Liby-phoenicians, see Birley (1988), Lancel (1995).",
@@ -10893,7 +10893,7 @@
         "p06v8w42cdg": {
           "id": "p06v8w42cdg",
           "label": "Eneolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Eneolithic"
           },
           "spatialCoverage": [
@@ -10920,7 +10920,7 @@
         "p06v8w42chg": {
           "id": "p06v8w42chg",
           "label": "Middle Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Paleolithic"
           },
           "spatialCoverage": [
@@ -10952,7 +10952,7 @@
           },
           "id": "p06v8w42hjz",
           "label": "Neolítico",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Neolítico"
           },
           "spatialCoverage": [
@@ -10979,7 +10979,7 @@
         "p06v8w42jtx": {
           "id": "p06v8w42jtx",
           "label": "Late Antiquity",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Antiquity"
           },
           "spatialCoverage": [
@@ -11006,7 +11006,7 @@
         "p06v8w42mhj": {
           "id": "p06v8w42mhj",
           "label": "Early Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iron Age"
           },
           "spatialCoverage": [
@@ -11033,7 +11033,7 @@
         "p06v8w42mmj": {
           "id": "p06v8w42mmj",
           "label": "Contemporary",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Contemporary"
           },
           "spatialCoverage": [
@@ -11065,7 +11065,7 @@
           },
           "id": "p06v8w42zft",
           "label": "Néolithique",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Néolithique"
           },
           "spatialCoverage": [
@@ -11097,7 +11097,7 @@
           },
           "id": "p06v8w42zp6",
           "label": "Medievale",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Medievale"
           },
           "spatialCoverage": [
@@ -11129,7 +11129,7 @@
           },
           "id": "p06v8w433p2",
           "label": "Mesolithique",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Mesolithique"
           },
           "spatialCoverage": [
@@ -11156,7 +11156,7 @@
         "p06v8w43fhb": {
           "id": "p06v8w43fhb",
           "label": "Modern",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern"
           },
           "spatialCoverage": [
@@ -11183,7 +11183,7 @@
         "p06v8w43gnx": {
           "id": "p06v8w43gnx",
           "label": "Roman Imperial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Imperial"
           },
           "spatialCoverage": [
@@ -11210,7 +11210,7 @@
         "p06v8w43hwk": {
           "id": "p06v8w43hwk",
           "label": "Middle Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Paleolithic"
           },
           "spatialCoverage": [
@@ -11237,7 +11237,7 @@
         "p06v8w43mms": {
           "id": "p06v8w43mms",
           "label": "Hellenistic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic"
           },
           "spatialCoverage": [
@@ -11269,7 +11269,7 @@
           },
           "id": "p06v8w43r5n",
           "label": "Contemporáneo",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Contemporáneo"
           },
           "spatialCoverage": [
@@ -11296,7 +11296,7 @@
         "p06v8w43vr7": {
           "id": "p06v8w43vr7",
           "label": "Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Paleolithic"
           },
           "spatialCoverage": [
@@ -11323,7 +11323,7 @@
         "p06v8w44448": {
           "id": "p06v8w44448",
           "label": "Contemporary",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Contemporary"
           },
           "spatialCoverage": [
@@ -11356,7 +11356,7 @@
           },
           "id": "p06v8w44bj2",
           "label": "Classic/Urban illyrian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classic/Urban illyrian"
           },
           "spatialCoverage": [
@@ -11388,7 +11388,7 @@
           },
           "id": "p06v8w44ckn",
           "label": "Contermporary",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Contermporary"
           },
           "spatialCoverage": [
@@ -11415,7 +11415,7 @@
         "p06v8w44cqz": {
           "id": "p06v8w44cqz",
           "label": "Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Period"
           },
           "spatialCoverage": [
@@ -11447,7 +11447,7 @@
           },
           "id": "p06v8w44jbs",
           "label": "Неоліт",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Неоліт"
           },
           "spatialCoverage": [
@@ -11478,7 +11478,7 @@
           },
           "id": "p06v8w44qmx",
           "label": "Tardoantiguo",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Tardoantiguo"
           },
           "spatialCoverage": [
@@ -11510,7 +11510,7 @@
           },
           "id": "p06v8w44qsm",
           "label": "Фінальний палеоліт",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Фінальний палеоліт"
           },
           "spatialCoverage": [
@@ -11536,7 +11536,7 @@
         "p06v8w44sk7": {
           "id": "p06v8w44sk7",
           "label": "Early Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
           "spatialCoverage": [
@@ -11563,7 +11563,7 @@
         "p06v8w44t6t": {
           "id": "p06v8w44t6t",
           "label": "Eneolothic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Eneolothic"
           },
           "spatialCoverage": [
@@ -11590,7 +11590,7 @@
         "p06v8w45852": {
           "id": "p06v8w45852",
           "label": "Orientalizing",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Orientalizing"
           },
           "spatialCoverage": [
@@ -11622,7 +11622,7 @@
           },
           "id": "p06v8w45hnr",
           "label": "Гуни",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Гуни"
           },
           "spatialCoverage": [
@@ -11648,7 +11648,7 @@
         "p06v8w45j9q": {
           "id": "p06v8w45j9q",
           "label": "Early Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iron Age"
           },
           "spatialCoverage": [
@@ -11680,7 +11680,7 @@
           },
           "id": "p06v8w45rp6",
           "label": "Готи",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Готи"
           },
           "spatialCoverage": [
@@ -11706,7 +11706,7 @@
         "p06v8w45wr2": {
           "id": "p06v8w45wr2",
           "label": "Lower Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lower Paleolithic"
           },
           "spatialCoverage": [
@@ -11733,7 +11733,7 @@
         "p06v8w464hf": {
           "id": "p06v8w464hf",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -11760,7 +11760,7 @@
         "p06v8w4658d": {
           "id": "p06v8w4658d",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "spatialCoverage": [
@@ -11787,7 +11787,7 @@
         "p06v8w4668p": {
           "id": "p06v8w4668p",
           "label": "Late Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Iron Age"
           },
           "spatialCoverage": [
@@ -11819,7 +11819,7 @@
           },
           "id": "p06v8w46crt",
           "label": "Romaine",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Romaine"
           },
           "spatialCoverage": [
@@ -11851,7 +11851,7 @@
           },
           "id": "p06v8w46cth",
           "label": "Давня Русь",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Давня Русь"
           },
           "spatialCoverage": [
@@ -11877,7 +11877,7 @@
         "p06v8w46tp2": {
           "id": "p06v8w46tp2",
           "label": "Ottoman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ottoman Period"
           },
           "spatialCoverage": [
@@ -11904,7 +11904,7 @@
         "p06v8w472bf": {
           "id": "p06v8w472bf",
           "label": "Early Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Medieval"
           },
           "spatialCoverage": [
@@ -11931,7 +11931,7 @@
         "p06v8w473dd": {
           "id": "p06v8w473dd",
           "label": "Early Imperial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Imperial"
           },
           "spatialCoverage": [
@@ -11958,7 +11958,7 @@
         "p06v8w4742c": {
           "id": "p06v8w4742c",
           "label": "Early Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
           "spatialCoverage": [
@@ -11985,7 +11985,7 @@
         "p06v8w477w8": {
           "id": "p06v8w477w8",
           "label": "Late Archaic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Archaic Period"
           },
           "spatialCoverage": [
@@ -12012,7 +12012,7 @@
         "p06v8w47bs5": {
           "id": "p06v8w47bs5",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "spatialCoverage": [
@@ -12039,7 +12039,7 @@
         "p06v8w47d2q": {
           "id": "p06v8w47d2q",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "spatialCoverage": [
@@ -12066,7 +12066,7 @@
         "p06v8w47hqx": {
           "id": "p06v8w47hqx",
           "label": "Classical Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classical Period"
           },
           "spatialCoverage": [
@@ -12098,7 +12098,7 @@
           },
           "id": "p06v8w47jcw",
           "label": "Bronz i vonë",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Bronz i vonë"
           },
           "spatialCoverage": [
@@ -12125,7 +12125,7 @@
         "p06v8w47jgw": {
           "id": "p06v8w47jgw",
           "label": "Roman Republican",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Republican"
           },
           "spatialCoverage": [
@@ -12158,7 +12158,7 @@
           },
           "id": "p06v8w47m8h",
           "label": "Archaic/Protourban illyrian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic/Protourban illyrian"
           },
           "spatialCoverage": [
@@ -12185,7 +12185,7 @@
         "p06v8w47prr": {
           "id": "p06v8w47prr",
           "label": "Lower Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lower Paleolithic"
           },
           "spatialCoverage": [
@@ -12212,7 +12212,7 @@
         "p06v8w47xjt": {
           "id": "p06v8w47xjt",
           "label": "Early Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Medieval"
           },
           "spatialCoverage": [
@@ -12239,7 +12239,7 @@
         "p06v8w483mn": {
           "id": "p06v8w483mn",
           "label": "Early Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
           "spatialCoverage": [
@@ -12266,7 +12266,7 @@
         "p06v8w485jk": {
           "id": "p06v8w485jk",
           "label": "Ottoman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ottoman"
           },
           "spatialCoverage": [
@@ -12293,7 +12293,7 @@
         "p06v8w48b3q": {
           "id": "p06v8w48b3q",
           "label": "Upper Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Upper Paleolithic"
           },
           "spatialCoverage": [
@@ -12325,7 +12325,7 @@
           },
           "id": "p06v8w48qxz",
           "label": "Paleolit i vonë",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Paleolit i vonë"
           },
           "spatialCoverage": [
@@ -12352,7 +12352,7 @@
         "p06v8w48r2x": {
           "id": "p06v8w48r2x",
           "label": "Lower Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lower Paleolithic"
           },
           "spatialCoverage": [
@@ -12384,7 +12384,7 @@
           },
           "id": "p06v8w496hs",
           "label": "Moderne",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Moderne"
           },
           "spatialCoverage": [
@@ -12411,7 +12411,7 @@
         "p06v8w498hd": {
           "id": "p06v8w498hd",
           "label": "Early Imperial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Imperial"
           },
           "spatialCoverage": [
@@ -12443,7 +12443,7 @@
           },
           "id": "p06v8w49hzs",
           "label": "Perandorake e hershme",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Perandorake e hershme"
           },
           "spatialCoverage": [
@@ -12476,7 +12476,7 @@
           },
           "id": "p06v8w49mp2",
           "label": "Klasike/Qytetare ilire",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Klasike/Qytetare ilire"
           },
           "spatialCoverage": [
@@ -12503,7 +12503,7 @@
         "p06v8w49pkm": {
           "id": "p06v8w49pkm",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "spatialCoverage": [
@@ -12530,7 +12530,7 @@
         "p06v8w49z2z": {
           "id": "p06v8w49z2z",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -12563,7 +12563,7 @@
           },
           "id": "p06v8w4b3x6",
           "label": "Classic/Urban illyrian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classic/Urban illyrian"
           },
           "spatialCoverage": [
@@ -12590,7 +12590,7 @@
         "p06v8w4bf8s": {
           "id": "p06v8w4bf8s",
           "label": "Late Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Iron Age"
           },
           "spatialCoverage": [
@@ -12617,7 +12617,7 @@
         "p06v8w4bh2d": {
           "id": "p06v8w4bh2d",
           "label": "Contemporary",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Contemporary"
           },
           "spatialCoverage": [
@@ -12644,7 +12644,7 @@
         "p06v8w4bh8d": {
           "id": "p06v8w4bh8d",
           "label": "Hellenistic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic Period"
           },
           "spatialCoverage": [
@@ -12676,7 +12676,7 @@
           },
           "id": "p06v8w4bjgp",
           "label": "Paleolit i mesëm",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Paleolit i mesëm"
           },
           "spatialCoverage": [
@@ -12708,7 +12708,7 @@
           },
           "id": "p06v8w4bk7n",
           "label": "Доба середньої бронзи",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Доба середньої бронзи"
           },
           "spatialCoverage": [
@@ -12734,7 +12734,7 @@
         "p06v8w4bm9m": {
           "id": "p06v8w4bm9m",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -12766,7 +12766,7 @@
           },
           "id": "p06v8w4bnqw",
           "label": "Новітня доба",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Новітня доба"
           },
           "spatialCoverage": [
@@ -12797,7 +12797,7 @@
           },
           "id": "p06v8w4bnsk",
           "label": "Bronz i hershëm",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Bronz i hershëm"
           },
           "spatialCoverage": [
@@ -12829,7 +12829,7 @@
           },
           "id": "p06v8w4br75",
           "label": "Eneolit",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Eneolit"
           },
           "spatialCoverage": [
@@ -12856,7 +12856,7 @@
         "p06v8w4br8g": {
           "id": "p06v8w4br8g",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -12883,7 +12883,7 @@
         "p06v8w4brkg": {
           "id": "p06v8w4brkg",
           "label": "Lower Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lower Paleolithic"
           },
           "spatialCoverage": [
@@ -12915,7 +12915,7 @@
           },
           "id": "p06v8w4bz9k",
           "label": "Age de Bronze",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Age de Bronze"
           },
           "spatialCoverage": [
@@ -12942,7 +12942,7 @@
         "p06v8w4bzqk": {
           "id": "p06v8w4bzqk",
           "label": "Early Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Medieval"
           },
           "spatialCoverage": [
@@ -12969,7 +12969,7 @@
         "p06v8w4c45d": {
           "id": "p06v8w4c45d",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -13001,7 +13001,7 @@
           },
           "id": "p06v8w4cgf2",
           "label": "Пізньоантичний період",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Пізньоантичний період"
           },
           "spatialCoverage": [
@@ -13027,7 +13027,7 @@
         "p06v8w4ct7z": {
           "id": "p06v8w4ct7z",
           "label": "Late Antique",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Antique"
           },
           "spatialCoverage": [
@@ -13054,7 +13054,7 @@
         "p06v8w4d47b": {
           "id": "p06v8w4d47b",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "spatialCoverage": [
@@ -13081,7 +13081,7 @@
         "p06v8w4d6hk": {
           "id": "p06v8w4d6hk",
           "label": "Early Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
           "spatialCoverage": [
@@ -13114,7 +13114,7 @@
           },
           "id": "p06v8w4d6vw",
           "label": "Arkaike/Para qytetare ilire",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Arkaike/Para qytetare ilire"
           },
           "spatialCoverage": [
@@ -13141,7 +13141,7 @@
         "p06v8w4d8wt": {
           "id": "p06v8w4d8wt",
           "label": "Modern",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern"
           },
           "spatialCoverage": [
@@ -13173,7 +13173,7 @@
           },
           "id": "p06v8w4dbcf",
           "label": "Ранньоримський період",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Ранньоримський період"
           },
           "spatialCoverage": [
@@ -13199,7 +13199,7 @@
         "p06v8w4dsjx": {
           "id": "p06v8w4dsjx",
           "label": "Ottoman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ottoman Period"
           },
           "spatialCoverage": [
@@ -13226,7 +13226,7 @@
         "p06v8w4dxn5": {
           "id": "p06v8w4dxn5",
           "label": "Middle Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Paleolithic"
           },
           "spatialCoverage": [
@@ -13253,7 +13253,7 @@
         "p06v8w4f2wb": {
           "id": "p06v8w4f2wb",
           "label": "Middle Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
           "spatialCoverage": [
@@ -13280,7 +13280,7 @@
         "p06v8w4f6kh": {
           "id": "p06v8w4f6kh",
           "label": "Early Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iron Age"
           },
           "spatialCoverage": [
@@ -13312,7 +13312,7 @@
           },
           "id": "p06v8w4f854",
           "label": "Пізньоримський та гунський період",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Пізньоримський та гунський період"
           },
           "spatialCoverage": [
@@ -13343,7 +13343,7 @@
           },
           "id": "p06v8w4fpkn",
           "label": "Мезоліт",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Мезоліт"
           },
           "spatialCoverage": [
@@ -13374,7 +13374,7 @@
           },
           "id": "p06v8w4ft2t",
           "label": "Mauretaine",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Mauretaine"
           },
           "spatialCoverage": [
@@ -13401,7 +13401,7 @@
         "p06v8w4ftt6": {
           "id": "p06v8w4ftt6",
           "label": "Upper Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Upper Paleolithic"
           },
           "spatialCoverage": [
@@ -13433,7 +13433,7 @@
           },
           "id": "p06v8w4g2dw",
           "label": "Раннє Середньовіччя",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Раннє Середньовіччя"
           },
           "spatialCoverage": [
@@ -13459,7 +13459,7 @@
         "p06v8w4g2pk": {
           "id": "p06v8w4g2pk",
           "label": "Early Medieval Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Medieval Period"
           },
           "spatialCoverage": [
@@ -13486,7 +13486,7 @@
         "p06v8w4g9dz": {
           "id": "p06v8w4g9dz",
           "label": "Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic"
           },
           "spatialCoverage": [
@@ -13518,7 +13518,7 @@
           },
           "id": "p06v8w4gj5q",
           "label": "Класичний період",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Класичний період"
           },
           "spatialCoverage": [
@@ -13549,7 +13549,7 @@
           },
           "id": "p06v8w4gm4z",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Medieval"
           },
           "spatialCoverage": [
@@ -13576,7 +13576,7 @@
         "p06v8w4gs35": {
           "id": "p06v8w4gs35",
           "label": "Republican",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Republican"
           },
           "spatialCoverage": [
@@ -13603,7 +13603,7 @@
         "p06v8w4gt6f": {
           "id": "p06v8w4gt6f",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "spatialCoverage": [
@@ -13635,7 +13635,7 @@
           },
           "id": "p06v8w4gw62",
           "label": "Нова доба",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Нова доба"
           },
           "spatialCoverage": [
@@ -13661,7 +13661,7 @@
         "p06v8w4gxzn": {
           "id": "p06v8w4gxzn",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "spatialCoverage": [
@@ -13688,7 +13688,7 @@
         "p06v8w4h3w5": {
           "id": "p06v8w4h3w5",
           "label": "Late Medieval Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Medieval Period"
           },
           "spatialCoverage": [
@@ -13720,7 +13720,7 @@
           },
           "id": "p06v8w4h4qr",
           "label": "Пізньолатенський період",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Пізньолатенський період"
           },
           "spatialCoverage": [
@@ -13746,7 +13746,7 @@
         "p06v8w4hk6m": {
           "id": "p06v8w4hk6m",
           "label": "Eneolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Eneolithic"
           },
           "spatialCoverage": [
@@ -13778,7 +13778,7 @@
           },
           "id": "p06v8w4htwc",
           "label": "Елліністичний період",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Елліністичний період"
           },
           "spatialCoverage": [
@@ -13809,7 +13809,7 @@
           },
           "id": "p06v8w4hx4w",
           "label": "Republikane",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Republikane"
           },
           "spatialCoverage": [
@@ -13841,7 +13841,7 @@
           },
           "id": "p06v8w4hzqv",
           "label": "Доба ранньої бронзи",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Доба ранньої бронзи"
           },
           "spatialCoverage": [
@@ -13872,7 +13872,7 @@
           },
           "id": "p06v8w4j58z",
           "label": "Moderno",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Moderno"
           },
           "spatialCoverage": [
@@ -13899,7 +13899,7 @@
         "p06v8w4j6g9": {
           "id": "p06v8w4j6g9",
           "label": "Modern Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern Period"
           },
           "spatialCoverage": [
@@ -13932,7 +13932,7 @@
           },
           "id": "p06v8w4j9dh",
           "label": "Archaic/Protourban illyrian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic/Protourban illyrian"
           },
           "spatialCoverage": [
@@ -13964,7 +13964,7 @@
           },
           "id": "p06v8w4jhjm",
           "label": "Mezolit",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Mezolit"
           },
           "spatialCoverage": [
@@ -13991,7 +13991,7 @@
         "p06v8w4jmrh": {
           "id": "p06v8w4jmrh",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval"
           },
           "spatialCoverage": [
@@ -14018,7 +14018,7 @@
         "p06v8w4jr7p": {
           "id": "p06v8w4jr7p",
           "label": "Transitional Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Transitional Period"
           },
           "spatialCoverage": [
@@ -14050,7 +14050,7 @@
           },
           "id": "p06v8w4jrfp",
           "label": "Доба фінальної бронзи",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Доба фінальної бронзи"
           },
           "spatialCoverage": [
@@ -14076,7 +14076,7 @@
         "p06v8w4k28c": {
           "id": "p06v8w4k28c",
           "label": "Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Period"
           },
           "spatialCoverage": [
@@ -14103,7 +14103,7 @@
         "p06v8w4k39z": {
           "id": "p06v8w4k39z",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "spatialCoverage": [
@@ -14130,7 +14130,7 @@
         "p06v8w4k59k": {
           "id": "p06v8w4k59k",
           "label": "Medieval/Byzantine",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval/Byzantine"
           },
           "spatialCoverage": [
@@ -14157,7 +14157,7 @@
         "p06v8w4k77h": {
           "id": "p06v8w4k77h",
           "label": "Roman Republican",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Republican"
           },
           "spatialCoverage": [
@@ -14184,7 +14184,7 @@
         "p06v8w4k7fh": {
           "id": "p06v8w4k7fh",
           "label": "Migrations Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Migrations Period"
           },
           "spatialCoverage": [
@@ -14211,7 +14211,7 @@
         "p06v8w4k8xg": {
           "id": "p06v8w4k8xg",
           "label": "Middle Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
           "spatialCoverage": [
@@ -14243,7 +14243,7 @@
           },
           "id": "p06v8w4kbt3",
           "label": "Mesjetë e hershme",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Mesjetë e hershme"
           },
           "spatialCoverage": [
@@ -14270,7 +14270,7 @@
         "p06v8w4kcjp": {
           "id": "p06v8w4kcjp",
           "label": "Eneolothic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Eneolothic"
           },
           "spatialCoverage": [
@@ -14297,7 +14297,7 @@
         "p06v8w4kg5w": {
           "id": "p06v8w4kg5w",
           "label": "Classical",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classical"
           },
           "spatialCoverage": [
@@ -14324,7 +14324,7 @@
         "p06v8w4kqqb": {
           "id": "p06v8w4kqqb",
           "label": "Bronze age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze age"
           },
           "spatialCoverage": [
@@ -14351,7 +14351,7 @@
         "p06v8w4ksmw": {
           "id": "p06v8w4ksmw",
           "label": "Early Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Roman Period"
           },
           "spatialCoverage": [
@@ -14378,7 +14378,7 @@
         "p06v8w4kw45": {
           "id": "p06v8w4kw45",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "spatialCoverage": [
@@ -14410,7 +14410,7 @@
           },
           "id": "p06v8w4m9zc",
           "label": "Perandorake e vonë",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Perandorake e vonë"
           },
           "spatialCoverage": [
@@ -14437,7 +14437,7 @@
         "p06v8w4mbjn": {
           "id": "p06v8w4mbjn",
           "label": "Late Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Roman Period"
           },
           "spatialCoverage": [
@@ -14469,7 +14469,7 @@
           },
           "id": "p06v8w4mc59",
           "label": "Римський період",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Римський період"
           },
           "spatialCoverage": [
@@ -14495,7 +14495,7 @@
         "p06v8w4mhr5": {
           "id": "p06v8w4mhr5",
           "label": "Middle Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Paleolithic"
           },
           "spatialCoverage": [
@@ -14522,7 +14522,7 @@
         "p06v8w4mj94": {
           "id": "p06v8w4mj94",
           "label": "Upper Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Upper Paleolithic"
           },
           "spatialCoverage": [
@@ -14555,7 +14555,7 @@
           },
           "id": "p06v8w4mkjq",
           "label": "Mesjetë /Bizantine",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Mesjetë /Bizantine"
           },
           "spatialCoverage": [
@@ -14582,7 +14582,7 @@
         "p06v8w4mnmz": {
           "id": "p06v8w4mnmz",
           "label": "Modern",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern"
           },
           "spatialCoverage": [
@@ -14609,7 +14609,7 @@
         "p06v8w4mqnw": {
           "id": "p06v8w4mqnw",
           "label": "Hellenistic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic"
           },
           "spatialCoverage": [
@@ -14636,7 +14636,7 @@
         "p06v8w4mwbd": {
           "id": "p06v8w4mwbd",
           "label": "Early Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iron Age"
           },
           "spatialCoverage": [
@@ -14663,7 +14663,7 @@
         "p06v8w4mwsq": {
           "id": "p06v8w4mwsq",
           "label": "Upper Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Upper Paleolithic"
           },
           "spatialCoverage": [
@@ -14690,7 +14690,7 @@
         "p06v8w4n594": {
           "id": "p06v8w4n594",
           "label": "Mid Imperial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mid Imperial"
           },
           "spatialCoverage": [
@@ -14722,7 +14722,7 @@
           },
           "id": "p06v8w4n66d",
           "label": "Contemporaine",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Contemporaine"
           },
           "spatialCoverage": [
@@ -14754,7 +14754,7 @@
           },
           "id": "p06v8w4ncv7",
           "label": "Енеоліт",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Енеоліт"
           },
           "spatialCoverage": [
@@ -14785,7 +14785,7 @@
           },
           "id": "p06v8w4nfqg",
           "label": "Bashkëkohore",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Bashkëkohore"
           },
           "spatialCoverage": [
@@ -14812,7 +14812,7 @@
         "p06v8w4ntkd": {
           "id": "p06v8w4ntkd",
           "label": "Late Antique",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Antique"
           },
           "spatialCoverage": [
@@ -14844,7 +14844,7 @@
           },
           "id": "p06v8w4p3qr",
           "label": "Paléolithique inférieur",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Paléolithique inférieur"
           },
           "spatialCoverage": [
@@ -14871,7 +14871,7 @@
         "p06v8w4p3r4": {
           "id": "p06v8w4p3r4",
           "label": "Upper Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Upper Paleolithic"
           },
           "spatialCoverage": [
@@ -14903,7 +14903,7 @@
           },
           "id": "p06v8w4pmpv",
           "label": "Calcolítico",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Calcolítico"
           },
           "spatialCoverage": [
@@ -14935,7 +14935,7 @@
           },
           "id": "p06v8w4pndh",
           "label": "Сармати",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Сармати"
           },
           "spatialCoverage": [
@@ -14961,7 +14961,7 @@
         "p06v8w4pr9d": {
           "id": "p06v8w4pr9d",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "spatialCoverage": [
@@ -14993,7 +14993,7 @@
           },
           "id": "p06v8w4q5mm",
           "label": "Edad del Bronce",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Edad del Bronce"
           },
           "spatialCoverage": [
@@ -15020,7 +15020,7 @@
         "p06v8w4qcqd": {
           "id": "p06v8w4qcqd",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "spatialCoverage": [
@@ -15052,7 +15052,7 @@
           },
           "id": "p06v8w4qf9z",
           "label": "Tard Antiquité",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Tard Antiquité"
           },
           "spatialCoverage": [
@@ -15079,7 +15079,7 @@
         "p06v8w4qjz7": {
           "id": "p06v8w4qjz7",
           "label": "Contemporary",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Contemporary"
           },
           "spatialCoverage": [
@@ -15111,7 +15111,7 @@
           },
           "id": "p06v8w4qp2q",
           "label": "Архаїчний період",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Архаїчний період"
           },
           "spatialCoverage": [
@@ -15137,7 +15137,7 @@
         "p06v8w4qpcq": {
           "id": "p06v8w4qpcq",
           "label": "Late Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Iron Age"
           },
           "spatialCoverage": [
@@ -15169,7 +15169,7 @@
           },
           "id": "p06v8w4qpm3",
           "label": "Нижній палеоліт",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Нижній палеоліт"
           },
           "spatialCoverage": [
@@ -15195,7 +15195,7 @@
         "p06v8w4qsn9": {
           "id": "p06v8w4qsn9",
           "label": "Orientalizing",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Orientalizing"
           },
           "spatialCoverage": [
@@ -15227,7 +15227,7 @@
           },
           "id": "p06v8w4qsqx",
           "label": "Mesolítico",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Mesolítico"
           },
           "spatialCoverage": [
@@ -15259,7 +15259,7 @@
           },
           "id": "p06v8w4qswm",
           "label": "Paleolítico medio",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Paleolítico medio"
           },
           "spatialCoverage": [
@@ -15286,7 +15286,7 @@
         "p06v8w4qwz6": {
           "id": "p06v8w4qwz6",
           "label": "Middle Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Paleolithic"
           },
           "spatialCoverage": [
@@ -15313,7 +15313,7 @@
         "p06v8w4qz54": {
           "id": "p06v8w4qz54",
           "label": "Middle Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
           "spatialCoverage": [
@@ -15340,7 +15340,7 @@
         "p06v8w4r43k": {
           "id": "p06v8w4r43k",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -15372,7 +15372,7 @@
           },
           "id": "p06v8w4r785",
           "label": "Середній палеоліт",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Середній палеоліт"
           },
           "spatialCoverage": [
@@ -15403,7 +15403,7 @@
           },
           "id": "p06v8w4rbc2",
           "label": "Helenistike",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Helenistike"
           },
           "spatialCoverage": [
@@ -15435,7 +15435,7 @@
           },
           "id": "p06v8w4s3k7",
           "label": "Paleolit i hershëm",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Paleolit i hershëm"
           },
           "spatialCoverage": [
@@ -15467,7 +15467,7 @@
           },
           "id": "p06v8w4s5q5",
           "label": "Paléolithique moyen",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Paléolithique moyen"
           },
           "spatialCoverage": [
@@ -15499,7 +15499,7 @@
           },
           "id": "p06v8w4s5zg",
           "label": "Кіммерійці",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Кіммерійці"
           },
           "spatialCoverage": [
@@ -15530,7 +15530,7 @@
           },
           "id": "p06v8w4s9pz",
           "label": "Edad del Hierro",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Edad del Hierro"
           },
           "spatialCoverage": [
@@ -15557,7 +15557,7 @@
         "p06v8w4sdnj": {
           "id": "p06v8w4sdnj",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval"
           },
           "spatialCoverage": [
@@ -15589,7 +15589,7 @@
           },
           "id": "p06v8w4sm9z",
           "label": "Hekur i zhvilluar",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Hekur i zhvilluar"
           },
           "spatialCoverage": [
@@ -15621,7 +15621,7 @@
           },
           "id": "p06v8w4spfw",
           "label": "Скіфи",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Скіфи"
           },
           "spatialCoverage": [
@@ -15647,7 +15647,7 @@
         "p06v8w4spnw": {
           "id": "p06v8w4spnw",
           "label": "Ottoman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ottoman"
           },
           "spatialCoverage": [
@@ -15674,7 +15674,7 @@
         "p06v8w4ss9g": {
           "id": "p06v8w4ss9g",
           "label": "Lower Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lower Paleolithic"
           },
           "spatialCoverage": [
@@ -15701,7 +15701,7 @@
         "p06v8w4ssdg": {
           "id": "p06v8w4ssdg",
           "label": "Late Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Iron Age"
           },
           "spatialCoverage": [
@@ -15728,7 +15728,7 @@
         "p06v8w4swtc": {
           "id": "p06v8w4swtc",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -15755,7 +15755,7 @@
         "p06v8w4sz8m": {
           "id": "p06v8w4sz8m",
           "label": "Ottoman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ottoman Period"
           },
           "spatialCoverage": [
@@ -15787,7 +15787,7 @@
           },
           "id": "p06v8w4t56d",
           "label": "Залізний вік",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Залізний вік"
           },
           "spatialCoverage": [
@@ -15813,7 +15813,7 @@
         "p06v8w4t5td": {
           "id": "p06v8w4t5td",
           "label": "Late Imperial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Imperial"
           },
           "spatialCoverage": [
@@ -15845,7 +15845,7 @@
           },
           "id": "p06v8w4tcnh",
           "label": "Romano imperial",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Romano imperial"
           },
           "spatialCoverage": [
@@ -15877,7 +15877,7 @@
           },
           "id": "p06v8w4trxf",
           "label": "Козаччина",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Козаччина"
           },
           "spatialCoverage": [
@@ -15908,7 +15908,7 @@
           },
           "id": "p06v8w4tswd",
           "label": "Moderne",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Moderne"
           },
           "spatialCoverage": [
@@ -15940,7 +15940,7 @@
           },
           "id": "p06v8w4v2r4",
           "label": "Доба пізньої бронзи",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Доба пізньої бронзи"
           },
           "spatialCoverage": [
@@ -15966,7 +15966,7 @@
         "p06v8w4v3h3": {
           "id": "p06v8w4v3h3",
           "label": "Late Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Medieval"
           },
           "spatialCoverage": [
@@ -15998,7 +15998,7 @@
           },
           "id": "p06v8w4v6xx",
           "label": "Paleolítico superior",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Paleolítico superior"
           },
           "spatialCoverage": [
@@ -16025,7 +16025,7 @@
         "p06v8w4v7jk": {
           "id": "p06v8w4v7jk",
           "label": "Eneolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Eneolithic"
           },
           "spatialCoverage": [
@@ -16057,7 +16057,7 @@
           },
           "id": "p06v8w4v9b6",
           "label": "Paléolithique supérieur",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Paléolithique supérieur"
           },
           "spatialCoverage": [
@@ -16089,7 +16089,7 @@
           },
           "id": "p06v8w4vck4",
           "label": "Bronz i mesëm",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Bronz i mesëm"
           },
           "spatialCoverage": [
@@ -16116,7 +16116,7 @@
         "p06v8w4vdj3": {
           "id": "p06v8w4vdj3",
           "label": "Eneolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Eneolithic"
           },
           "spatialCoverage": [
@@ -16143,7 +16143,7 @@
         "p06v8w4vkx7": {
           "id": "p06v8w4vkx7",
           "label": "Mid Imperial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mid Imperial"
           },
           "spatialCoverage": [
@@ -16170,7 +16170,7 @@
         "p06v8w4vkzj": {
           "id": "p06v8w4vkzj",
           "label": "Upper Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Upper Paleolithic"
           },
           "spatialCoverage": [
@@ -16197,7 +16197,7 @@
         "p06v8w4vpq4": {
           "id": "p06v8w4vpq4",
           "label": "Modern",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern"
           },
           "spatialCoverage": [
@@ -16224,7 +16224,7 @@
         "p06v8w4vzs5": {
           "id": "p06v8w4vzs5",
           "label": "Lower Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lower Paleolithic"
           },
           "spatialCoverage": [
@@ -16256,7 +16256,7 @@
           },
           "id": "p06v8w4w2bc",
           "label": "Enéolithique",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Enéolithique"
           },
           "spatialCoverage": [
@@ -16283,7 +16283,7 @@
         "p06v8w4w4jx": {
           "id": "p06v8w4w4jx",
           "label": "Transitional Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Transitional Period"
           },
           "spatialCoverage": [
@@ -16315,7 +16315,7 @@
           },
           "id": "p06v8w4w68v",
           "label": "Пізнє Середньовіччя",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Пізнє Середньовіччя"
           },
           "spatialCoverage": [
@@ -16341,7 +16341,7 @@
         "p06v8w4wf39": {
           "id": "p06v8w4wf39",
           "label": "Middle Paleolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Paleolithic"
           },
           "spatialCoverage": [
@@ -16368,7 +16368,7 @@
         "p06v8w4wh77": {
           "id": "p06v8w4wh77",
           "label": "Middle Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
           "spatialCoverage": [
@@ -16400,7 +16400,7 @@
           },
           "id": "p06v8w4wpdc",
           "label": "Hekuri i hershëm",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Hekuri i hershëm"
           },
           "spatialCoverage": [
@@ -16427,7 +16427,7 @@
         "p06v8w4wq7z": {
           "id": "p06v8w4wq7z",
           "label": "Republican",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Republican"
           },
           "spatialCoverage": [
@@ -16454,7 +16454,7 @@
         "p06v8w4wrf9": {
           "id": "p06v8w4wrf9",
           "label": "Contemporary",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Contemporary"
           },
           "spatialCoverage": [
@@ -16481,7 +16481,7 @@
         "p06v8w4ww7g": {
           "id": "p06v8w4ww7g",
           "label": "Transitional Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Transitional Period"
           },
           "spatialCoverage": [
@@ -16513,7 +16513,7 @@
           },
           "id": "p06v8w4x3fw",
           "label": "Paleolítico inferior",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Paleolítico inferior"
           },
           "spatialCoverage": [
@@ -16545,7 +16545,7 @@
           },
           "id": "p06v8w4x4sj",
           "label": "Punique",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Punique"
           },
           "spatialCoverage": [
@@ -16577,7 +16577,7 @@
           },
           "id": "p06v8w4x58t",
           "label": "Osmane",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Osmane"
           },
           "spatialCoverage": [
@@ -16604,7 +16604,7 @@
         "p06v8w4xb4z": {
           "id": "p06v8w4xb4z",
           "label": "Roman Imperial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Imperial"
           },
           "spatialCoverage": [
@@ -16631,7 +16631,7 @@
         "p06v8w4xcwm": {
           "id": "p06v8w4xcwm",
           "label": "Late Imperial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Imperial"
           },
           "spatialCoverage": [
@@ -16664,7 +16664,7 @@
           },
           "id": "p06v8w4xdt8",
           "label": "Medieval/Byzantine",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval/Byzantine"
           },
           "spatialCoverage": [
@@ -16696,7 +16696,7 @@
           },
           "id": "p06v8w4xtf5",
           "label": "Perandorake e mesme",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Perandorake e mesme"
           },
           "spatialCoverage": [
@@ -16728,7 +16728,7 @@
           },
           "id": "p06v8w4xz8n",
           "label": "Neolit",
-          "localizedLabel": {
+          "originalLabel": {
             "als-latn": "Neolit"
           },
           "spatialCoverage": [
@@ -16755,7 +16755,7 @@
         "p06v8w4xzmz": {
           "id": "p06v8w4xzmz",
           "label": "Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Period"
           },
           "spatialCoverage": [
@@ -16782,7 +16782,7 @@
         "p06v8w4z4ng": {
           "id": "p06v8w4z4ng",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval"
           },
           "spatialCoverage": [
@@ -16809,7 +16809,7 @@
         "p06v8w4z7d2": {
           "id": "p06v8w4z7d2",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "spatialCoverage": [
@@ -16836,7 +16836,7 @@
         "p06v8w4z7h2": {
           "id": "p06v8w4z7h2",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -16863,7 +16863,7 @@
         "p06v8w4z929": {
           "id": "p06v8w4z929",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "spatialCoverage": [
@@ -16890,7 +16890,7 @@
         "p06v8w4z9mm": {
           "id": "p06v8w4z9mm",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -16922,7 +16922,7 @@
           },
           "id": "p06v8w4zbxw",
           "label": "Верхній палеоліт",
-          "localizedLabel": {
+          "originalLabel": {
             "ukr-cyrl": "Верхній палеоліт"
           },
           "spatialCoverage": [
@@ -16948,7 +16948,7 @@
         "p06v8w4zmbm": {
           "id": "p06v8w4zmbm",
           "label": "Late Antiquity",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Antiquity"
           },
           "spatialCoverage": [
@@ -16975,7 +16975,7 @@
         "p06v8w4ztd3": {
           "id": "p06v8w4ztd3",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -17002,7 +17002,7 @@
         "p06v8w4zx49": {
           "id": "p06v8w4zx49",
           "label": "Eneolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Eneolithic"
           },
           "spatialCoverage": [
@@ -17054,7 +17054,7 @@
           },
           "id": "p06xc6mq829",
           "label": "Early Iberian Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iberian Period"
           },
           "spatialCoverage": [
@@ -17086,7 +17086,7 @@
           },
           "id": "p06xc6mvjx2",
           "label": "Classical Iberian Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classical Iberian Period"
           },
           "note": "Equivalent to Iberian III (450-350 B.C.) and IV (350-200 B.C.) - cf. M. Diaz-Andreu & S. Keay, 1997. The Archaeology of Iberia; Dominguez in C. Sanchez & G.R. Tsetskhladze, 2001. Greek Pottery from the Iberian Peninsula.",
@@ -17134,7 +17134,7 @@
         "p077fc55t8z": {
           "id": "p077fc55t8z",
           "label": "Iron IIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron IIA"
           },
           "source": {
@@ -17171,7 +17171,7 @@
           "editorialNote": "this date: see also Mazar, 1992",
           "id": "p077fc5wb89",
           "label": "Iron III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron III"
           },
           "source": {
@@ -17202,7 +17202,7 @@
         "p077fc5wk2c": {
           "id": "p077fc5wk2c",
           "label": "Iron IIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron IIB"
           },
           "source": {
@@ -17233,7 +17233,7 @@
         "p077fc5wvfd": {
           "id": "p077fc5wvfd",
           "label": "Iron IIC",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron IIC"
           },
           "source": {
@@ -17275,7 +17275,7 @@
         "p077pzf5t94": {
           "id": "p077pzf5t94",
           "label": "Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic"
           },
           "source": {
@@ -17306,7 +17306,7 @@
         "p077pzf7r62": {
           "id": "p077pzf7r62",
           "label": "Gallic Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Gallic Empire"
           },
           "source": {
@@ -17338,7 +17338,7 @@
           "editorialNote": "GeoDia had 9 separate entries for Republican (unclear), each with different spatial coverages. Could add back later if figure out page sources.",
           "id": "p077pzf85fk",
           "label": "Republican",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Republican"
           },
           "source": {
@@ -17369,7 +17369,7 @@
         "p077pzf9gq6": {
           "id": "p077pzf9gq6",
           "label": "Trajanic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Trajanic"
           },
           "source": {
@@ -17400,7 +17400,7 @@
         "p077pzf9m52": {
           "id": "p077pzf9m52",
           "label": "Imperial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Imperial"
           },
           "source": {
@@ -17431,7 +17431,7 @@
         "p077pzfjkdv": {
           "id": "p077pzfjkdv",
           "label": "High Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "High Empire"
           },
           "source": {
@@ -17462,7 +17462,7 @@
         "p077pzfmvpf": {
           "id": "p077pzfmvpf",
           "label": "Orientalizing",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Orientalizing"
           },
           "source": {
@@ -17493,7 +17493,7 @@
         "p077pzfpvh9": {
           "id": "p077pzfpvh9",
           "label": "Antonine",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Antonine"
           },
           "source": {
@@ -17524,7 +17524,7 @@
         "p077pzfpw3k": {
           "id": "p077pzfpw3k",
           "label": "Julio-Claudian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Julio-Claudian"
           },
           "note": "Includes the year of the four emperors for purposes of timeline continuity.",
@@ -17556,7 +17556,7 @@
         "p077pzfr5f7": {
           "id": "p077pzfr5f7",
           "label": "Severan",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Severan"
           },
           "source": {
@@ -17587,7 +17587,7 @@
         "p077pzfv66x": {
           "id": "p077pzfv66x",
           "label": "Augustan",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Augustan"
           },
           "source": {
@@ -17618,7 +17618,7 @@
         "p077pzfw3mb": {
           "id": "p077pzfw3mb",
           "label": "Augustan",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Augustan"
           },
           "source": {
@@ -17649,7 +17649,7 @@
         "p077pzfw49m": {
           "id": "p077pzfw49m",
           "label": "Flavian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Flavian"
           },
           "source": {
@@ -17680,7 +17680,7 @@
         "p077pzfwxfr": {
           "id": "p077pzfwxfr",
           "label": "Hadrianic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hadrianic"
           },
           "source": {
@@ -17711,7 +17711,7 @@
         "p077pzfxk2d": {
           "id": "p077pzfxk2d",
           "label": "Late Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Roman"
           },
           "source": {
@@ -17774,7 +17774,7 @@
           },
           "id": "p07h9k62chw",
           "label": "Paleolítico Inferior",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Paleolítico Inferior"
           },
           "spatialCoverage": [
@@ -17814,7 +17814,7 @@
           },
           "id": "p07h9k62pfw",
           "label": "Paleolítico Medio",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Paleolítico Medio"
           },
           "spatialCoverage": [
@@ -17854,7 +17854,7 @@
           },
           "id": "p07h9k62rq6",
           "label": "Epipaleolítico",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Epipaleolítico"
           },
           "spatialCoverage": [
@@ -17894,7 +17894,7 @@
           },
           "id": "p07h9k634vf",
           "label": "Siglos XX y XXI",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Siglos XX y XXI"
           },
           "spatialCoverage": [
@@ -17934,7 +17934,7 @@
           },
           "id": "p07h9k63z2v",
           "label": "Edad Moderna",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Edad Moderna"
           },
           "spatialCoverage": [
@@ -17974,7 +17974,7 @@
           },
           "id": "p07h9k65xxf",
           "label": "Edad del Bronce",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Edad del Bronce"
           },
           "spatialCoverage": [
@@ -18014,7 +18014,7 @@
           },
           "id": "p07h9k65zqq",
           "label": "Segunda Edad del Hierro",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Segunda Edad del Hierro"
           },
           "spatialCoverage": [
@@ -18054,7 +18054,7 @@
           },
           "id": "p07h9k69b54",
           "label": "Paleolítico",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Paleolítico"
           },
           "spatialCoverage": [
@@ -18094,7 +18094,7 @@
           },
           "id": "p07h9k69cj3",
           "label": "Neolítico Antiguo",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Neolítico Antiguo"
           },
           "spatialCoverage": [
@@ -18134,7 +18134,7 @@
           },
           "id": "p07h9k69qf2",
           "label": "Edad del Hierro",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Edad del Hierro"
           },
           "spatialCoverage": [
@@ -18174,7 +18174,7 @@
           },
           "id": "p07h9k69vsj",
           "label": "Paleolítico Superior",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Paleolítico Superior"
           },
           "spatialCoverage": [
@@ -18214,7 +18214,7 @@
           },
           "id": "p07h9k6b656",
           "label": "Indígena-Romano",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Indígena-Romano"
           },
           "note": "The Indigenous-Roman and Early Roman subdivisions of Roman Period have identical dates, but they refer to very different cultural contexts.",
@@ -18255,7 +18255,7 @@
           },
           "id": "p07h9k6b6dh",
           "label": "Prehistoria Temprana",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Prehistoria Temprana"
           },
           "spatialCoverage": [
@@ -18295,7 +18295,7 @@
           },
           "id": "p07h9k6ch24",
           "label": "Época Romana",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Época Romana"
           },
           "note": "The Indigenous-Roman and Early Roman subdivisions of Roman Period have identical dates, but they refer to very different cultural contexts.",
@@ -18336,7 +18336,7 @@
           },
           "id": "p07h9k6dpt6",
           "label": "Siglos XVIII y XIX",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Siglos XVIII y XIX"
           },
           "spatialCoverage": [
@@ -18376,7 +18376,7 @@
           },
           "id": "p07h9k6f5tz",
           "label": "Edad Media",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Edad Media"
           },
           "spatialCoverage": [
@@ -18416,7 +18416,7 @@
           },
           "id": "p07h9k6hrk7",
           "label": "Prehistoria Reciente",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Prehistoria Reciente"
           },
           "spatialCoverage": [
@@ -18456,7 +18456,7 @@
           },
           "id": "p07h9k6k759",
           "label": "Edad Contemporánea",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Edad Contemporánea"
           },
           "spatialCoverage": [
@@ -18496,7 +18496,7 @@
           },
           "id": "p07h9k6k9vj",
           "label": "Bajo Romano",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Bajo Romano"
           },
           "spatialCoverage": [
@@ -18536,7 +18536,7 @@
           },
           "id": "p07h9k6kh4b",
           "label": "Edad del Bronce Inicial",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Edad del Bronce Inicial"
           },
           "spatialCoverage": [
@@ -18576,7 +18576,7 @@
           },
           "id": "p07h9k6m88t",
           "label": "Edad Media central",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Edad Media central"
           },
           "spatialCoverage": [
@@ -18616,7 +18616,7 @@
           },
           "id": "p07h9k6n24z",
           "label": "Neolítico",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Neolítico"
           },
           "note": "The Neolithic category is split between Early Prehistory and Late Prehistory.",
@@ -18657,7 +18657,7 @@
           },
           "id": "p07h9k6npwn",
           "label": "Alto Romano",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Alto Romano"
           },
           "spatialCoverage": [
@@ -18697,7 +18697,7 @@
           },
           "id": "p07h9k6q5bd",
           "label": "Edad del Bronce Media",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Edad del Bronce Media"
           },
           "spatialCoverage": [
@@ -18737,7 +18737,7 @@
           },
           "id": "p07h9k6q7dn",
           "label": "Neolítico Final",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Neolítico Final"
           },
           "spatialCoverage": [
@@ -18777,7 +18777,7 @@
           },
           "id": "p07h9k6s57w",
           "label": "Baja Edad Media",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Baja Edad Media"
           },
           "spatialCoverage": [
@@ -18817,7 +18817,7 @@
           },
           "id": "p07h9k6tmr2",
           "label": "Edad del Bronce Final",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Edad del Bronce Final"
           },
           "spatialCoverage": [
@@ -18857,7 +18857,7 @@
           },
           "id": "p07h9k6tz6n",
           "label": "Siglos XVI y XVII",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Siglos XVI y XVII"
           },
           "spatialCoverage": [
@@ -18897,7 +18897,7 @@
           },
           "id": "p07h9k6w344",
           "label": "Primera Edad del Hierro",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Primera Edad del Hierro"
           },
           "spatialCoverage": [
@@ -18937,7 +18937,7 @@
           },
           "id": "p07h9k6z49k",
           "label": "Alta Edad Media",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Alta Edad Media"
           },
           "spatialCoverage": [
@@ -18991,7 +18991,7 @@
         "p083p5r2rtq": {
           "id": "p083p5r2rtq",
           "label": "Predynastic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Predynastic"
           },
           "source": {
@@ -19023,7 +19023,7 @@
           "editorialNote": "Gates notes \"to the end of the Persian Wars\"",
           "id": "p083p5r3hqw",
           "label": "Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic"
           },
           "source": {
@@ -19058,7 +19058,7 @@
         "p083p5r44kk": {
           "id": "p083p5r44kk",
           "label": "Middle Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Kingdom"
           },
           "source": {
@@ -19089,7 +19089,7 @@
         "p083p5r4hkt": {
           "id": "p083p5r4hkt",
           "label": "Late Cypriot I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Cypriot I"
           },
           "source": {
@@ -19120,7 +19120,7 @@
         "p083p5r5hbr": {
           "id": "p083p5r5hbr",
           "label": "Troy VIIb 1",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Troy VIIb 1"
           },
           "source": {
@@ -19151,7 +19151,7 @@
         "p083p5r5nk9": {
           "id": "p083p5r5nk9",
           "label": "Middle Hittite Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Hittite Kingdom"
           },
           "source": {
@@ -19186,7 +19186,7 @@
         "p083p5r5qm7": {
           "id": "p083p5r5qm7",
           "label": "Flavians",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Flavians"
           },
           "source": {
@@ -19217,7 +19217,7 @@
         "p083p5r5wgc": {
           "id": "p083p5r5wgc",
           "label": "Late Cypriot III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Cypriot III"
           },
           "source": {
@@ -19249,7 +19249,7 @@
           "editorialNote": "Gates discusses Greek cities that are now in the territory of Turkey, although he does not refer to Anatolia specifically.",
           "id": "p083p5r65wd",
           "label": "Protogeometric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Protogeometric"
           },
           "source": {
@@ -19284,7 +19284,7 @@
         "p083p5r6mhk": {
           "id": "p083p5r6mhk",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "source": {
@@ -19341,7 +19341,7 @@
         "p083p5r7nws": {
           "id": "p083p5r7nws",
           "label": "Early Dynastic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic"
           },
           "source": {
@@ -19387,7 +19387,7 @@
           "editorialNote": "\"(= Middle Minoan IB)\"",
           "id": "p083p5r8kpg",
           "label": "Old Palace (Protopalatial)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Palace (Protopalatial)"
           },
           "source": {
@@ -19418,7 +19418,7 @@
         "p083p5r8ww5": {
           "id": "p083p5r8ww5",
           "label": "Troy VIIb 2",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Troy VIIb 2"
           },
           "source": {
@@ -19449,7 +19449,7 @@
         "p083p5r9nnz": {
           "id": "p083p5r9nnz",
           "label": "Gutian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Gutian"
           },
           "note": "According to Gates, Gutian domination of Mesopotamia was ended by Ur-Nammu, the first ruler of the Third dynasty of Ur (2100 B.C.-2000 B.C.), which contradicts the end date of 2000 BC (p. 55).",
@@ -19493,7 +19493,7 @@
         "p083p5r9q68": {
           "id": "p083p5r9q68",
           "label": "Old Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Kingdom"
           },
           "source": {
@@ -19530,7 +19530,7 @@
           "editorialNote": "Gates discusses only the Achaemenids in Persia proper in this chapter.",
           "id": "p083p5r9rs7",
           "label": "Achaemenids",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Achaemenids"
           },
           "source": {
@@ -19561,7 +19561,7 @@
         "p083p5r9sqt": {
           "id": "p083p5r9sqt",
           "label": "Late Helladic II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic II"
           },
           "source": {
@@ -19592,7 +19592,7 @@
         "p083p5r9zvn": {
           "id": "p083p5r9zvn",
           "label": "Old Hittite Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Hittite Kingdom"
           },
           "source": {
@@ -19623,7 +19623,7 @@
         "p083p5rb574": {
           "id": "p083p5rb574",
           "label": "Late Helladic IIIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIIB"
           },
           "source": {
@@ -19655,7 +19655,7 @@
           "editorialNote": "Gates concentrates on Athens, so Greece is most appropriate coverage.",
           "id": "p083p5rb9mx",
           "label": "Early Classical",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Classical"
           },
           "source": {
@@ -19687,7 +19687,7 @@
           "editorialNote": "Gates discusses Greek cities that are now in the territory of Turkey, although he does not refer to Anatolia specifically.",
           "id": "p083p5rbcqj",
           "label": "Geometric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Geometric"
           },
           "source": {
@@ -19722,7 +19722,7 @@
         "p083p5rbhdq": {
           "id": "p083p5rbhdq",
           "label": "Troy I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Troy I"
           },
           "source": {
@@ -19754,7 +19754,7 @@
           "editorialNote": "Gates concentrates on Athens, so Greece is most appropriate coverage.",
           "id": "p083p5rbj32",
           "label": "High Classical",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "High Classical"
           },
           "source": {
@@ -19785,7 +19785,7 @@
         "p083p5rcd2r": {
           "id": "p083p5rcd2r",
           "label": "Neo-Sumerian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Sumerian"
           },
           "source": {
@@ -19824,7 +19824,7 @@
         "p083p5rcq8f": {
           "id": "p083p5rcq8f",
           "label": "High Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "High Empire"
           },
           "source": {
@@ -19855,7 +19855,7 @@
         "p083p5rdfxn": {
           "id": "p083p5rdfxn",
           "label": "Third Intermediate",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Third Intermediate"
           },
           "source": {
@@ -19887,7 +19887,7 @@
           "editorialNote": "Gates notes \"to the Battle of Actium\"",
           "id": "p083p5rdh8w",
           "label": "Hellenistic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic"
           },
           "source": {
@@ -19922,7 +19922,7 @@
         "p083p5rdhcw": {
           "id": "p083p5rdhcw",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "source": {
@@ -19977,7 +19977,7 @@
         "p083p5rdr2z": {
           "id": "p083p5rdr2z",
           "label": "Ubaid",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ubaid"
           },
           "source": {
@@ -20021,7 +20021,7 @@
           },
           "id": "p083p5rdz7f",
           "label": "Etruscan rule",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Etruscan rule"
           },
           "source": {
@@ -20052,7 +20052,7 @@
         "p083p5rfkx4": {
           "id": "p083p5rfkx4",
           "label": "Troy II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Troy II"
           },
           "source": {
@@ -20083,7 +20083,7 @@
         "p083p5rg9zb": {
           "id": "p083p5rg9zb",
           "label": "Late Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Period"
           },
           "source": {
@@ -20114,7 +20114,7 @@
         "p083p5rgw32": {
           "id": "p083p5rgw32",
           "label": "Late Minoan II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Minoan II"
           },
           "source": {
@@ -20145,7 +20145,7 @@
         "p083p5rj8d7": {
           "id": "p083p5rj8d7",
           "label": "Roman Republic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Republic"
           },
           "source": {
@@ -20176,7 +20176,7 @@
         "p083p5rj8gv": {
           "id": "p083p5rj8gv",
           "label": "Kassite",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Kassite"
           },
           "source": {
@@ -20211,7 +20211,7 @@
         "p083p5rjm96": {
           "id": "p083p5rjm96",
           "label": "Isin-Larsa",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Isin-Larsa"
           },
           "source": {
@@ -20254,7 +20254,7 @@
         "p083p5rjn85": {
           "id": "p083p5rjn85",
           "label": "Ur III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ur III"
           },
           "source": {
@@ -20293,7 +20293,7 @@
         "p083p5rm92p": {
           "id": "p083p5rm92p",
           "label": "Halaf and Ubaid",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Halaf and Ubaid"
           },
           "source": {
@@ -20348,7 +20348,7 @@
         "p083p5rmv3r": {
           "id": "p083p5rmv3r",
           "label": "Hittite Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hittite Empire"
           },
           "source": {
@@ -20383,7 +20383,7 @@
         "p083p5rnj3c": {
           "id": "p083p5rnj3c",
           "label": "Neo-Babylonian Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Babylonian Empire"
           },
           "source": {
@@ -20446,7 +20446,7 @@
         "p083p5rnq5h": {
           "id": "p083p5rnq5h",
           "label": "New Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "New Kingdom"
           },
           "source": {
@@ -20483,7 +20483,7 @@
           },
           "id": "p083p5rpb46",
           "label": "Late Bronze Age (= Late Cypriot)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age (= Late Cypriot)"
           },
           "source": {
@@ -20514,7 +20514,7 @@
         "p083p5rpbht": {
           "id": "p083p5rpbht",
           "label": "Troy VIIa",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Troy VIIa"
           },
           "source": {
@@ -20546,7 +20546,7 @@
           "editorialNote": "The chapter associated with this term covers sites in both Greece and Turkey, although map of conquests of Alexander also covers the Levant, Egypt, Iraq, Iran, Afghanistan, and parts of India and Pakistan.",
           "id": "p083p5rpvbm",
           "label": "Late Classical",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Classical"
           },
           "source": {
@@ -20581,7 +20581,7 @@
         "p083p5rpwg8": {
           "id": "p083p5rpwg8",
           "label": "Troy VI",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Troy VI"
           },
           "source": {
@@ -20613,7 +20613,7 @@
           "editorialNote": "\"(= Late Minoan IIIA, B, and C)\"",
           "id": "p083p5rqgfm",
           "label": "Post-Palatial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Post-Palatial"
           },
           "source": {
@@ -20644,7 +20644,7 @@
         "p083p5rr7tg": {
           "id": "p083p5rr7tg",
           "label": "Akkadian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Akkadian"
           },
           "source": {
@@ -20683,7 +20683,7 @@
         "p083p5rrgmj": {
           "id": "p083p5rrgmj",
           "label": "Late Helladic IIIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIIA"
           },
           "source": {
@@ -20721,7 +20721,7 @@
           "editorialNote": "\"(= Middle Minoan III, Late Minoan IA and B)\"",
           "id": "p083p5rrnpp",
           "label": "New Palace (Neopalatial)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "New Palace (Neopalatial)"
           },
           "source": {
@@ -20752,7 +20752,7 @@
         "p083p5rs75d": {
           "id": "p083p5rs75d",
           "label": "First Intermediate",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "First Intermediate"
           },
           "source": {
@@ -20784,7 +20784,7 @@
           "editorialNote": "Gates notes \"to the death of Alexander the Great\"",
           "id": "p083p5rsg8g",
           "label": "Classical",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classical"
           },
           "source": {
@@ -20819,7 +20819,7 @@
         "p083p5rtmh8": {
           "id": "p083p5rtmh8",
           "label": "Old Babylonian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Babylonian"
           },
           "source": {
@@ -20854,7 +20854,7 @@
         "p083p5rtqd5": {
           "id": "p083p5rtqd5",
           "label": "Second Intermediate",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Second Intermediate"
           },
           "source": {
@@ -20885,7 +20885,7 @@
         "p083p5rtt5p": {
           "id": "p083p5rtt5p",
           "label": "Neo-Assyrian Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Assyrian Empire"
           },
           "source": {
@@ -20920,7 +20920,7 @@
         "p083p5rvfkp": {
           "id": "p083p5rvfkp",
           "label": "Severans",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Severans"
           },
           "source": {
@@ -20957,7 +20957,7 @@
           },
           "id": "p083p5rw9rf",
           "label": "Protoliterate (Uruk)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Protoliterate (Uruk)"
           },
           "source": {
@@ -21002,7 +21002,7 @@
           },
           "id": "p083p5rwbk3",
           "label": "Early Dynastic (Archaic)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic (Archaic)"
           },
           "source": {
@@ -21033,7 +21033,7 @@
         "p083p5rwd4b": {
           "id": "p083p5rwd4b",
           "label": "Late Cypriot II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Cypriot II"
           },
           "source": {
@@ -21071,7 +21071,7 @@
           "editorialNote": "Gates discusses Greek cities that are now in the territory of Turkey, although he does not refer to Anatolia specifically.",
           "id": "p083p5rwk9g",
           "label": "Orientalizing (Early Archaic)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Orientalizing (Early Archaic)"
           },
           "source": {
@@ -21112,7 +21112,7 @@
           "editorialNote": "Indus Valley is defined as \"a region now situated in modern Pakistan and north-west India\"",
           "id": "p083p5rwkfs",
           "label": "Harappan, or Mature",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Harappan, or Mature"
           },
           "source": {
@@ -21147,7 +21147,7 @@
         "p083p5rx625": {
           "id": "p083p5rx625",
           "label": "Troy III-V",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Troy III-V"
           },
           "source": {
@@ -21178,7 +21178,7 @@
         "p083p5rz9jx": {
           "id": "p083p5rz9jx",
           "label": "Late Helladic IIIC",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIIC"
           },
           "source": {
@@ -21209,7 +21209,7 @@
         "p083p5rzt33": {
           "id": "p083p5rzt33",
           "label": "Julio-Claudians",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Julio-Claudians"
           },
           "source": {
@@ -21262,7 +21262,7 @@
           },
           "id": "p086kj9235v",
           "label": "British 1763-1783",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "British 1763-1783"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -21295,7 +21295,7 @@
           },
           "id": "p086kj924nt",
           "label": "18th Century::3rd quarter (1750 - 1774)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "18th Century::3rd quarter (1750 - 1774)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -21323,7 +21323,7 @@
         "p086kj926q4": {
           "id": "p086kj926q4",
           "label": "Archaic, indeterminate",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic, indeterminate"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -21351,7 +21351,7 @@
         "p086kj927td": {
           "id": "p086kj927td",
           "label": "Fort Ancient",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Fort Ancient"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -21379,7 +21379,7 @@
         "p086kj9298n": {
           "id": "p086kj9298n",
           "label": "Icarian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Icarian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR5",
@@ -21407,7 +21407,7 @@
         "p086kj929mz": {
           "id": "p086kj929mz",
           "label": "Middle Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -21435,7 +21435,7 @@
         "p086kj92dpj": {
           "id": "p086kj92dpj",
           "label": "Lamar",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lamar"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -21463,7 +21463,7 @@
         "p086kj92h3r": {
           "id": "p086kj92h3r",
           "label": "St. Johns Ia",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "St. Johns Ia"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -21496,7 +21496,7 @@
           },
           "id": "p086kj92hb4",
           "label": "Glades II, A.D. 750-1200",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glades II, A.D. 750-1200"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -21524,7 +21524,7 @@
         "p086kj92ks2": {
           "id": "p086kj92ks2",
           "label": "Adena",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Adena"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR46",
@@ -21552,7 +21552,7 @@
         "p086kj92kvp": {
           "id": "p086kj92kvp",
           "label": "Nebo Hill",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Nebo Hill"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR31",
@@ -21580,7 +21580,7 @@
         "p086kj92p98": {
           "id": "p086kj92p98",
           "label": "Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA23",
@@ -21608,7 +21608,7 @@
         "p086kj92s2s": {
           "id": "p086kj92s2s",
           "label": "Glades IIIa",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glades IIIa"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -21636,7 +21636,7 @@
         "p086kj92scs": {
           "id": "p086kj92scs",
           "label": "19th cent. urban",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th cent. urban"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR116",
@@ -21664,7 +21664,7 @@
         "p086kj92svg": {
           "id": "p086kj92svg",
           "label": "Any Archaic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Any Archaic Period"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -21697,7 +21697,7 @@
           },
           "id": "p086kj92szg",
           "label": "Glades III, A.D. 1000-1700",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glades III, A.D. 1000-1700"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -21725,7 +21725,7 @@
         "p086kj92tdf": {
           "id": "p086kj92tdf",
           "label": "Green River",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Green River"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -21753,7 +21753,7 @@
         "p086kj92vmq": {
           "id": "p086kj92vmq",
           "label": "20th Century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "20th Century"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -21781,7 +21781,7 @@
         "p086kj92w8p": {
           "id": "p086kj92w8p",
           "label": "Amana Colonists",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Amana Colonists"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR68",
@@ -21809,7 +21809,7 @@
         "p086kj92x6b": {
           "id": "p086kj92x6b",
           "label": "Mid-late 20th century commerce",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mid-late 20th century commerce"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR112",
@@ -21837,7 +21837,7 @@
         "p086kj92xvn": {
           "id": "p086kj92xvn",
           "label": "Linn",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Linn"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR82",
@@ -21870,7 +21870,7 @@
           },
           "id": "p086kj932pt",
           "label": "Indian Pond A.D. 950-contact",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Indian Pond A.D. 950-contact"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -21898,7 +21898,7 @@
         "p086kj9334s": {
           "id": "p086kj9334s",
           "label": "Late Paleoindian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Paleoindian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -21926,7 +21926,7 @@
         "p086kj9346r": {
           "id": "p086kj9346r",
           "label": "Indeterminate",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Indeterminate"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -21954,7 +21954,7 @@
         "p086kj934tr": {
           "id": "p086kj934tr",
           "label": "late Early Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "late Early Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR100",
@@ -21982,7 +21982,7 @@
         "p086kj9372b": {
           "id": "p086kj9372b",
           "label": "Historic American Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic American Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -22010,7 +22010,7 @@
         "p086kj9373n": {
           "id": "p086kj9373n",
           "label": "Prairie/Plains Late Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Prairie/Plains Late Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR15",
@@ -22038,7 +22038,7 @@
         "p086kj9377z": {
           "id": "p086kj9377z",
           "label": "Sac and Fox",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Sac and Fox"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR42",
@@ -22071,7 +22071,7 @@
           },
           "id": "p086kj93btj",
           "label": "18th Century::1st half (1700 - 1749)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "18th Century::1st half (1700 - 1749)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -22104,7 +22104,7 @@
           },
           "id": "p086kj93gmq",
           "label": "Paleoindian, 10000 B.C.-8500 B.C.",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Paleoindian, 10000 B.C.-8500 B.C."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -22132,7 +22132,7 @@
         "p086kj93h92": {
           "id": "p086kj93h92",
           "label": "contemporary with Hartley phase",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "contemporary with Hartley phase"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR59",
@@ -22165,7 +22165,7 @@
           },
           "id": "p086kj93hq2",
           "label": "WW I & Aftermath 1917-1920",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "WW I & Aftermath 1917-1920"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -22193,7 +22193,7 @@
         "p086kj93pnt": {
           "id": "p086kj93pnt",
           "label": "Santa Rosa-Swift Creek",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Santa Rosa-Swift Creek"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -22221,7 +22221,7 @@
         "p086kj93pxh": {
           "id": "p086kj93pxh",
           "label": "Early Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -22249,7 +22249,7 @@
         "p086kj93qxs": {
           "id": "p086kj93qxs",
           "label": "Glenwood",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glenwood"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR50",
@@ -22277,7 +22277,7 @@
         "p086kj93r5r": {
           "id": "p086kj93r5r",
           "label": "Yankeetown",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Yankeetown"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -22305,7 +22305,7 @@
         "p086kj93rh4": {
           "id": "p086kj93rh4",
           "label": "Cumberland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cumberland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -22333,7 +22333,7 @@
         "p086kj93snq": {
           "id": "p086kj93snq",
           "label": "Great Oasis or Oneota",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Great Oasis or Oneota"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR69",
@@ -22361,7 +22361,7 @@
         "p086kj93std": {
           "id": "p086kj93std",
           "label": "Upper Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Upper Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -22389,7 +22389,7 @@
         "p086kj93tb2": {
           "id": "p086kj93tb2",
           "label": "St. Johns Ib",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "St. Johns Ib"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -22417,7 +22417,7 @@
         "p086kj93v9z": {
           "id": "p086kj93v9z",
           "label": "Central Plains Tradition(?)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Central Plains Tradition(?)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR55",
@@ -22445,7 +22445,7 @@
         "p086kj93wsx": {
           "id": "p086kj93wsx",
           "label": "St. Johns IIb",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "St. Johns IIb"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -22473,7 +22473,7 @@
         "p086kj944pp": {
           "id": "p086kj944pp",
           "label": "Lewis",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lewis"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -22501,7 +22501,7 @@
         "p086kj944wp": {
           "id": "p086kj944wp",
           "label": "Helton phase",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Helton phase"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR110",
@@ -22534,7 +22534,7 @@
           },
           "id": "p086kj946k9",
           "label": "Antebellum (1821-1861)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Antebellum (1821-1861)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA34",
@@ -22562,7 +22562,7 @@
         "p086kj946qm": {
           "id": "p086kj946qm",
           "label": "Historic, Native American (Seminole)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic, Native American (Seminole)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -22590,7 +22590,7 @@
         "p086kj947j8": {
           "id": "p086kj947j8",
           "label": "Meskwaki",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Meskwaki"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR25",
@@ -22623,7 +22623,7 @@
           },
           "id": "p086kj948gv",
           "label": "18th Century::2nd quarter (1725 - 1749)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "18th Century::2nd quarter (1725 - 1749)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -22651,7 +22651,7 @@
         "p086kj9499h": {
           "id": "p086kj9499h",
           "label": "Weaver-like",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Weaver-like"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR83",
@@ -22679,7 +22679,7 @@
         "p086kj94b8g": {
           "id": "p086kj94b8g",
           "label": "Hopewellian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hopewellian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -22712,7 +22712,7 @@
           },
           "id": "p086kj94c64",
           "label": "19th Century::4th quarter (1875 - 1899)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th Century::4th quarter (1875 - 1899)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -22740,7 +22740,7 @@
         "p086kj94d3d": {
           "id": "p086kj94d3d",
           "label": "Woodland, Undifferentiated",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Woodland, Undifferentiated"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -22773,7 +22773,7 @@
           },
           "id": "p086kj94dk3",
           "label": "19th Century::1st half (1800 - 1849)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th Century::1st half (1800 - 1849)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -22801,7 +22801,7 @@
         "p086kj94g2n": {
           "id": "p086kj94g2n",
           "label": "War of 1812",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "War of 1812"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR144",
@@ -22834,7 +22834,7 @@
           },
           "id": "p086kj94mbh",
           "label": "20th Century::2nd half (1950 - 1999)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "20th Century::2nd half (1950 - 1999)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -22867,7 +22867,7 @@
           },
           "id": "p086kj94nmg",
           "label": "20th Century::1st quarter (1900 - 1924)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "20th Century::1st quarter (1900 - 1924)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -22900,7 +22900,7 @@
           },
           "id": "p086kj94pwf",
           "label": "Post-Reconstruction 1880-1897",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Post-Reconstruction 1880-1897"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -22928,7 +22928,7 @@
         "p086kj94t5m": {
           "id": "p086kj94t5m",
           "label": "Middle Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA13",
@@ -22956,7 +22956,7 @@
         "p086kj94t9x": {
           "id": "p086kj94t9x",
           "label": "Reported Site",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Reported Site"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -22984,7 +22984,7 @@
         "p086kj94tsm": {
           "id": "p086kj94tsm",
           "label": "Pleistocene",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pleistocene"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR41",
@@ -23012,7 +23012,7 @@
         "p086kj94vq8": {
           "id": "p086kj94vq8",
           "label": "Great Oasis",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Great Oasis"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR17",
@@ -23040,7 +23040,7 @@
         "p086kj955k8": {
           "id": "p086kj955k8",
           "label": "Oneota",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Oneota"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR6",
@@ -23068,7 +23068,7 @@
         "p086kj955xk": {
           "id": "p086kj955xk",
           "label": "Unknown",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Unknown"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -23096,7 +23096,7 @@
         "p086kj9562j": {
           "id": "p086kj9562j",
           "label": "Dalton",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Dalton"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -23124,7 +23124,7 @@
         "p086kj9568j": {
           "id": "p086kj9568j",
           "label": "General Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "General Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -23152,7 +23152,7 @@
         "p086kj958hg": {
           "id": "p086kj958hg",
           "label": "Angel",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Angel"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -23180,7 +23180,7 @@
         "p086kj959mr": {
           "id": "p086kj959mr",
           "label": "late Middle Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "late Middle Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR13",
@@ -23213,7 +23213,7 @@
           },
           "id": "p086kj95c6c",
           "label": "Statehood & Antebellum 1845-1860",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Statehood & Antebellum 1845-1860"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -23241,7 +23241,7 @@
         "p086kj95gpw": {
           "id": "p086kj95gpw",
           "label": "possibly Hanna",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "possibly Hanna"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR105",
@@ -23274,7 +23274,7 @@
           },
           "id": "p086kj95kss",
           "label": "17th Century::2nd quarter (1625 - 1649)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "17th Century::2nd quarter (1625 - 1649)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -23302,7 +23302,7 @@
         "p086kj95kzg": {
           "id": "p086kj95kzg",
           "label": "Historic, Native American (Cherokee)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic, Native American (Cherokee)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -23330,7 +23330,7 @@
         "p086kj95ntq": {
           "id": "p086kj95ntq",
           "label": "Lane Farm",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lane Farm"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR78",
@@ -23358,7 +23358,7 @@
         "p086kj95q9b": {
           "id": "p086kj95q9b",
           "label": "late 19th -20th cent residential",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "late 19th -20th cent residential"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR119",
@@ -23386,7 +23386,7 @@
         "p086kj95vg6": {
           "id": "p086kj95vg6",
           "label": "Weeden Island 3",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Weeden Island 3"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -23414,7 +23414,7 @@
         "p086kj95wkg": {
           "id": "p086kj95wkg",
           "label": "Oneota, Correctionville phase",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Oneota, Correctionville phase"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR65",
@@ -23442,7 +23442,7 @@
         "p086kj95z7q": {
           "id": "p086kj95z7q",
           "label": "Protohistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Protohistoric"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -23470,7 +23470,7 @@
         "p086kj962v9": {
           "id": "p086kj962v9",
           "label": "Baytown",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Baytown"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -23498,7 +23498,7 @@
         "p086kj963bk": {
           "id": "p086kj963bk",
           "label": "Urban Industrial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Urban Industrial"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -23526,7 +23526,7 @@
         "p086kj963pw": {
           "id": "p086kj963pw",
           "label": "Middle Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -23554,7 +23554,7 @@
         "p086kj964jv": {
           "id": "p086kj964jv",
           "label": "St. Johns I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "St. Johns I"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -23582,7 +23582,7 @@
         "p086kj964zv": {
           "id": "p086kj964zv",
           "label": "Hopewell",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hopewell"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR70",
@@ -23610,7 +23610,7 @@
         "p086kj965kh": {
           "id": "p086kj965kh",
           "label": "Potano unspecified",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Potano unspecified"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -23638,7 +23638,7 @@
         "p086kj966m5": {
           "id": "p086kj966m5",
           "label": "Terminal Middle Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Terminal Middle Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -23666,7 +23666,7 @@
         "p086kj966ws": {
           "id": "p086kj966ws",
           "label": "19th-20th cent urban",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th-20th cent urban"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR118",
@@ -23694,7 +23694,7 @@
         "p086kj967xf": {
           "id": "p086kj967xf",
           "label": "War of 1812",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "War of 1812"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR125",
@@ -23722,7 +23722,7 @@
         "p086kj9688d": {
           "id": "p086kj9688d",
           "label": "Early Woodland, indet",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Woodland, indet"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -23750,7 +23750,7 @@
         "p086kj96bwz": {
           "id": "p086kj96bwz",
           "label": "Historic, Native American (Yuchi)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic, Native American (Yuchi)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -23778,7 +23778,7 @@
         "p086kj96cdm": {
           "id": "p086kj96cdm",
           "label": "Woodland, indet.",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Woodland, indet."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -23806,7 +23806,7 @@
         "p086kj96dwk": {
           "id": "p086kj96dwk",
           "label": "Depression era",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Depression era"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR127",
@@ -23834,7 +23834,7 @@
         "p086kj96fkv": {
           "id": "p086kj96fkv",
           "label": "Late Woodland/Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Woodland/Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -23862,7 +23862,7 @@
         "p086kj96g7t": {
           "id": "p086kj96g7t",
           "label": "Plains Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Plains Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR24",
@@ -23884,7 +23884,7 @@
         "p086kj96jx4": {
           "id": "p086kj96jx4",
           "label": "Historic Non-Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic Non-Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -23912,7 +23912,7 @@
         "p086kj96mkc": {
           "id": "p086kj96mkc",
           "label": "Indet. Mississippi",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Indet. Mississippi"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -23940,7 +23940,7 @@
         "p086kj96mr2": {
           "id": "p086kj96mr2",
           "label": "Middle Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -23968,7 +23968,7 @@
         "p086kj96s5t": {
           "id": "p086kj96s5t",
           "label": "Early Side Notched",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Side Notched"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -23996,7 +23996,7 @@
         "p086kj96tvs": {
           "id": "p086kj96tvs",
           "label": "Glades IIa",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glades IIa"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -24029,7 +24029,7 @@
           },
           "id": "p086kj96z3n",
           "label": "Early Woodland (1200 B.C. - 299 A.D.)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Woodland (1200 B.C. - 299 A.D.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -24057,7 +24057,7 @@
         "p086kj97594": {
           "id": "p086kj97594",
           "label": "Middle Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -24085,7 +24085,7 @@
         "p086kj978jb": {
           "id": "p086kj978jb",
           "label": "Malabar",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Malabar"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -24113,7 +24113,7 @@
         "p086kj979h9": {
           "id": "p086kj979h9",
           "label": "Middle Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -24141,7 +24141,7 @@
         "p086kj97dst": {
           "id": "p086kj97dst",
           "label": "Crawford Phase",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Crawford Phase"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR104",
@@ -24169,7 +24169,7 @@
         "p086kj97f3g": {
           "id": "p086kj97f3g",
           "label": "Historic, Native American (Chatot)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic, Native American (Chatot)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -24197,7 +24197,7 @@
         "p086kj97frs": {
           "id": "p086kj97frs",
           "label": "Paleo-Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Paleo-Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA12",
@@ -24225,7 +24225,7 @@
         "p086kj97fw5": {
           "id": "p086kj97fw5",
           "label": "Central Plains Tradition",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Central Plains Tradition"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR32",
@@ -24253,7 +24253,7 @@
         "p086kj97gdr": {
           "id": "p086kj97gdr",
           "label": "Late Paleoindian/Early Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Paleoindian/Early Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -24281,7 +24281,7 @@
         "p086kj97j6c": {
           "id": "p086kj97j6c",
           "label": "Maple Creek",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Maple Creek"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -24309,7 +24309,7 @@
         "p086kj97kxn": {
           "id": "p086kj97kxn",
           "label": "Middle Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -24337,7 +24337,7 @@
         "p086kj97nm8": {
           "id": "p086kj97nm8",
           "label": "Early Archaic Kirk",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Archaic Kirk"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -24365,7 +24365,7 @@
         "p086kj97nww": {
           "id": "p086kj97nww",
           "label": "Middle Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA20",
@@ -24393,7 +24393,7 @@
         "p086kj97q3t": {
           "id": "p086kj97q3t",
           "label": "16th Century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "16th Century"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -24421,7 +24421,7 @@
         "p086kj97sfr": {
           "id": "p086kj97sfr",
           "label": "Lake Benton",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lake Benton"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR136",
@@ -24454,7 +24454,7 @@
           },
           "id": "p086kj97wnn",
           "label": "19th Century::3rd quarter (1850 - 1874)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th Century::3rd quarter (1850 - 1874)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -24482,7 +24482,7 @@
         "p086kj97zn8": {
           "id": "p086kj97zn8",
           "label": "Proto-historic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Proto-historic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -24510,7 +24510,7 @@
         "p086kj97zsk": {
           "id": "p086kj97zsk",
           "label": "Fox",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Fox"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR40",
@@ -24538,7 +24538,7 @@
         "p086kj982fs": {
           "id": "p086kj982fs",
           "label": "Frontier",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Frontier"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -24571,7 +24571,7 @@
           },
           "id": "p086kj983gf",
           "label": "The New Dominion (1946 - 1988)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "The New Dominion (1946 - 1988)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -24599,7 +24599,7 @@
         "p086kj9848q": {
           "id": "p086kj9848q",
           "label": "Early Paleoindian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Paleoindian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -24627,7 +24627,7 @@
         "p086kj98493": {
           "id": "p086kj98493",
           "label": "Late Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA14",
@@ -24655,7 +24655,7 @@
         "p086kj985c2": {
           "id": "p086kj985c2",
           "label": "Hemphill",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hemphill"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR74",
@@ -24683,7 +24683,7 @@
         "p086kj9875m": {
           "id": "p086kj9875m",
           "label": "Orange",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Orange"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -24711,7 +24711,7 @@
         "p086kj989mj": {
           "id": "p086kj989mj",
           "label": "Historic, Native American (Creek)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic, Native American (Creek)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -24744,7 +24744,7 @@
           },
           "id": "p086kj98d84",
           "label": "St. Johns, 700 B.C.-A.D. 1500",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "St. Johns, 700 B.C.-A.D. 1500"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -24772,7 +24772,7 @@
         "p086kj98drr": {
           "id": "p086kj98drr",
           "label": "Historic, Native American (Tenesaw)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic, Native American (Tenesaw)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -24805,7 +24805,7 @@
           },
           "id": "p086kj98fpd",
           "label": "Woodland (1200 B.C. - 1606 A.D.)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Woodland (1200 B.C. - 1606 A.D.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -24833,7 +24833,7 @@
         "p086kj98hzn": {
           "id": "p086kj98hzn",
           "label": "Mormon (alleged)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mormon (alleged)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR80",
@@ -24866,7 +24866,7 @@
           },
           "id": "p086kj98jxm",
           "label": "Reconstruction 1866-1879",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Reconstruction 1866-1879"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -24894,7 +24894,7 @@
         "p086kj98kck": {
           "id": "p086kj98kck",
           "label": "Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -24922,7 +24922,7 @@
         "p086kj98mgv": {
           "id": "p086kj98mgv",
           "label": "Early Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR130",
@@ -24950,7 +24950,7 @@
         "p086kj98njt": {
           "id": "p086kj98njt",
           "label": "Amana",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Amana"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR66",
@@ -24978,7 +24978,7 @@
         "p086kj98p5g": {
           "id": "p086kj98p5g",
           "label": "Late 19th-Early 20th Century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late 19th-Early 20th Century"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR139",
@@ -25006,7 +25006,7 @@
         "p086kj98p9s": {
           "id": "p086kj98p9s",
           "label": "Early Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR141",
@@ -25034,7 +25034,7 @@
         "p086kj98pds": {
           "id": "p086kj98pds",
           "label": "Upper Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Upper Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -25062,7 +25062,7 @@
         "p086kj98qx4": {
           "id": "p086kj98qx4",
           "label": "Glades IIIb",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glades IIIb"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -25090,7 +25090,7 @@
         "p086kj98scc": {
           "id": "p086kj98scc",
           "label": "Dalton-Henderson",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Dalton-Henderson"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -25118,7 +25118,7 @@
         "p086kj98shp": {
           "id": "p086kj98shp",
           "label": "Post War",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Post War"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -25151,7 +25151,7 @@
           },
           "id": "p086kj98vgx",
           "label": "Territorial (1804-1820)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Territorial (1804-1820)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA17",
@@ -25186,7 +25186,7 @@
           },
           "id": "p086kj98vq9",
           "label": "Seminole, 2nd War to 3rd 1835-1855",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Seminole, 2nd War to 3rd 1835-1855"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -25214,7 +25214,7 @@
         "p086kj98vrm": {
           "id": "p086kj98vrm",
           "label": "Black Sand complex",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Black Sand complex"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR84",
@@ -25242,7 +25242,7 @@
         "p086kj98xn7": {
           "id": "p086kj98xn7",
           "label": "Early Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -25270,7 +25270,7 @@
         "p086kj98z7h": {
           "id": "p086kj98z7h",
           "label": "Belle Glade III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Belle Glade III"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -25303,7 +25303,7 @@
           },
           "id": "p086kj9947n",
           "label": "17th Century::4th quarter (1675 - 1699)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "17th Century::4th quarter (1675 - 1699)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -25331,7 +25331,7 @@
         "p086kj995k9": {
           "id": "p086kj995k9",
           "label": "Titterington Phase",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Titterington Phase"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR60",
@@ -25364,7 +25364,7 @@
           },
           "id": "p086kj996ck",
           "label": "WW II & Aftermath 1941-1950",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "WW II & Aftermath 1941-1950"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -25397,7 +25397,7 @@
           },
           "id": "p086kj997fj",
           "label": "Belle Glade, 700 B.C.-A.D. 1700",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Belle Glade, 700 B.C.-A.D. 1700"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -25430,7 +25430,7 @@
           },
           "id": "p086kj997h7",
           "label": "17th Century::1st half (1600 - 1649)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "17th Century::1st half (1600 - 1649)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -25465,7 +25465,7 @@
           },
           "id": "p086kj998dh",
           "label": "Seminole, 1st War to 2nd 1817-1834",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Seminole, 1st War to 2nd 1817-1834"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -25493,7 +25493,7 @@
         "p086kj998w6": {
           "id": "p086kj998w6",
           "label": "Graham Cave",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Graham Cave"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR99",
@@ -25521,7 +25521,7 @@
         "p086kj99cbq": {
           "id": "p086kj99cbq",
           "label": "Pammel",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pammel"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR76",
@@ -25549,7 +25549,7 @@
         "p086kj99dsc": {
           "id": "p086kj99dsc",
           "label": "Late Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -25577,7 +25577,7 @@
         "p086kj99fnb": {
           "id": "p086kj99fnb",
           "label": "Moingona",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Moingona"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR58",
@@ -25605,7 +25605,7 @@
         "p086kj99hxk": {
           "id": "p086kj99hxk",
           "label": "Early Paleo-Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Paleo-Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -25638,7 +25638,7 @@
           },
           "id": "p086kj99m9g",
           "label": "American Acquisition & Development 1821-45",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "American Acquisition & Development 1821-45"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -25666,7 +25666,7 @@
         "p086kj99mzs": {
           "id": "p086kj99mzs",
           "label": "Clovis",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Clovis"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR14",
@@ -25694,7 +25694,7 @@
         "p086kj99nj4": {
           "id": "p086kj99nj4",
           "label": "Prehistoric-Unspecified",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Prehistoric-Unspecified"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -25722,7 +25722,7 @@
         "p086kj99pfd": {
           "id": "p086kj99pfd",
           "label": "Marion",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Marion"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR49",
@@ -25750,7 +25750,7 @@
         "p086kj99t98": {
           "id": "p086kj99t98",
           "label": "Glades Ib",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glades Ib"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -25778,7 +25778,7 @@
         "p086kj99tcw": {
           "id": "p086kj99tcw",
           "label": "late Late Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "late Late Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR18",
@@ -25806,7 +25806,7 @@
         "p086kj99tsw": {
           "id": "p086kj99tsw",
           "label": "Hopewell",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hopewell"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR35",
@@ -25839,7 +25839,7 @@
           },
           "id": "p086kj99vs7",
           "label": "18th Century::2nd/3rd quarter (1725 - 1774)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "18th Century::2nd/3rd quarter (1725 - 1774)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -25867,7 +25867,7 @@
         "p086kj99w9t": {
           "id": "p086kj99w9t",
           "label": "Late Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -25895,7 +25895,7 @@
         "p086kj99wch": {
           "id": "p086kj99wch",
           "label": "Early Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -25923,7 +25923,7 @@
         "p086kj99x65": {
           "id": "p086kj99x65",
           "label": "Caborn-Welborn",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Caborn-Welborn"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -25951,7 +25951,7 @@
         "p086kj9b2cn": {
           "id": "p086kj9b2cn",
           "label": "Prehistoric-Ceramic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Prehistoric-Ceramic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -25984,7 +25984,7 @@
           },
           "id": "p086kj9b399",
           "label": "19th Century::2nd/3rd quarter (1825 - 1874)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th Century::2nd/3rd quarter (1825 - 1874)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -26012,7 +26012,7 @@
         "p086kj9b43k": {
           "id": "p086kj9b43k",
           "label": "Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -26040,7 +26040,7 @@
         "p086kj9b7ns": {
           "id": "p086kj9b7ns",
           "label": "Fox Lake",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Fox Lake"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR137",
@@ -26068,7 +26068,7 @@
         "p086kj9b8xr": {
           "id": "p086kj9b8xr",
           "label": "Middle Gulf Formational",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Gulf Formational"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -26101,7 +26101,7 @@
           },
           "id": "p086kj9b8z4",
           "label": "Swift Creek, 300 B.C.-A.D. 450",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Swift Creek, 300 B.C.-A.D. 450"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -26134,7 +26134,7 @@
           },
           "id": "p086kj9b92q",
           "label": "20th Century::2nd/3rd quarter (1925 - 1974)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "20th Century::2nd/3rd quarter (1925 - 1974)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -26162,7 +26162,7 @@
         "p086kj9bbs2": {
           "id": "p086kj9bbs2",
           "label": "Middle Archaic, indet.",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Archaic, indet."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -26195,7 +26195,7 @@
           },
           "id": "p086kj9bcrz",
           "label": "Cades Pond 300 B.C.-A.D. 800",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cades Pond 300 B.C.-A.D. 800"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -26223,7 +26223,7 @@
         "p086kj9bfh8": {
           "id": "p086kj9bfh8",
           "label": "Louisa Phase",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Louisa Phase"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR90",
@@ -26251,7 +26251,7 @@
         "p086kj9bhmt": {
           "id": "p086kj9bhmt",
           "label": "Historic Oneota",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic Oneota"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR9",
@@ -26284,7 +26284,7 @@
           },
           "id": "p086kj9bj2s",
           "label": "Manasota, 700 B.C.-A.D. 700",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Manasota, 700 B.C.-A.D. 700"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -26312,7 +26312,7 @@
         "p086kj9bmcd": {
           "id": "p086kj9bmcd",
           "label": "Swift Creek-Late",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Swift Creek-Late"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -26340,7 +26340,7 @@
         "p086kj9bp8z": {
           "id": "p086kj9bp8z",
           "label": "Early Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -26368,7 +26368,7 @@
         "p086kj9bqrx": {
           "id": "p086kj9bqrx",
           "label": "Historic Native American",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic Native American"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA15",
@@ -26396,7 +26396,7 @@
         "p086kj9bqtm": {
           "id": "p086kj9bqtm",
           "label": "Late Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -26424,7 +26424,7 @@
         "p086kj9bssv": {
           "id": "p086kj9bssv",
           "label": "Early Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -26452,7 +26452,7 @@
         "p086kj9bvn5": {
           "id": "p086kj9bvn5",
           "label": "Early Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -26480,7 +26480,7 @@
         "p086kj9bxjq": {
           "id": "p086kj9bxjq",
           "label": "Gulf Formational, Undifferentiated",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Gulf Formational, Undifferentiated"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -26508,7 +26508,7 @@
         "p086kj9bxs3": {
           "id": "p086kj9bxs3",
           "label": "Cemetery",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cemetery"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR122",
@@ -26536,7 +26536,7 @@
         "p086kj9bz5c": {
           "id": "p086kj9bz5c",
           "label": "Loseke Creek Variant",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Loseke Creek Variant"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR97",
@@ -26564,7 +26564,7 @@
         "p086kj9bzwc": {
           "id": "p086kj9bzwc",
           "label": "Gast phase",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Gast phase"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR103",
@@ -26597,7 +26597,7 @@
           },
           "id": "p086kj9bzz2",
           "label": "18th Century::1st quarter (1700 - 1724)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "18th Century::1st quarter (1700 - 1724)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -26630,7 +26630,7 @@
           },
           "id": "p086kj9c327",
           "label": "Seminole 1716-present",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Seminole 1716-present"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -26658,7 +26658,7 @@
         "p086kj9c357": {
           "id": "p086kj9c357",
           "label": "Early Industrial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Industrial"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -26686,7 +26686,7 @@
         "p086kj9c5bg": {
           "id": "p086kj9c5bg",
           "label": "Caloosahatchee IV",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Caloosahatchee IV"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -26714,7 +26714,7 @@
         "p086kj9c5ws": {
           "id": "p086kj9c5ws",
           "label": "Historic, Native American (Mobile)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic, Native American (Mobile)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -26742,7 +26742,7 @@
         "p086kj9c97n": {
           "id": "p086kj9c97n",
           "label": "Pensacola",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pensacola"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -26775,7 +26775,7 @@
           },
           "id": "p086kj9c9vn",
           "label": "Spanish-American War 1898-1916",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Spanish-American War 1898-1916"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -26803,7 +26803,7 @@
         "p086kj9cbfx": {
           "id": "p086kj9cbfx",
           "label": "Jonathan Creek",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Jonathan Creek"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -26831,7 +26831,7 @@
         "p086kj9cckk": {
           "id": "p086kj9cckk",
           "label": "Hardin",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hardin"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR108",
@@ -26866,7 +26866,7 @@
           },
           "id": "p086kj9ccn8",
           "label": "Seminole, 3rd War onward, 1856-",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Seminole, 3rd War onward, 1856-"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -26894,7 +26894,7 @@
         "p086kj9cdh7": {
           "id": "p086kj9cdh7",
           "label": "Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -26922,7 +26922,7 @@
         "p086kj9cfg6": {
           "id": "p086kj9cfg6",
           "label": "Protohistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Protohistoric"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -26950,7 +26950,7 @@
         "p086kj9cgb5": {
           "id": "p086kj9cgb5",
           "label": "Middle/Late Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle/Late Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -26978,7 +26978,7 @@
         "p086kj9cgts": {
           "id": "p086kj9cgts",
           "label": "Protohistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Protohistoric"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -27006,7 +27006,7 @@
         "p086kj9cj23": {
           "id": "p086kj9cj23",
           "label": "Mississippian, Undifferentiated",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mississippian, Undifferentiated"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -27034,7 +27034,7 @@
         "p086kj9ck2c": {
           "id": "p086kj9ck2c",
           "label": "Loseke",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Loseke"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR134",
@@ -27067,7 +27067,7 @@
           },
           "id": "p086kj9cm7b",
           "label": "World War I to World War II (1917 - 1945)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "World War I to World War II (1917 - 1945)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -27095,7 +27095,7 @@
         "p086kj9cmbb": {
           "id": "p086kj9cmbb",
           "label": "Blacksand",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Blacksand"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR133",
@@ -27123,7 +27123,7 @@
         "p086kj9cnsx": {
           "id": "p086kj9cnsx",
           "label": "Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -27151,7 +27151,7 @@
         "p086kj9cpjw": {
           "id": "p086kj9cpjw",
           "label": "Late Archaic/Early Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Archaic/Early Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -27179,7 +27179,7 @@
         "p086kj9cq8j": {
           "id": "p086kj9cq8j",
           "label": "Early Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -27207,7 +27207,7 @@
         "p086kj9crzh": {
           "id": "p086kj9crzh",
           "label": "Middle Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR142",
@@ -27235,7 +27235,7 @@
         "p086kj9css5": {
           "id": "p086kj9css5",
           "label": "Late Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -27268,7 +27268,7 @@
           },
           "id": "p086kj9ctdr",
           "label": "Contact Period (1607 - 1750)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Contact Period (1607 - 1750)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -27296,7 +27296,7 @@
         "p086kj9cttr": {
           "id": "p086kj9cttr",
           "label": "Sterns Creek",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Sterns Creek"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR52",
@@ -27324,7 +27324,7 @@
         "p086kj9cx9n": {
           "id": "p086kj9cx9n",
           "label": "Historic, Native American (Choctaw)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic, Native American (Choctaw)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -27352,7 +27352,7 @@
         "p086kj9cxbz": {
           "id": "p086kj9cxbz",
           "label": "Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -27380,7 +27380,7 @@
         "p086kj9czgm": {
           "id": "p086kj9czgm",
           "label": "Early Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -27408,7 +27408,7 @@
         "p086kj9czv9": {
           "id": "p086kj9czv9",
           "label": "Pioneer Iowa, Wisconsin Territory to early statehood",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pioneer Iowa, Wisconsin Territory to early statehood"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR140",
@@ -27436,7 +27436,7 @@
         "p086kj9d2g6": {
           "id": "p086kj9d2g6",
           "label": "Sioux",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Sioux"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR57",
@@ -27464,7 +27464,7 @@
         "p086kj9d5hd": {
           "id": "p086kj9d5hd",
           "label": "Colonial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Colonial"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -27492,7 +27492,7 @@
         "p086kj9d5nq": {
           "id": "p086kj9d5nq",
           "label": "Late Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -27520,7 +27520,7 @@
         "p086kj9d6kc": {
           "id": "p086kj9d6kc",
           "label": "Alachua",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Alachua"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -27548,7 +27548,7 @@
         "p086kj9d6mp": {
           "id": "p086kj9d6mp",
           "label": "Osceola",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Osceola"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR28",
@@ -27581,7 +27581,7 @@
           },
           "id": "p086kj9d84m",
           "label": "20th Century (1900 - 1999)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "20th Century (1900 - 1999)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -27609,7 +27609,7 @@
         "p086kj9d9c8": {
           "id": "p086kj9d9c8",
           "label": "Old Copper Culture",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Copper Culture"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR30",
@@ -27637,7 +27637,7 @@
         "p086kj9d9xk": {
           "id": "p086kj9d9xk",
           "label": "Medley",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medley"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -27665,7 +27665,7 @@
         "p086kj9dbcj": {
           "id": "p086kj9dbcj",
           "label": "Fayette",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Fayette"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -27693,7 +27693,7 @@
         "p086kj9dbv7": {
           "id": "p086kj9dbv7",
           "label": "German Amana Colonists",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "German Amana Colonists"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR61",
@@ -27721,7 +27721,7 @@
         "p086kj9dcst": {
           "id": "p086kj9dcst",
           "label": "Prehistoric-Aceramic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Prehistoric-Aceramic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -27749,7 +27749,7 @@
         "p086kj9ddg5": {
           "id": "p086kj9ddg5",
           "label": "Undifferentiated Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Undifferentiated Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -27782,7 +27782,7 @@
           },
           "id": "p086kj9dfv4",
           "label": "Safety Harbor, A.D. 1000-1500",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Safety Harbor, A.D. 1000-1500"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -27810,7 +27810,7 @@
         "p086kj9dfz4": {
           "id": "p086kj9dfz4",
           "label": "Early Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -27838,7 +27838,7 @@
         "p086kj9dgd3": {
           "id": "p086kj9dgd3",
           "label": "Late Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR56",
@@ -27866,7 +27866,7 @@
         "p086kj9dgnd": {
           "id": "p086kj9dgnd",
           "label": "Elliots Point",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Elliots Point"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -27894,7 +27894,7 @@
         "p086kj9dkj9": {
           "id": "p086kj9dkj9",
           "label": "Quaker",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Quaker"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR64",
@@ -27922,7 +27922,7 @@
         "p086kj9dng7": {
           "id": "p086kj9dng7",
           "label": "Middle Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -27950,7 +27950,7 @@
         "p086kj9dqjg": {
           "id": "p086kj9dqjg",
           "label": "Multi",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Multi"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -27978,7 +27978,7 @@
         "p086kj9drbr": {
           "id": "p086kj9drbr",
           "label": "Caloosahatchee I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Caloosahatchee I"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -28006,7 +28006,7 @@
         "p086kj9dt92": {
           "id": "p086kj9dt92",
           "label": "Late Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -28034,7 +28034,7 @@
         "p086kj9dzbj": {
           "id": "p086kj9dzbj",
           "label": "Historic Native American",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic Native American"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -28062,7 +28062,7 @@
         "p086kj9f4k2": {
           "id": "p086kj9f4k2",
           "label": "Nebraska",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Nebraska"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR54",
@@ -28090,7 +28090,7 @@
         "p086kj9f56n": {
           "id": "p086kj9f56n",
           "label": "Terminal Late Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Terminal Late Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -28118,7 +28118,7 @@
         "p086kj9f7x8": {
           "id": "p086kj9f7x8",
           "label": "Santa Rosa",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Santa Rosa"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -28146,7 +28146,7 @@
         "p086kj9f83j": {
           "id": "p086kj9f83j",
           "label": "20th century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "20th century"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR73",
@@ -28174,7 +28174,7 @@
         "p086kj9fc9f": {
           "id": "p086kj9fc9f",
           "label": "LW & Miss - FA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "LW & Miss - FA"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -28207,7 +28207,7 @@
           },
           "id": "p086kj9fcmf",
           "label": "Middle Archaic (6500 - 3001 B.C.)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Archaic (6500 - 3001 B.C.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -28235,7 +28235,7 @@
         "p086kj9ff2p": {
           "id": "p086kj9ff2p",
           "label": "Spring Hollow; Weaver",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Spring Hollow; Weaver"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR85",
@@ -28263,7 +28263,7 @@
         "p086kj9ffx2": {
           "id": "p086kj9ffx2",
           "label": "Oto",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Oto"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR33",
@@ -28291,7 +28291,7 @@
         "p086kj9fgzn": {
           "id": "p086kj9fgzn",
           "label": "Pre-Contact",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pre-Contact"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -28319,7 +28319,7 @@
         "p086kj9fhtm": {
           "id": "p086kj9fhtm",
           "label": "pre 1873",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "pre 1873"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR124",
@@ -28352,7 +28352,7 @@
           },
           "id": "p086kj9fnds",
           "label": "17th Century::1st quarter (1600 - 1624)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "17th Century::1st quarter (1600 - 1624)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -28385,7 +28385,7 @@
           },
           "id": "p086kj9frv2",
           "label": "17th Century::2nd half (1650 - 1699)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "17th Century::2nd half (1650 - 1699)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -28413,7 +28413,7 @@
         "p086kj9fstz": {
           "id": "p086kj9fstz",
           "label": "Belle Glade II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Belle Glade II"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -28441,7 +28441,7 @@
         "p086kj9ftd9": {
           "id": "p086kj9ftd9",
           "label": "Glenwood(?)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glenwood(?)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR53",
@@ -28469,7 +28469,7 @@
         "p086kj9fwr7": {
           "id": "p086kj9fwr7",
           "label": "Quad",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Quad"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -28497,7 +28497,7 @@
         "p086kj9fxt6": {
           "id": "p086kj9fxt6",
           "label": "Pioneer",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pioneer"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR132",
@@ -28525,7 +28525,7 @@
         "p086kj9g2q2": {
           "id": "p086kj9g2q2",
           "label": "Late Paleo-Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Paleo-Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR128",
@@ -28558,7 +28558,7 @@
           },
           "id": "p086kj9g4c9",
           "label": "Colonial (1700-1803)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Colonial (1700-1803)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA8",
@@ -28586,7 +28586,7 @@
         "p086kj9g4dm": {
           "id": "p086kj9g4dm",
           "label": "Any Woodland Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Any Woodland Period"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -28614,7 +28614,7 @@
         "p086kj9g4hm": {
           "id": "p086kj9g4hm",
           "label": "Wahpekute Dakota",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Wahpekute Dakota"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR114",
@@ -28642,7 +28642,7 @@
         "p086kj9g7w6": {
           "id": "p086kj9g7w6",
           "label": "Late Prehistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Prehistoric"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -28670,7 +28670,7 @@
         "p086kj9g8sg": {
           "id": "p086kj9g8sg",
           "label": "Oneota/Ioway/Oto",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Oneota/Ioway/Oto"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR37",
@@ -28698,7 +28698,7 @@
         "p086kj9g9jf": {
           "id": "p086kj9g9jf",
           "label": "Prehistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Prehistoric"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA35",
@@ -28731,7 +28731,7 @@
           },
           "id": "p086kj9gbmd",
           "label": "18th Century (1700 - 1799)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "18th Century (1700 - 1799)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -28759,7 +28759,7 @@
         "p086kj9gbqd": {
           "id": "p086kj9gbqd",
           "label": "Black Sand",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Black Sand"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR12",
@@ -28787,7 +28787,7 @@
         "p086kj9gdmz": {
           "id": "p086kj9gdmz",
           "label": "Malabar II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Malabar II"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -28815,7 +28815,7 @@
         "p086kj9ghf7": {
           "id": "p086kj9ghf7",
           "label": "Creek-Lower",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Creek-Lower"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -28843,7 +28843,7 @@
         "p086kj9gkmg": {
           "id": "p086kj9gkmg",
           "label": "Late Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -28871,7 +28871,7 @@
         "p086kj9gkqg": {
           "id": "p086kj9gkqg",
           "label": "Early Pioneer",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Pioneer"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR120",
@@ -28899,7 +28899,7 @@
         "p086kj9gn2q": {
           "id": "p086kj9gn2q",
           "label": "Paleoindian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Paleoindian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -28927,7 +28927,7 @@
         "p086kj9gn8q": {
           "id": "p086kj9gn8q",
           "label": "Early Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -28955,7 +28955,7 @@
         "p086kj9gpvp": {
           "id": "p086kj9gpvp",
           "label": "Lg SN Cluster",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lg SN Cluster"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -28983,7 +28983,7 @@
         "p086kj9grkm": {
           "id": "p086kj9grkm",
           "label": "Unidentified",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Unidentified"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -29011,7 +29011,7 @@
         "p086kj9gt6j": {
           "id": "p086kj9gt6j",
           "label": "Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA25",
@@ -29039,7 +29039,7 @@
         "p086kj9gtbv": {
           "id": "p086kj9gtbv",
           "label": "European Miscellaneous",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "European Miscellaneous"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -29067,7 +29067,7 @@
         "p086kj9gxdf": {
           "id": "p086kj9gxdf",
           "label": "Havana",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Havana"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR21",
@@ -29095,7 +29095,7 @@
         "p086kj9gzcd": {
           "id": "p086kj9gzcd",
           "label": "Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR29",
@@ -29123,7 +29123,7 @@
         "p086kj9gzj3": {
           "id": "p086kj9gzj3",
           "label": "Caloosahatchee III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Caloosahatchee III"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -29151,7 +29151,7 @@
         "p086kj9h22x": {
           "id": "p086kj9h22x",
           "label": "1880 to 2008",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "1880 to 2008"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR138",
@@ -29179,7 +29179,7 @@
         "p086kj9h358": {
           "id": "p086kj9h358",
           "label": "Early Swift Creek",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Swift Creek"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -29207,7 +29207,7 @@
         "p086kj9h447": {
           "id": "p086kj9h447",
           "label": "Late Paleo-Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Paleo-Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR143",
@@ -29240,7 +29240,7 @@
           },
           "id": "p086kj9h55t",
           "label": "Nineteenth C. American 1821-1899",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Nineteenth C. American 1821-1899"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -29268,7 +29268,7 @@
         "p086kj9hb3n": {
           "id": "p086kj9hb3n",
           "label": "Thebes-Lost Lake",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Thebes-Lost Lake"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -29296,7 +29296,7 @@
         "p086kj9hb5b": {
           "id": "p086kj9hb5b",
           "label": "Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA21",
@@ -29324,7 +29324,7 @@
         "p086kj9hfdj": {
           "id": "p086kj9hfdj",
           "label": "Paleoindian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Paleoindian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -29357,7 +29357,7 @@
           },
           "id": "p086kj9hk3q",
           "label": "17th Century (1600 - 1699)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "17th Century (1600 - 1699)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -29385,7 +29385,7 @@
         "p086kj9hq48": {
           "id": "p086kj9hq48",
           "label": "Historical",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historical"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -29413,7 +29413,7 @@
         "p086kj9hqkk": {
           "id": "p086kj9hqkk",
           "label": "Apalachee",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Apalachee"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -29446,7 +29446,7 @@
           },
           "id": "p086kj9hqsk",
           "label": "Post Cold War (1989 - Present)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Post Cold War (1989 - Present)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -29474,7 +29474,7 @@
         "p086kj9hrkv": {
           "id": "p086kj9hrkv",
           "label": "Pammel Creek",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pammel Creek"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR79",
@@ -29502,7 +29502,7 @@
         "p086kj9ht5g": {
           "id": "p086kj9ht5g",
           "label": "Crab Orchard",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Crab Orchard"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -29530,7 +29530,7 @@
         "p086kj9hvkr": {
           "id": "p086kj9hvkr",
           "label": "Red Ochre",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Red Ochre"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR102",
@@ -29558,7 +29558,7 @@
         "p086kj9hxn2": {
           "id": "p086kj9hxn2",
           "label": "Unknown Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Unknown Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -29586,7 +29586,7 @@
         "p086kj9j2k7": {
           "id": "p086kj9j2k7",
           "label": "Late Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -29620,7 +29620,7 @@
           },
           "id": "p086kj9j3tt",
           "label": "Terminal Late Woodland (Emergent Miss.)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Terminal Late Woodland (Emergent Miss.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA16",
@@ -29648,7 +29648,7 @@
         "p086kj9j4fg": {
           "id": "p086kj9j4fg",
           "label": "General Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "General Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -29676,7 +29676,7 @@
         "p086kj9j5rr": {
           "id": "p086kj9j5rr",
           "label": "Weeden Island II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Weeden Island II"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -29709,7 +29709,7 @@
           },
           "id": "p086kj9j8fn",
           "label": "Antebellum Period (1830 - 1860)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Antebellum Period (1830 - 1860)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -29742,7 +29742,7 @@
           },
           "id": "p086kj9j8wz",
           "label": "Twentieth C American",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Twentieth C American"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -29770,7 +29770,7 @@
         "p086kj9j94x": {
           "id": "p086kj9j94x",
           "label": "WWI military structure remains",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "WWI military structure remains"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR86",
@@ -29798,7 +29798,7 @@
         "p086kj9j989": {
           "id": "p086kj9j989",
           "label": "Late Paleo Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Paleo Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -29826,7 +29826,7 @@
         "p086kj9jc8v": {
           "id": "p086kj9jc8v",
           "label": "Early Paleoindian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Paleoindian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -29854,7 +29854,7 @@
         "p086kj9jcrj": {
           "id": "p086kj9jcrj",
           "label": "Suwannee Valley Culture",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Suwannee Valley Culture"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -29882,7 +29882,7 @@
         "p086kj9jd26": {
           "id": "p086kj9jd26",
           "label": "Belle Glade I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Belle Glade I"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -29910,7 +29910,7 @@
         "p086kj9jg7f": {
           "id": "p086kj9jg7f",
           "label": "Mill Phase",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mill Phase"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR8",
@@ -29938,7 +29938,7 @@
         "p086kj9jggr": {
           "id": "p086kj9jggr",
           "label": "African-American",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "African-American"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -29966,7 +29966,7 @@
         "p086kj9jhs3": {
           "id": "p086kj9jhs3",
           "label": "Middle Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR129",
@@ -29999,7 +29999,7 @@
           },
           "id": "p086kj9jkgn",
           "label": "Late Archaic (3000 - 1201 B.C.)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Archaic (3000 - 1201 B.C.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -30027,7 +30027,7 @@
         "p086kj9jkrb": {
           "id": "p086kj9jkrb",
           "label": "Early Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -30060,7 +30060,7 @@
           },
           "id": "p086kj9jn9k",
           "label": "Civil War (1861 - 1865)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Civil War (1861 - 1865)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -30093,7 +30093,7 @@
           },
           "id": "p086kj9jndk",
           "label": "Seminole-Colonization Period 1750-1816",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Seminole-Colonization Period 1750-1816"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -30121,7 +30121,7 @@
         "p086kj9jpmv": {
           "id": "p086kj9jpmv",
           "label": "Winnebago",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Winnebago"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR38",
@@ -30154,7 +30154,7 @@
           },
           "id": "p086kj9jqnh",
           "label": "Early National Period (1790 - 1829)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early National Period (1790 - 1829)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -30182,7 +30182,7 @@
         "p086kj9jrg5": {
           "id": "p086kj9jrg5",
           "label": "St. Johns IIc",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "St. Johns IIc"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -30210,7 +30210,7 @@
         "p086kj9jvdc": {
           "id": "p086kj9jvdc",
           "label": "Glades IIIc",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glades IIIc"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -30238,7 +30238,7 @@
         "p086kj9jvrp": {
           "id": "p086kj9jvrp",
           "label": "Archaic unspecified",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic unspecified"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -30271,7 +30271,7 @@
           },
           "id": "p086kj9jvw2",
           "label": "Late Woodland (1000 - 1606)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Woodland (1000 - 1606)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -30299,7 +30299,7 @@
         "p086kj9jzcw": {
           "id": "p086kj9jzcw",
           "label": "early Late Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "early Late Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR10",
@@ -30327,7 +30327,7 @@
         "p086kj9jzkw": {
           "id": "p086kj9jzkw",
           "label": "Early Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA9",
@@ -30355,7 +30355,7 @@
         "p086kj9kbct": {
           "id": "p086kj9kbct",
           "label": "Middle Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -30388,7 +30388,7 @@
           },
           "id": "p086kj9kft3",
           "label": "17th Century::3rd quarter (1650 - 1674)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "17th Century::3rd quarter (1650 - 1674)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -30416,7 +30416,7 @@
         "p086kj9kfzd": {
           "id": "p086kj9kfzd",
           "label": "Perico Island",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Perico Island"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -30449,7 +30449,7 @@
           },
           "id": "p086kj9kh9n",
           "label": "Glades I, 1000 B.C.-A.D. 750",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glades I, 1000 B.C.-A.D. 750"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -30477,7 +30477,7 @@
         "p086kj9kknk": {
           "id": "p086kj9kknk",
           "label": "Late Paleoindian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Paleoindian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -30510,7 +30510,7 @@
           },
           "id": "p086kj9kkzk",
           "label": "Transitional, 1000 B.C.-700 B.C.",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Transitional, 1000 B.C.-700 B.C."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -30538,7 +30538,7 @@
         "p086kj9km57": {
           "id": "p086kj9km57",
           "label": "Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -30566,7 +30566,7 @@
         "p086kj9kr9q": {
           "id": "p086kj9kr9q",
           "label": "Archaic-Late",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic-Late"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -30594,7 +30594,7 @@
         "p086kj9ksh2": {
           "id": "p086kj9ksh2",
           "label": "Pre-Clovis",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pre-Clovis"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA11",
@@ -30622,7 +30622,7 @@
         "p086kj9ktwz": {
           "id": "p086kj9ktwz",
           "label": "Gast",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Gast"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR115",
@@ -30650,7 +30650,7 @@
         "p086kj9kv3m": {
           "id": "p086kj9kv3m",
           "label": "Hopewell/Havana",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hopewell/Havana"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR107",
@@ -30683,7 +30683,7 @@
           },
           "id": "p086kj9kvs9",
           "label": "Colony to Nation (1751 - 1789)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Colony to Nation (1751 - 1789)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -30716,7 +30716,7 @@
           },
           "id": "p086kj9kwkk",
           "label": "Ft. Walton A.D. 1000-1500",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ft. Walton A.D. 1000-1500"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -30744,7 +30744,7 @@
         "p086kj9kx67": {
           "id": "p086kj9kx67",
           "label": "Malabar I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Malabar I"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -30772,7 +30772,7 @@
         "p086kj9kxpv": {
           "id": "p086kj9kxpv",
           "label": "Late Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -30805,7 +30805,7 @@
           },
           "id": "p086kj9kxzj",
           "label": "20th Century::1st half (1900 - 1949)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "20th Century::1st half (1900 - 1949)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -30833,7 +30833,7 @@
         "p086kj9kzth": {
           "id": "p086kj9kzth",
           "label": "Middle Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -30861,7 +30861,7 @@
         "p086kj9m263": {
           "id": "p086kj9m263",
           "label": "Paleoindian, Undifferentiated",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Paleoindian, Undifferentiated"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -30894,7 +30894,7 @@
           },
           "id": "p086kj9m2fd",
           "label": "Urban / Industrial (1900-1960)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Urban / Industrial (1900-1960)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA18",
@@ -30922,7 +30922,7 @@
         "p086kj9m39c": {
           "id": "p086kj9m39c",
           "label": "Late Archaic, indet.",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Archaic, indet."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -30950,7 +30950,7 @@
         "p086kj9m5wm": {
           "id": "p086kj9m5wm",
           "label": "First Spanish, Early 1600-1699",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "First Spanish, Early 1600-1699"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -30983,7 +30983,7 @@
           },
           "id": "p086kj9m6nk",
           "label": "18th Century::2nd half (1750 - 1799)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "18th Century::2nd half (1750 - 1799)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -31011,7 +31011,7 @@
         "p086kj9m757": {
           "id": "p086kj9m757",
           "label": "Glades IIc",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glades IIc"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -31039,7 +31039,7 @@
         "p086kj9m8ch": {
           "id": "p086kj9m8ch",
           "label": "Clovis",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Clovis"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -31067,7 +31067,7 @@
         "p086kj9m9gs": {
           "id": "p086kj9m9gs",
           "label": "General Paleo Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "General Paleo Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -31095,7 +31095,7 @@
         "p086kj9mb3f": {
           "id": "p086kj9mb3f",
           "label": "Glades IIb",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glades IIb"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -31123,7 +31123,7 @@
         "p086kj9mdwp": {
           "id": "p086kj9mdwp",
           "label": "Riverton",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Riverton"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -31151,7 +31151,7 @@
         "p086kj9mf4n": {
           "id": "p086kj9mf4n",
           "label": "Historic, Undifferentiated",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic, Undifferentiated"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -31179,7 +31179,7 @@
         "p086kj9mkdh": {
           "id": "p086kj9mkdh",
           "label": "Nebraska Phase",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Nebraska Phase"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR26",
@@ -31207,7 +31207,7 @@
         "p086kj9mr3z": {
           "id": "p086kj9mr3z",
           "label": "Mill Creek",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mill Creek"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR7",
@@ -31235,7 +31235,7 @@
         "p086kj9mtdk": {
           "id": "p086kj9mtdk",
           "label": "Middle Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -31263,7 +31263,7 @@
         "p086kj9mtxk": {
           "id": "p086kj9mtxk",
           "label": "1870-1998",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "1870-1998"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR94",
@@ -31291,7 +31291,7 @@
         "p086kj9n54j": {
           "id": "p086kj9n54j",
           "label": "Pelican Lake",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pelican Lake"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR75",
@@ -31324,7 +31324,7 @@
           },
           "id": "p086kj9n5x7",
           "label": "Boom Times 1921-1929",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Boom Times 1921-1929"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -31352,7 +31352,7 @@
         "p086kj9ndfm": {
           "id": "p086kj9ndfm",
           "label": "Archaic, Early Big Sandy",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic, Early Big Sandy"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -31380,7 +31380,7 @@
         "p086kj9ndsx": {
           "id": "p086kj9ndsx",
           "label": "Norwood",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Norwood"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -31408,7 +31408,7 @@
         "p086kj9nfg8": {
           "id": "p086kj9nfg8",
           "label": "Contact Era Prehistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Contact Era Prehistoric"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -31436,7 +31436,7 @@
         "p086kj9nkmr": {
           "id": "p086kj9nkmr",
           "label": "Ioway",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ioway"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR34",
@@ -31464,7 +31464,7 @@
         "p086kj9nm4d": {
           "id": "p086kj9nm4d",
           "label": "Sac?",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Sac?"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR89",
@@ -31492,7 +31492,7 @@
         "p086kj9nmgq": {
           "id": "p086kj9nmgq",
           "label": "Louisa",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Louisa"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR92",
@@ -31525,7 +31525,7 @@
           },
           "id": "p086kj9np4z",
           "label": "1870 - 1930",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "1870 - 1930"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR95",
@@ -31553,7 +31553,7 @@
         "p086kj9npfz": {
           "id": "p086kj9npfz",
           "label": "Late Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -31581,7 +31581,7 @@
         "p086kj9nqcm": {
           "id": "p086kj9nqcm",
           "label": "Early Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA29",
@@ -31609,7 +31609,7 @@
         "p086kj9ntb6": {
           "id": "p086kj9ntb6",
           "label": "James Bayou",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "James Bayou"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -31637,7 +31637,7 @@
         "p086kj9ntgh": {
           "id": "p086kj9ntgh",
           "label": "Liverpool",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Liverpool"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR27",
@@ -31665,7 +31665,7 @@
         "p086kj9nvrg": {
           "id": "p086kj9nvrg",
           "label": "Skidmore",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Skidmore"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -31693,7 +31693,7 @@
         "p086kj9nzgp": {
           "id": "p086kj9nzgp",
           "label": "Late Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -31721,7 +31721,7 @@
         "p086kj9p2c8": {
           "id": "p086kj9p2c8",
           "label": "Historic Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -31749,7 +31749,7 @@
         "p086kj9p3qv": {
           "id": "p086kj9p3qv",
           "label": "Late Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA27",
@@ -31777,7 +31777,7 @@
         "p086kj9p63r": {
           "id": "p086kj9p63r",
           "label": "Historic, Native American (Tomeh)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic, Native American (Tomeh)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -31805,7 +31805,7 @@
         "p086kj9p68f": {
           "id": "p086kj9p68f",
           "label": "Keyes",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Keyes"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR11",
@@ -31833,7 +31833,7 @@
         "p086kj9pbdx": {
           "id": "p086kj9pbdx",
           "label": "Prehistoric, unspecified",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Prehistoric, unspecified"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -31861,7 +31861,7 @@
         "p086kj9pbf9": {
           "id": "p086kj9pbf9",
           "label": "Faulkner",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Faulkner"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -31889,7 +31889,7 @@
         "p086kj9pdhj": {
           "id": "p086kj9pdhj",
           "label": "Newtown",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Newtown"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -31917,7 +31917,7 @@
         "p086kj9pf2h": {
           "id": "p086kj9pf2h",
           "label": "Pioneer",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pioneer"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -31945,7 +31945,7 @@
         "p086kj9ph84": {
           "id": "p086kj9ph84",
           "label": "Unknown historic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Unknown historic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -31973,7 +31973,7 @@
         "p086kj9phrr": {
           "id": "p086kj9phrr",
           "label": "Belle Glade IV",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Belle Glade IV"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -32001,7 +32001,7 @@
         "p086kj9pk32": {
           "id": "p086kj9pk32",
           "label": "19th century urban",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th century urban"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR131",
@@ -32029,7 +32029,7 @@
         "p086kj9pk8p": {
           "id": "p086kj9pk8p",
           "label": "Late Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -32057,7 +32057,7 @@
         "p086kj9pkgp": {
           "id": "p086kj9pkgp",
           "label": "Weeden Island 4",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Weeden Island 4"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -32085,7 +32085,7 @@
         "p086kj9pmnn": {
           "id": "p086kj9pmnn",
           "label": "Middle Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -32113,7 +32113,7 @@
         "p086kj9pn59": {
           "id": "p086kj9pn59",
           "label": "Middle Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR36",
@@ -32141,7 +32141,7 @@
         "p086kj9ppwk": {
           "id": "p086kj9ppwk",
           "label": "early Middle Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "early Middle Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR72",
@@ -32169,7 +32169,7 @@
         "p086kj9pr3h": {
           "id": "p086kj9pr3h",
           "label": "Mt. Taylor",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mt. Taylor"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -32202,7 +32202,7 @@
           },
           "id": "p086kj9pr6h",
           "label": "Modern (Post 1950)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern (Post 1950)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -32230,7 +32230,7 @@
         "p086kj9prmh": {
           "id": "p086kj9prmh",
           "label": "Dorena",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Dorena"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -32258,7 +32258,7 @@
         "p086kj9pshs": {
           "id": "p086kj9pshs",
           "label": "Madison Phase",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Madison Phase"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR19",
@@ -32286,7 +32286,7 @@
         "p086kj9ptt4": {
           "id": "p086kj9ptt4",
           "label": "<c.1950",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "<c.1950"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR109",
@@ -32319,7 +32319,7 @@
           },
           "id": "p086kj9pv4q",
           "label": "19th Century::1st quarter (1800 - 1825)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th Century::1st quarter (1800 - 1825)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -32352,7 +32352,7 @@
           },
           "id": "p086kj9pxcn",
           "label": "19th Century::2nd half (1850 - 1899)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th Century::2nd half (1850 - 1899)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -32385,7 +32385,7 @@
           },
           "id": "p086kj9q8fx",
           "label": "St. Johns II, A.D. 800-1500",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "St. Johns II, A.D. 800-1500"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -32413,7 +32413,7 @@
         "p086kj9qdms": {
           "id": "p086kj9qdms",
           "label": "Middle Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -32441,7 +32441,7 @@
         "p086kj9qgvq": {
           "id": "p086kj9qgvq",
           "label": "Terminal Late Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Terminal Late Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -32469,7 +32469,7 @@
         "p086kj9qmp8": {
           "id": "p086kj9qmp8",
           "label": "Folsom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Folsom"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR16",
@@ -32497,7 +32497,7 @@
         "p086kj9qn8j": {
           "id": "p086kj9qn8j",
           "label": "Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -32525,7 +32525,7 @@
         "p086kj9qp5t": {
           "id": "p086kj9qp5t",
           "label": "Millville",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Millville"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR81",
@@ -32553,7 +32553,7 @@
         "p086kj9qppt": {
           "id": "p086kj9qppt",
           "label": "Orr phase",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Orr phase"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR93",
@@ -32586,7 +32586,7 @@
           },
           "id": "p086kj9qq6g",
           "label": "Spanish-Second Period 1783-1821",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Spanish-Second Period 1783-1821"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -32614,7 +32614,7 @@
         "p086kj9qqdg": {
           "id": "p086kj9qqdg",
           "label": "Hoecake",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hoecake"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -32642,7 +32642,7 @@
         "p086kj9qqfs": {
           "id": "p086kj9qqfs",
           "label": "Clovis/Gainey",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Clovis/Gainey"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR111",
@@ -32670,7 +32670,7 @@
         "p086kj9qt22": {
           "id": "p086kj9qt22",
           "label": "Weeden Island 2",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Weeden Island 2"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -32703,7 +32703,7 @@
           },
           "id": "p086kj9qtfp",
           "label": "Spanish-First Period 1513-1763",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Spanish-First Period 1513-1763"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -32731,7 +32731,7 @@
         "p086kj9qxjk": {
           "id": "p086kj9qxjk",
           "label": "Late Gulf Formational",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Gulf Formational"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -32764,7 +32764,7 @@
           },
           "id": "p086kj9qztj",
           "label": "Prehistoric/Unknown (15000 B.C. - 1606 A.D.)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Prehistoric/Unknown (15000 B.C. - 1606 A.D.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -32792,7 +32792,7 @@
         "p086kj9qzzv": {
           "id": "p086kj9qzzv",
           "label": "French",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "French"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -32820,7 +32820,7 @@
         "p086kj9r59z": {
           "id": "p086kj9r59z",
           "label": "Paleo Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Paleo Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -32848,7 +32848,7 @@
         "p086kj9rbs5": {
           "id": "p086kj9rbs5",
           "label": "St. Augustine",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "St. Augustine"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -32876,7 +32876,7 @@
         "p086kj9rdfd": {
           "id": "p086kj9rdfd",
           "label": "Spanish-1st or 2nd",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Spanish-1st or 2nd"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -32904,7 +32904,7 @@
         "p086kj9rhj9": {
           "id": "p086kj9rhj9",
           "label": "Other",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Other"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA19",
@@ -32932,7 +32932,7 @@
         "p086kj9rj2w": {
           "id": "p086kj9rj2w",
           "label": "General Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "General Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -32960,7 +32960,7 @@
         "p086kj9rkxj": {
           "id": "p086kj9rkxj",
           "label": "Bifurcate",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bifurcate"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -32988,7 +32988,7 @@
         "p086kj9rm6t": {
           "id": "p086kj9rm6t",
           "label": "Historic, Native American (Natchez)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic, Native American (Natchez)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -33021,7 +33021,7 @@
           },
           "id": "p086kj9rn4g",
           "label": "American 1821-present",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "American 1821-present"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -33049,7 +33049,7 @@
         "p086kj9rvj8": {
           "id": "p086kj9rvj8",
           "label": "Frederick?",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Frederick?"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR91",
@@ -33077,7 +33077,7 @@
         "p086kj9rwbj": {
           "id": "p086kj9rwbj",
           "label": "Weeden Island 5",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Weeden Island 5"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -33105,7 +33105,7 @@
         "p086kj9rwzj": {
           "id": "p086kj9rwzj",
           "label": "German Amana Colonist",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "German Amana Colonist"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR62",
@@ -33138,7 +33138,7 @@
           },
           "id": "p086kj9rxqh",
           "label": "Civil War 1861-1865",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Civil War 1861-1865"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -33166,7 +33166,7 @@
         "p086kj9rxvt": {
           "id": "p086kj9rxvt",
           "label": "Agate Basin",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Agate Basin"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR88",
@@ -33194,7 +33194,7 @@
         "p086kj9s35b": {
           "id": "p086kj9s35b",
           "label": "Middle-Late Woodland, indet.",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle-Late Woodland, indet."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -33222,7 +33222,7 @@
         "p086kj9s48m": {
           "id": "p086kj9s48m",
           "label": "Eighteenth Century Spanish 1700-1763",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Eighteenth Century Spanish 1700-1763"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -33250,7 +33250,7 @@
         "p086kj9s4pm": {
           "id": "p086kj9s4pm",
           "label": "Paleo-Early",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Paleo-Early"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -33278,7 +33278,7 @@
         "p086kj9s4tx": {
           "id": "p086kj9s4tx",
           "label": "Not Reported",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Not Reported"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA30",
@@ -33306,7 +33306,7 @@
         "p086kj9s5ww": {
           "id": "p086kj9s5ww",
           "label": "Early Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -33334,7 +33334,7 @@
         "p086kj9s6bv": {
           "id": "p086kj9s6bv",
           "label": "Mann",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mann"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -33362,7 +33362,7 @@
         "p086kj9sdpz": {
           "id": "p086kj9sdpz",
           "label": "Quaker?",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Quaker?"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR63",
@@ -33395,7 +33395,7 @@
           },
           "id": "p086kj9sf59",
           "label": "18th Century::4th quarter (1775 - 1799)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "18th Century::4th quarter (1775 - 1799)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -33428,7 +33428,7 @@
           },
           "id": "p086kj9sfdm",
           "label": "20th Century::4th quarter (1975 - 1999)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "20th Century::4th quarter (1975 - 1999)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -33456,7 +33456,7 @@
         "p086kj9sg6w": {
           "id": "p086kj9sg6w",
           "label": "Late Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA24",
@@ -33484,7 +33484,7 @@
         "p086kj9shbj": {
           "id": "p086kj9shbj",
           "label": "Caloosahatchee IIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Caloosahatchee IIA"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -33512,7 +33512,7 @@
         "p086kj9sp72": {
           "id": "p086kj9sp72",
           "label": "Indet. Fort Ancient",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Indet. Fort Ancient"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -33540,7 +33540,7 @@
         "p086kj9sphp": {
           "id": "p086kj9sphp",
           "label": "Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -33573,7 +33573,7 @@
           },
           "id": "p086kj9srkx",
           "label": "Glades, 1000 B.C.-A.D. 1700",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glades, 1000 B.C.-A.D. 1700"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -33606,7 +33606,7 @@
           },
           "id": "p086kj9srm9",
           "label": "Paleo-Indian (15000 - 8501 B.C.)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Paleo-Indian (15000 - 8501 B.C.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -33634,7 +33634,7 @@
         "p086kj9ssnw": {
           "id": "p086kj9ssnw",
           "label": "Hell Gap",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hell Gap"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR47",
@@ -33662,7 +33662,7 @@
         "p086kj9sttv": {
           "id": "p086kj9sttv",
           "label": "Early Paleo Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Paleo Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -33690,7 +33690,7 @@
         "p086kj9svgt": {
           "id": "p086kj9svgt",
           "label": "Middle Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA28",
@@ -33718,7 +33718,7 @@
         "p086kj9sw6g": {
           "id": "p086kj9sw6g",
           "label": "Adena",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Adena"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -33746,7 +33746,7 @@
         "p086kj9swk5": {
           "id": "p086kj9swk5",
           "label": "18th Century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "18th Century"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -33779,7 +33779,7 @@
           },
           "id": "p086kj9sxn4",
           "label": "Early Industrial (1866-1899)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Industrial (1866-1899)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA32",
@@ -33807,7 +33807,7 @@
         "p086kj9sxxr": {
           "id": "p086kj9sxxr",
           "label": "Historic, Native American (Apalachee)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic, Native American (Apalachee)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -33835,7 +33835,7 @@
         "p086kj9szbd": {
           "id": "p086kj9szbd",
           "label": "Sac",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Sac"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR48",
@@ -33863,7 +33863,7 @@
         "p086kj9szpq": {
           "id": "p086kj9szpq",
           "label": "Possible Paleoindian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Possible Paleoindian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -33891,7 +33891,7 @@
         "p086kj9szvd": {
           "id": "p086kj9szvd",
           "label": "Middle Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -33919,7 +33919,7 @@
         "p086kj9t437": {
           "id": "p086kj9t437",
           "label": "17th Century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "17th Century"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -33947,7 +33947,7 @@
         "p086kj9t69s": {
           "id": "p086kj9t69s",
           "label": "Tri Pt Only",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Tri Pt Only"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -33975,7 +33975,7 @@
         "p086kj9t6r5": {
           "id": "p086kj9t6r5",
           "label": "Historic/Unknown",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic/Unknown"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -34008,7 +34008,7 @@
           },
           "id": "p086kj9t9hp",
           "label": "Early Archaic (8500 - 6501 B.C.)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Archaic (8500 - 6501 B.C.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -34036,7 +34036,7 @@
         "p086kj9tbgn": {
           "id": "p086kj9tbgn",
           "label": "Early-Middle Archaic, indet.",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early-Middle Archaic, indet."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -34064,7 +34064,7 @@
         "p086kj9tc2x": {
           "id": "p086kj9tc2x",
           "label": "Allamakee Phase",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Allamakee Phase"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR22",
@@ -34092,7 +34092,7 @@
         "p086kj9tcwx": {
           "id": "p086kj9tcwx",
           "label": "Paleo-indian, undefined",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Paleo-indian, undefined"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -34120,7 +34120,7 @@
         "p086kj9thdg": {
           "id": "p086kj9thdg",
           "label": "Weaver",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Weaver"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR20",
@@ -34153,7 +34153,7 @@
           },
           "id": "p086kj9tj9r",
           "label": "Archaic (8500 - 1201 B.C.)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic (8500 - 1201 B.C.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -34181,7 +34181,7 @@
         "p086kj9tjj4": {
           "id": "p086kj9tjj4",
           "label": "Caloosahatchee IIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Caloosahatchee IIB"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -34209,7 +34209,7 @@
         "p086kj9tqd8": {
           "id": "p086kj9tqd8",
           "label": "Missouri Bluffs",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Missouri Bluffs"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR51",
@@ -34237,7 +34237,7 @@
         "p086kj9tqsw": {
           "id": "p086kj9tqsw",
           "label": "Quakers",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Quakers"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR71",
@@ -34265,7 +34265,7 @@
         "p086kj9tqzk": {
           "id": "p086kj9tqzk",
           "label": "19th Century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th Century"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -34298,7 +34298,7 @@
           },
           "id": "p086kj9tr4v",
           "label": "Civil War (1861-1865)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Civil War (1861-1865)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA33",
@@ -34326,7 +34326,7 @@
         "p086kj9tr6j": {
           "id": "p086kj9tr6j",
           "label": "Judge Tobin",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Judge Tobin"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR121",
@@ -34359,7 +34359,7 @@
           },
           "id": "p086kj9ttng",
           "label": "Early/Middle Woodland (1200 B.C. - 999 A.D.)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early/Middle Woodland (1200 B.C. - 999 A.D.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -34392,7 +34392,7 @@
           },
           "id": "p086kj9twsd",
           "label": "Depression/New Deal 1930-1940",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Depression/New Deal 1930-1940"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -34425,7 +34425,7 @@
           },
           "id": "p086kj9v37h",
           "label": "Caloosahatchee 500 B.C.-1700 A.D.",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Caloosahatchee 500 B.C.-1700 A.D."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -34458,7 +34458,7 @@
           },
           "id": "p086kj9v6zd",
           "label": "Hickory Pond, A.D. 800-1250",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hickory Pond, A.D. 800-1250"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -34491,7 +34491,7 @@
           },
           "id": "p086kj9v8jz",
           "label": "Deptford 700 B.C.-300 B.C.",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Deptford 700 B.C.-300 B.C."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -34519,7 +34519,7 @@
         "p086kj9vbx8": {
           "id": "p086kj9vbx8",
           "label": "Unidentified Prehistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Unidentified Prehistoric"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -34547,7 +34547,7 @@
         "p086kj9vc57": {
           "id": "p086kj9vc57",
           "label": "Possible Meskwaki",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Possible Meskwaki"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR67",
@@ -34575,7 +34575,7 @@
         "p086kj9vh3q": {
           "id": "p086kj9vh3q",
           "label": "Contact",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Contact"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -34603,7 +34603,7 @@
         "p086kj9vqdh": {
           "id": "p086kj9vqdh",
           "label": "Indet. Prehistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Indet. Prehistoric"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -34631,7 +34631,7 @@
         "p086kj9vqjt": {
           "id": "p086kj9vqjt",
           "label": "Durst",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Durst"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR43",
@@ -34659,7 +34659,7 @@
         "p086kj9vv5c": {
           "id": "p086kj9vv5c",
           "label": "Tablerock",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Tablerock"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -34687,7 +34687,7 @@
         "p086kj9vv6p": {
           "id": "p086kj9vv6p",
           "label": "Protohistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Protohistoric"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -34715,7 +34715,7 @@
         "p086kj9vvr2": {
           "id": "p086kj9vvr2",
           "label": "early Middle Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "early Middle Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR101",
@@ -34743,7 +34743,7 @@
         "p086kj9vxnm": {
           "id": "p086kj9vxnm",
           "label": "early 19th century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "early 19th century"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR135",
@@ -34776,7 +34776,7 @@
           },
           "id": "p086kj9vzjw",
           "label": "Weeden Island A.D. 450-1000",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Weeden Island A.D. 450-1000"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -34804,7 +34804,7 @@
         "p086kj9w265": {
           "id": "p086kj9w265",
           "label": "Allamakee",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Allamakee"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR77",
@@ -34832,7 +34832,7 @@
         "p086kj9w6vn": {
           "id": "p086kj9w6vn",
           "label": "Kolomoki",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Kolomoki"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -34860,7 +34860,7 @@
         "p086kj9w7rx": {
           "id": "p086kj9w7rx",
           "label": "Late Paleo-Indian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Paleo-Indian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -34888,7 +34888,7 @@
         "p086kj9w8v8": {
           "id": "p086kj9w8v8",
           "label": "ca. 1930s-1940s",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "ca. 1930s-1940s"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR126",
@@ -34921,7 +34921,7 @@
           },
           "id": "p086kj9w9vj",
           "label": "Reconstruction and Growth (1866 - 1916)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Reconstruction and Growth (1866 - 1916)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -34949,7 +34949,7 @@
         "p086kj9wb7t": {
           "id": "p086kj9wb7t",
           "label": "Weeden Island I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Weeden Island I"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -34982,7 +34982,7 @@
           },
           "id": "p086kj9wbvt",
           "label": "19th Century (1800 - 1899)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th Century (1800 - 1899)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -35010,7 +35010,7 @@
         "p086kj9wghp": {
           "id": "p086kj9wghp",
           "label": "Historic-Unspecified",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic-Unspecified"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -35038,7 +35038,7 @@
         "p086kj9wk7w": {
           "id": "p086kj9wk7w",
           "label": "Havana/ Hopewell",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Havana/ Hopewell"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR106",
@@ -35066,7 +35066,7 @@
         "p086kj9wmf7": {
           "id": "p086kj9wmf7",
           "label": "Dutch",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Dutch"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -35094,7 +35094,7 @@
         "p086kj9wn5t": {
           "id": "p086kj9wn5t",
           "label": "Late Woodland, indet.",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Woodland, indet."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -35122,7 +35122,7 @@
         "p086kj9wtwb": {
           "id": "p086kj9wtwb",
           "label": "Protohistoric, Undifferentiated",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Protohistoric, Undifferentiated"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -35155,7 +35155,7 @@
           },
           "id": "p086kj9wzb6",
           "label": "20th Century::2nd quarter (1925 - 1949)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "20th Century::2nd quarter (1925 - 1949)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -35188,7 +35188,7 @@
           },
           "id": "p086kj9x24q",
           "label": "17th Century::2nd/3rd quarter (1625 - 1674)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "17th Century::2nd/3rd quarter (1625 - 1674)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -35216,7 +35216,7 @@
         "p086kj9x4kn": {
           "id": "p086kj9x4kn",
           "label": "Early Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -35244,7 +35244,7 @@
         "p086kj9x64w": {
           "id": "p086kj9x64w",
           "label": "Middle Woodland, indet",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Woodland, indet"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -35272,7 +35272,7 @@
         "p086kj9x8h6": {
           "id": "p086kj9x8h6",
           "label": "Historic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -35300,7 +35300,7 @@
         "p086kj9xc33": {
           "id": "p086kj9xc33",
           "label": "Middle Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -35333,7 +35333,7 @@
           },
           "id": "p086kj9xd3c",
           "label": "20th Century::3rd quarter (1950 - 1974)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "20th Century::3rd quarter (1950 - 1974)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -35361,7 +35361,7 @@
         "p086kj9xfhn": {
           "id": "p086kj9xfhn",
           "label": "Red Ocher",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Red Ocher"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR39",
@@ -35389,7 +35389,7 @@
         "p086kj9xgsm": {
           "id": "p086kj9xgsm",
           "label": "Dalton",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Dalton"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA22",
@@ -35417,7 +35417,7 @@
         "p086kj9xj27": {
           "id": "p086kj9xj27",
           "label": "Pottawattamie",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pottawattamie"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR45",
@@ -35445,7 +35445,7 @@
         "p086kj9xp73": {
           "id": "p086kj9xp73",
           "label": "Wahpkute band of the Santee Dakota Sioux",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Wahpkute band of the Santee Dakota Sioux"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR87",
@@ -35473,7 +35473,7 @@
         "p086kj9xr2z": {
           "id": "p086kj9xr2z",
           "label": "Historic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA31",
@@ -35501,7 +35501,7 @@
         "p086kj9xshm": {
           "id": "p086kj9xshm",
           "label": "Middle Paleoindian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Paleoindian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -35529,7 +35529,7 @@
         "p086kj9xt78": {
           "id": "p086kj9xt78",
           "label": "Englewood",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Englewood"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -35557,7 +35557,7 @@
         "p086kj9xt8k": {
           "id": "p086kj9xt8k",
           "label": "Late Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
@@ -35590,7 +35590,7 @@
           },
           "id": "p086kj9xtn8",
           "label": "First Spanish Period 1513-1599",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "First Spanish Period 1513-1599"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -35618,7 +35618,7 @@
         "p086kj9xzq4": {
           "id": "p086kj9xzq4",
           "label": "Early Gulf Formational",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Gulf Formational"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -35646,7 +35646,7 @@
         "p086kj9z468": {
           "id": "p086kj9z468",
           "label": "Webb and Funk Survey",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Webb and Funk Survey"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -35674,7 +35674,7 @@
         "p086kj9z47k": {
           "id": "p086kj9z47k",
           "label": "Indeterminate",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Indeterminate"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -35702,7 +35702,7 @@
         "p086kj9z4d8": {
           "id": "p086kj9z4d8",
           "label": "Mormon",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mormon"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR44",
@@ -35730,7 +35730,7 @@
         "p086kj9z527": {
           "id": "p086kj9z527",
           "label": "St. Johns IIa",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "St. Johns IIa"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -35758,7 +35758,7 @@
         "p086kj9z557": {
           "id": "p086kj9z557",
           "label": "Dalton",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Dalton"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR23",
@@ -35786,7 +35786,7 @@
         "p086kj9z66t": {
           "id": "p086kj9z66t",
           "label": "19th urban",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th urban"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR117",
@@ -35814,7 +35814,7 @@
         "p086kj9z6ph": {
           "id": "p086kj9z6ph",
           "label": "Prehistoric and Historic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Prehistoric and Historic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -35842,7 +35842,7 @@
         "p086kj9z854": {
           "id": "p086kj9z854",
           "label": "High Rim Horizon",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "High Rim Horizon"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR96",
@@ -35870,7 +35870,7 @@
         "p086kj9z8c4": {
           "id": "p086kj9z8c4",
           "label": "Middle-Late Archaic, indet.",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle-Late Archaic, indet."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -35898,7 +35898,7 @@
         "p086kj9zb5p": {
           "id": "p086kj9zb5p",
           "label": "post 1937",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "post 1937"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR123",
@@ -35926,7 +35926,7 @@
         "p086kj9zbh2": {
           "id": "p086kj9zbh2",
           "label": "or Turin",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "or Turin"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR98",
@@ -35954,7 +35954,7 @@
         "p086kj9zd59": {
           "id": "p086kj9zd59",
           "label": "Cahokia",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cahokia"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR113",
@@ -35982,7 +35982,7 @@
         "p086kj9zdk9": {
           "id": "p086kj9zdk9",
           "label": "Italian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Italian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -36010,7 +36010,7 @@
         "p086kj9zgh7": {
           "id": "p086kj9zgh7",
           "label": "Historic Euro-american",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Historic Euro-american"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -36038,7 +36038,7 @@
         "p086kj9zj3s": {
           "id": "p086kj9zj3s",
           "label": "Unknown Prehistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Unknown Prehistoric"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -36066,7 +36066,7 @@
         "p086kj9zjcg": {
           "id": "p086kj9zjcg",
           "label": "Glades Ia",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Glades Ia"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -36094,7 +36094,7 @@
         "p086kj9zm53": {
           "id": "p086kj9zm53",
           "label": "Kirk-Palmer",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Kirk-Palmer"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -36122,7 +36122,7 @@
         "p086kj9zn6p": {
           "id": "p086kj9zn6p",
           "label": "Weeden Island 1",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Weeden Island 1"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -36150,7 +36150,7 @@
         "p086kj9zpqz": {
           "id": "p086kj9zpqz",
           "label": "Late Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Archaic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -36178,7 +36178,7 @@
         "p086kj9zqnm": {
           "id": "p086kj9zqnm",
           "label": "Proto-Historic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Proto-Historic"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA10",
@@ -36206,7 +36206,7 @@
         "p086kj9zs5j": {
           "id": "p086kj9zs5j",
           "label": "Late Prehistoric, indet.",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Prehistoric, indet."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
@@ -36239,7 +36239,7 @@
           },
           "id": "p086kj9zswj",
           "label": "19th Century::2nd quarter (1825 - 1849)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "19th Century::2nd quarter (1825 - 1849)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
@@ -36267,7 +36267,7 @@
         "p086kj9ztd6": {
           "id": "p086kj9ztd6",
           "label": "Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
@@ -36295,7 +36295,7 @@
         "p086kj9ztfh": {
           "id": "p086kj9ztfh",
           "label": "Early Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA26",
@@ -36323,7 +36323,7 @@
         "p086kj9zxq3": {
           "id": "p086kj9zxq3",
           "label": "Early Mississippian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Mississippian"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
@@ -36351,7 +36351,7 @@
         "p086kj9zzfp": {
           "id": "p086kj9zzfp",
           "label": "Middle Woodland",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
@@ -36418,7 +36418,7 @@
         "p08h8hs24xm": {
           "id": "p08h8hs24xm",
           "label": "Final Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Final Neolithic"
           },
           "note": "Applies to \"Mainland Greece in general\", including Thessaly and the Peloponnese.",
@@ -36445,7 +36445,7 @@
         "p08h8hsj4h8": {
           "id": "p08h8hsj4h8",
           "label": "Late Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Neolithic"
           },
           "note": "Applies to \"Mainland Greece in general\", including Thessaly and the Peloponnese.",
@@ -36472,7 +36472,7 @@
         "p08h8hstvzv": {
           "id": "p08h8hstvzv",
           "label": "Middle Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Neolithic"
           },
           "note": "Applies to \"Mainland Greece in general\", including Thessaly and the Peloponnese.",
@@ -36523,7 +36523,7 @@
         "p08nrfc2m7f": {
           "id": "p08nrfc2m7f",
           "label": "Villanovan",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Villanovan"
           },
           "source": {
@@ -36553,7 +36553,7 @@
         "p08nrfc958q": {
           "id": "p08nrfc958q",
           "label": "Regal",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Regal"
           },
           "source": {
@@ -36583,7 +36583,7 @@
         "p08nrfccf79": {
           "id": "p08nrfccf79",
           "label": "Latial Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Latial Iron Age"
           },
           "source": {
@@ -36613,7 +36613,7 @@
         "p08nrfcpmcf": {
           "id": "p08nrfcpmcf",
           "label": "Proto-Villanovan",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Proto-Villanovan"
           },
           "source": {
@@ -36643,7 +36643,7 @@
         "p08nrfcq7kf": {
           "id": "p08nrfcq7kf",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "source": {
@@ -36691,7 +36691,7 @@
           "editorialNote": "In GeoDia as \"Achaemenid\". ",
           "id": "p08tf6p2jqh",
           "label": "Persian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Persian"
           },
           "source": {
@@ -36754,7 +36754,7 @@
         "p08tf6p2xgf": {
           "id": "p08tf6p2xgf",
           "label": "Akkadian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Akkadian"
           },
           "source": {
@@ -36790,7 +36790,7 @@
           "editorialNote": "In chronological discussion on p. 56, refers to this as the Third Dynasty of Ur.",
           "id": "p08tf6p65sx",
           "label": "Neo-Sumerian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Sumerian"
           },
           "source": {
@@ -36825,7 +36825,7 @@
         "p08tf6p8t3f": {
           "id": "p08tf6p8t3f",
           "label": "Sassanian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Sassanian"
           },
           "source": {
@@ -36865,7 +36865,7 @@
           },
           "id": "p08tf6p9dvg",
           "label": "Neo Assyrian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo Assyrian"
           },
           "source": {
@@ -36905,7 +36905,7 @@
           "editorialNote": "In GeoDia as \"Median\". ",
           "id": "p08tf6pbxv6",
           "label": "Neo-Babylonian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Babylonian"
           },
           "source": {
@@ -36936,7 +36936,7 @@
         "p08tf6pfmr9": {
           "id": "p08tf6pfmr9",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "source": {
@@ -36976,7 +36976,7 @@
           "editorialNote": "Old Babylonian and Old Assyrian grouped together under one heading on p. 340.",
           "id": "p08tf6pgxdv",
           "label": "Old Babylonian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Babylonian"
           },
           "source": {
@@ -37008,7 +37008,7 @@
           "editorialNote": "in chronological discussion on p. 55, provides \"ca.\" before date",
           "id": "p08tf6phg5x",
           "label": "Jemdet Nasr",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Jemdet Nasr"
           },
           "source": {
@@ -37039,7 +37039,7 @@
         "p08tf6pjb22": {
           "id": "p08tf6pjb22",
           "label": "Hellenistic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic"
           },
           "source": {
@@ -37079,7 +37079,7 @@
           "editorialNote": "Dates different in GeoDia.",
           "id": "p08tf6pjv45",
           "label": "Middle Assyrian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Assyrian"
           },
           "source": {
@@ -37119,7 +37119,7 @@
           "editorialNote": "Old Babylonian and Old Assyrian grouped together under one heading on p. 340.",
           "id": "p08tf6pm76z",
           "label": "Old Assyrian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Assyrian"
           },
           "source": {
@@ -37159,7 +37159,7 @@
           "editorialNote": "226 A.D. in GeoDia.",
           "id": "p08tf6prkqz",
           "label": "Parthian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Parthian"
           },
           "source": {
@@ -37198,7 +37198,7 @@
         "p08tf6psdr4": {
           "id": "p08tf6psdr4",
           "label": "Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Palaeolithic"
           },
           "source": {
@@ -37238,7 +37238,7 @@
           "editorialNote": "in chronological discussion on p. 55, provides \"ca.\" before date",
           "id": "p08tf6ptjm7",
           "label": "Uruk",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Uruk"
           },
           "source": {
@@ -37270,7 +37270,7 @@
           "editorialNote": "in chronological discussion on p. 56, provides \"ca.\" before date",
           "id": "p08tf6ptn8r",
           "label": "Early Dynastic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic"
           },
           "source": {
@@ -37301,7 +37301,7 @@
         "p08tf6pv9w3": {
           "id": "p08tf6pv9w3",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "source": {
@@ -37341,7 +37341,7 @@
           "editorialNote": "Does not seem to be present in this work",
           "id": "p08tf6pvrcw",
           "label": "Chalcolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Chalcolithic"
           },
           "source": {
@@ -37380,7 +37380,7 @@
         "p08tf6pwtff": {
           "id": "p08tf6pwtff",
           "label": "Ubaid",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ubaid"
           },
           "source": {
@@ -37436,7 +37436,7 @@
         "p09xsbn5x3b": {
           "id": "p09xsbn5x3b",
           "label": "Middle Helladic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Helladic"
           },
           "spatialCoverage": [
@@ -37466,7 +37466,7 @@
         "p09xsbn7ptr": {
           "id": "p09xsbn7ptr",
           "label": "Late Helladic IIIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIIA"
           },
           "spatialCoverage": [
@@ -37496,7 +37496,7 @@
         "p09xsbnpsgp": {
           "id": "p09xsbnpsgp",
           "label": "Dark Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Dark Age"
           },
           "spatialCoverage": [
@@ -37547,7 +37547,7 @@
           "editorialNote": "GeoDia had Amarna 1352-1336 B.C. (Egyptian capital) and Bronze Age 3150-1070 B.C.",
           "id": "p0bd664243d",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "source": {
@@ -37582,7 +37582,7 @@
           },
           "id": "p0bd66427t9",
           "label": "Third Intermediate period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Third Intermediate period"
           },
           "source": {
@@ -37618,7 +37618,7 @@
           "editorialNote": "GeoDia had 1795-1550 B.C., and Hyksos from 1650-1550 B.C.",
           "id": "p0bd6642r9q",
           "label": "Second Intermediate Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Second Intermediate Period"
           },
           "source": {
@@ -37648,7 +37648,7 @@
         "p0bd6642s92": {
           "id": "p0bd6642s92",
           "label": "Archaic Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic Age"
           },
           "source": {
@@ -37678,7 +37678,7 @@
         "p0bd6643bzr": {
           "id": "p0bd6643bzr",
           "label": "Orientalizing Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Orientalizing Period"
           },
           "source": {
@@ -37709,7 +37709,7 @@
           "editorialNote": "added",
           "id": "p0bd6643st9",
           "label": "Classical Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classical Age"
           },
           "source": {
@@ -37740,7 +37740,7 @@
           "editorialNote": "added",
           "id": "p0bd66442fn",
           "label": "Villanovan period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Villanovan period"
           },
           "source": {
@@ -37771,7 +37771,7 @@
         "p0bd6644jns": {
           "id": "p0bd6644jns",
           "label": "Israelite",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Israelite"
           },
           "source": {
@@ -37813,7 +37813,7 @@
         "p0bd66485rk": {
           "id": "p0bd66485rk",
           "label": "First Intermediate Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "First Intermediate Period"
           },
           "source": {
@@ -37843,7 +37843,7 @@
         "p0bd66487b6": {
           "id": "p0bd66487b6",
           "label": "Old Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Kingdom"
           },
           "source": {
@@ -37874,7 +37874,7 @@
           "editorialNote": "added",
           "id": "p0bd664c848",
           "label": "Hellenistic Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic Age"
           },
           "source": {
@@ -37905,7 +37905,7 @@
           "editorialNote": "added",
           "id": "p0bd664fgvj",
           "label": "Hittite",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hittite"
           },
           "source": {
@@ -37936,7 +37936,7 @@
           "editorialNote": "added",
           "id": "p0bd664gkrp",
           "label": "Byzantine Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Byzantine Empire"
           },
           "source": {
@@ -37961,7 +37961,7 @@
           "editorialNote": "GeoDia had Late Period 664 and 760 B.C. to 332 B.C. (unclear).",
           "id": "p0bd664ktkv",
           "label": "Dark Ages",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Dark Ages"
           },
           "source": {
@@ -37992,7 +37992,7 @@
           "editorialNote": "added",
           "id": "p0bd664m9wp",
           "label": "New Palace Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "New Palace Period"
           },
           "source": {
@@ -38023,7 +38023,7 @@
           "editorialNote": "added",
           "id": "p0bd664mq9k",
           "label": "Middle Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Kingdom"
           },
           "source": {
@@ -38053,7 +38053,7 @@
         "p0bd664mwkq": {
           "id": "p0bd664mwkq",
           "label": "New Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "New Kingdom"
           },
           "source": {
@@ -38084,7 +38084,7 @@
           "editorialNote": "added",
           "id": "p0bd664n3ft",
           "label": "Old Palace Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Palace Period"
           },
           "source": {
@@ -38115,7 +38115,7 @@
           "editorialNote": "GeoDia had 3000-2613 B.C.",
           "id": "p0bd664nvzc",
           "label": "Early Dynastic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic"
           },
           "source": {
@@ -38146,7 +38146,7 @@
           "editorialNote": "added",
           "id": "p0bd664tb47",
           "label": "Assyrian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Assyrian"
           },
           "source": {
@@ -38210,7 +38210,7 @@
           "editorialNote": "added",
           "id": "p0bd664xzrb",
           "label": "Mycenaean",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mycenaean"
           },
           "source": {
@@ -38257,7 +38257,7 @@
         "p0bsjms2dzb": {
           "id": "p0bsjms2dzb",
           "label": "Republican",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Republican"
           },
           "note": "Beginning-date corresponds with the end of the Celtiberian wars; outside of the Celtiberian homeland, the Republican period in Spain begins 218 B.C. (Second Punic War).",
@@ -38305,7 +38305,7 @@
         "p0ccnvb793h": {
           "id": "p0ccnvb793h",
           "label": "Classical",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classical"
           },
           "source": {
@@ -38336,7 +38336,7 @@
         "p0ccnvb84cx": {
           "id": "p0ccnvb84cx",
           "label": "Early Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Archaic"
           },
           "source": {
@@ -38368,7 +38368,7 @@
           "editorialNote": "Brendel also calls this period \"Response to Greek Classical Art\" (259).",
           "id": "p0ccnvbcdnr",
           "label": "Classical",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classical"
           },
           "source": {
@@ -38399,7 +38399,7 @@
         "p0ccnvbfhb6": {
           "id": "p0ccnvbfhb6",
           "label": "Middle Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
           "source": {
@@ -38430,7 +38430,7 @@
         "p0ccnvbkmr4": {
           "id": "p0ccnvbkmr4",
           "label": "Orientalizing",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Orientalizing"
           },
           "source": {
@@ -38461,7 +38461,7 @@
         "p0ccnvbpbfh": {
           "id": "p0ccnvbpbfh",
           "label": "Geometric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Geometric"
           },
           "source": {
@@ -38499,7 +38499,7 @@
           "editorialNote": "Brendel also calls this period \"Proto-Classical\" (e.g. 283ff).",
           "id": "p0ccnvbpfm3",
           "label": "Transitional",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Transitional"
           },
           "source": {
@@ -38530,7 +38530,7 @@
         "p0ccnvbps4c": {
           "id": "p0ccnvbps4c",
           "label": "Hellenistic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic"
           },
           "source": {
@@ -38561,7 +38561,7 @@
         "p0ccnvbqx6g": {
           "id": "p0ccnvbqx6g",
           "label": "Late Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Archaic"
           },
           "source": {
@@ -38593,7 +38593,7 @@
           "editorialNote": "Brendel earlier calls this period \"Etruscan Art of the Fourth Century\", but then only refers to art of this period as \"Classical\" or \"Late Classical\", with the same temporal boundaries.",
           "id": "p0ccnvbvhv9",
           "label": "Late Classical",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Classical"
           },
           "source": {
@@ -38624,7 +38624,7 @@
         "p0ccnvbw8ps": {
           "id": "p0ccnvbw8ps",
           "label": "Villanovan Geometric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Villanovan Geometric"
           },
           "source": {
@@ -38655,7 +38655,7 @@
         "p0ccnvbxn4z": {
           "id": "p0ccnvbxn4z",
           "label": "Grecizing Geometric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Grecizing Geometric"
           },
           "source": {
@@ -38710,7 +38710,7 @@
         "p0cfv7g3447": {
           "id": "p0cfv7g3447",
           "label": "Early Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
           "source": {
@@ -38766,7 +38766,7 @@
           },
           "id": "p0cfv7g66d8",
           "label": "Old Syrian Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Syrian Period"
           },
           "source": {
@@ -38817,7 +38817,7 @@
         "p0cfv7g6ckd": {
           "id": "p0cfv7g6ckd",
           "label": "Israelite Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Israelite Period"
           },
           "source": {
@@ -38868,7 +38868,7 @@
         "p0cfv7g83cj": {
           "id": "p0cfv7g83cj",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "source": {
@@ -38919,7 +38919,7 @@
         "p0cfv7gm9d8": {
           "id": "p0cfv7gm9d8",
           "label": "Middle Syrian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Syrian"
           },
           "source": {
@@ -38970,7 +38970,7 @@
         "p0cfv7gmsmd": {
           "id": "p0cfv7gmsmd",
           "label": "Middle Canaanite",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Canaanite"
           },
           "source": {
@@ -39021,7 +39021,7 @@
         "p0cfv7gnc8r": {
           "id": "p0cfv7gnc8r",
           "label": "Middle Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
           "source": {
@@ -39077,7 +39077,7 @@
           },
           "id": "p0cfv7gpdxn",
           "label": "New Syrian Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "New Syrian Period"
           },
           "source": {
@@ -39128,7 +39128,7 @@
         "p0cfv7gqfsv": {
           "id": "p0cfv7gqfsv",
           "label": "Late Canaanite",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Canaanite"
           },
           "source": {
@@ -39184,7 +39184,7 @@
           },
           "id": "p0cfv7gqtzs",
           "label": "monarchic period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "monarchic period"
           },
           "source": {
@@ -39235,7 +39235,7 @@
         "p0cfv7gr6qd": {
           "id": "p0cfv7gr6qd",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "source": {
@@ -39292,7 +39292,7 @@
           "editorialNote": "see also Mazar, 1992",
           "id": "p0cfv7gxhs2",
           "label": "Early Canaanite Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Canaanite Period"
           },
           "source": {
@@ -39365,7 +39365,7 @@
           },
           "id": "p0cmdf94cnf",
           "label": "Late Lydian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Lydian"
           },
           "note": "From chronology chart on p. 12; = Achaemenid period",
@@ -39398,7 +39398,7 @@
           },
           "id": "p0cmdf9kmfv",
           "label": "Middle Lydian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Lydian"
           },
           "note": "R's Middle Lydian period is coterminous with the Mermnad dynasty: chronological chart on p. 12",
@@ -39431,7 +39431,7 @@
           },
           "id": "p0cmdf9ntkh",
           "label": "Early Lydian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Lydian"
           },
           "note": "From chronological table on p. 12; = Lydian \"Early Iron Age\"",
@@ -39459,7 +39459,7 @@
         "p0cmdf9qqdg": {
           "id": "p0cmdf9qqdg",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "spatialCoverage": [
@@ -39506,7 +39506,7 @@
         "p0cp4472vm9": {
           "id": "p0cp4472vm9",
           "label": "Roman emperors",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman emperors"
           },
           "source": {
@@ -39538,7 +39538,7 @@
           "editorialNote": "unsure why GeoDia end_label said 1550 B.C.",
           "id": "p0cp447757z",
           "label": "Second Intermediate Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Second Intermediate Period"
           },
           "source": {
@@ -39569,7 +39569,7 @@
         "p0cp44786m7": {
           "id": "p0cp44786m7",
           "label": "Predynastic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Predynastic Period"
           },
           "source": {
@@ -39601,7 +39601,7 @@
           "editorialNote": "unsure why GeoDia start_label said 2055 B.C.",
           "id": "p0cp447b435",
           "label": "Middle Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Kingdom"
           },
           "source": {
@@ -39632,7 +39632,7 @@
         "p0cp447bc2v": {
           "id": "p0cp447bc2v",
           "label": "Graeco-Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Graeco-Roman Period"
           },
           "source": {
@@ -39663,7 +39663,7 @@
         "p0cp447cfpq": {
           "id": "p0cp447cfpq",
           "label": "Old Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Kingdom"
           },
           "source": {
@@ -39694,7 +39694,7 @@
         "p0cp447dmgg": {
           "id": "p0cp447dmgg",
           "label": "Early Dynastic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic Period"
           },
           "source": {
@@ -39726,7 +39726,7 @@
           "editorialNote": "unsure why GeoDia start_label said 2055 B.C.",
           "id": "p0cp447hxh8",
           "label": "Third Intermediate Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Third Intermediate Period"
           },
           "source": {
@@ -39758,7 +39758,7 @@
           "editorialNote": "unsure why GeoDia dates are 2130-2055 B.C.",
           "id": "p0cp447jts9",
           "label": "First Intermediate Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "First Intermediate Period"
           },
           "note": "Robins' chronology is being used in preference to Freeman's, since it seems to represent the general textbook situation more accurately.",
@@ -39790,7 +39790,7 @@
         "p0cp447qz64": {
           "id": "p0cp447qz64",
           "label": "New Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "New Kingdom"
           },
           "source": {
@@ -39821,7 +39821,7 @@
         "p0cp447sbx9": {
           "id": "p0cp447sbx9",
           "label": "Late Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Period"
           },
           "source": {
@@ -39869,7 +39869,7 @@
         "p0ctc357stj": {
           "id": "p0ctc357stj",
           "label": "Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman"
           },
           "source": {
@@ -39907,7 +39907,7 @@
         "p0ctc358p9w": {
           "id": "p0ctc358p9w",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "source": {
@@ -39949,7 +39949,7 @@
         "p0ctc359kcx": {
           "id": "p0ctc359kcx",
           "label": "La Tene",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "La Tene"
           },
           "source": {
@@ -39983,7 +39983,7 @@
         "p0ctc35dj5f": {
           "id": "p0ctc35dj5f",
           "label": "Hallstatt",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hallstatt"
           },
           "source": {
@@ -40017,7 +40017,7 @@
         "p0ctc35fr8g": {
           "id": "p0ctc35fr8g",
           "label": "High Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "High Empire"
           },
           "source": {
@@ -40047,7 +40047,7 @@
         "p0ctc35hdbp": {
           "id": "p0ctc35hdbp",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "source": {
@@ -40085,7 +40085,7 @@
         "p0ctc35kv5d": {
           "id": "p0ctc35kv5d",
           "label": "Julio-Claudian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Julio-Claudian"
           },
           "source": {
@@ -40115,7 +40115,7 @@
         "p0ctc35r2h7": {
           "id": "p0ctc35r2h7",
           "label": "Flavian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Flavian"
           },
           "source": {
@@ -40145,7 +40145,7 @@
         "p0ctc35tdmp": {
           "id": "p0ctc35tdmp",
           "label": "Gallo-Belgic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Gallo-Belgic"
           },
           "source": {
@@ -40201,7 +40201,7 @@
           "editorialNote": "May be an inference, not statement / assertion.",
           "id": "p0d39r7d5km",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -40248,7 +40248,7 @@
         "p0dfzs7sjcq": {
           "id": "p0dfzs7sjcq",
           "label": "Lerna III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lerna III"
           },
           "note": "Applies to Lerna; equivalent to Lerna III. CC307C, Spring 2011, group 1: Jelyne Jesusa and Kevin Sartin.",
@@ -40299,7 +40299,7 @@
         "p0dhmkc4kxb": {
           "id": "p0dhmkc4kxb",
           "label": "Herakleid",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Herakleid"
           },
           "note": "chronological table on p. 4",
@@ -40326,7 +40326,7 @@
         "p0dhmkc7dmm": {
           "id": "p0dhmkc7dmm",
           "label": "Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic"
           },
           "note": "chronological table on p. 4; not dividing the archaic period by dynasties (all Mermnad, not usually used to refer to material) or using \"Orientalizing\" (since Lydia the source of much of what is called \"Orientalizing\" in Greece)",
@@ -40388,7 +40388,7 @@
           },
           "id": "p0dntkb67vz",
           "label": "Fase III",
-          "localizedLabel": {
+          "originalLabel": {
             "ita-latn": "Fase III"
           },
           "note": "This period only applies to the indigenous necropolis of Monte Casasia in Sicily. The end date is provided by the assumption that the site was destroyed by the Carthaginians in 405 B.C.",
@@ -40424,7 +40424,7 @@
           },
           "id": "p0dntkbc6tn",
           "label": "Fase II",
-          "localizedLabel": {
+          "originalLabel": {
             "ita-latn": "Fase II"
           },
           "note": "This period only applies to the indigenous necropolis of Monte Casasia in Sicily.",
@@ -40462,7 +40462,7 @@
           },
           "id": "p0dntkbcv4m",
           "label": "Fase I",
-          "localizedLabel": {
+          "originalLabel": {
             "ita-latn": "Fase I"
           },
           "note": "This periodization only applies to the indigenous necropolis at Monte Casasia in Sicily.",
@@ -40519,7 +40519,7 @@
           "editorialNote": "See map as ill. 227, page 392.",
           "id": "p0f65r239z2",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -40579,7 +40579,7 @@
           "editorialNote": "See map as ill. 227, page 392.",
           "id": "p0f65r2mh52",
           "label": "Early Bronze IV/Middle Bronze I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze IV/Middle Bronze I"
           },
           "spatialCoverage": [
@@ -40631,7 +40631,7 @@
           "editorialNote": "See map as ill. 227, page 392.",
           "id": "p0f65r2nb5s",
           "label": "Middle Bronze II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze II"
           },
           "spatialCoverage": [
@@ -40683,7 +40683,7 @@
           "editorialNote": "See map as ill. 227, page 392.",
           "id": "p0f65r2nwf7",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -40735,7 +40735,7 @@
           "editorialNote": "See map as ill. 227, page 392.",
           "id": "p0f65r2qmh2",
           "label": "Early Bronze",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze"
           },
           "spatialCoverage": [
@@ -40787,7 +40787,7 @@
           "editorialNote": "See map as ill. 227, page 392.",
           "id": "p0f65r2s5gc",
           "label": "Persian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Persian"
           },
           "spatialCoverage": [
@@ -40839,7 +40839,7 @@
           "editorialNote": "this date: see also Mazar, 1992. See map as ill. 227, page 392.",
           "id": "p0f65r2sb36",
           "label": "Neo-Babylonian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Babylonian"
           },
           "spatialCoverage": [
@@ -40899,7 +40899,7 @@
           "editorialNote": "See map as ill. 227, page 392.",
           "id": "p0f65r2v4dw",
           "label": "Hellenistic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic"
           },
           "spatialCoverage": [
@@ -40951,7 +40951,7 @@
           "editorialNote": "See map as ill. 227, page 392.",
           "id": "p0f65r2v4mw",
           "label": "Late Bronze",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze"
           },
           "spatialCoverage": [
@@ -41003,7 +41003,7 @@
           "editorialNote": "See map as ill. 227, page 392.",
           "id": "p0f65r2xs4d",
           "label": "Chalcolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Chalcolithic"
           },
           "spatialCoverage": [
@@ -41079,7 +41079,7 @@
           "editorialNote": "check map references",
           "id": "p0ff3dt2w3c",
           "label": "La Tène D",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "La Tène D"
           },
           "source": {
@@ -41120,7 +41120,7 @@
           "editorialNote": "Maps pages 116, 119.",
           "id": "p0ff3dt3t2p",
           "label": "Early Christian (Britain, Ireland)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Christian (Britain, Ireland)"
           },
           "source": {
@@ -41156,7 +41156,7 @@
           "editorialNote": "check map references",
           "id": "p0ff3dt5x84",
           "label": "La Tène C",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "La Tène C"
           },
           "source": {
@@ -41199,7 +41199,7 @@
         "p0ff3dt6szt": {
           "id": "p0ff3dt6szt",
           "label": "Hallstatt C",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hallstatt C"
           },
           "source": {
@@ -41256,7 +41256,7 @@
           "editorialNote": "Maps pages 110-111.",
           "id": "p0ff3dt8j6x",
           "label": "Anglo-Saxon (East Britain)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Anglo-Saxon (East Britain)"
           },
           "source": {
@@ -41287,7 +41287,7 @@
         "p0ff3dtjscr": {
           "id": "p0ff3dtjscr",
           "label": "Hallstatt D",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hallstatt D"
           },
           "source": {
@@ -41343,7 +41343,7 @@
           },
           "id": "p0ff3dtmpwd",
           "label": "Hallstatt B",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hallstatt B"
           },
           "source": {
@@ -41379,7 +41379,7 @@
           "editorialNote": "Map page 131.",
           "id": "p0ff3dts53k",
           "label": "Viking",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Viking"
           },
           "source": {
@@ -41414,7 +41414,7 @@
         "p0ff3dtsspk": {
           "id": "p0ff3dtsspk",
           "label": "Hallstatt Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hallstatt Iron Age"
           },
           "source": {
@@ -41466,7 +41466,7 @@
           "editorialNote": "Map page 60.",
           "id": "p0ff3dtthgg",
           "label": "Romano-Celtic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Romano-Celtic"
           },
           "source": {
@@ -41498,7 +41498,7 @@
           "editorialNote": "check map references",
           "id": "p0ff3dtw9p7",
           "label": "La Tène A",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "La Tène A"
           },
           "source": {
@@ -41546,7 +41546,7 @@
           },
           "id": "p0ff3dtxpjd",
           "label": "Hallstatt A",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hallstatt A"
           },
           "source": {
@@ -41582,7 +41582,7 @@
           "editorialNote": "check map references",
           "id": "p0ff3dtxq82",
           "label": "La Tène B",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "La Tène B"
           },
           "source": {
@@ -41626,7 +41626,7 @@
           "editorialNote": "check map references",
           "id": "p0ff3dtzkrr",
           "label": "La Tène Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "La Tène Iron Age"
           },
           "source": {
@@ -41692,7 +41692,7 @@
         "p0fh3zcg927": {
           "id": "p0fh3zcg927",
           "label": "Late Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Iron Age"
           },
           "spatialCoverage": [
@@ -41719,7 +41719,7 @@
         "p0fh3zcqs6h": {
           "id": "p0fh3zcqs6h",
           "label": "Early Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iron Age"
           },
           "spatialCoverage": [
@@ -41765,7 +41765,7 @@
         "p0gjgrs2dmz": {
           "id": "p0gjgrs2dmz",
           "label": "Middle Bronze",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze"
           },
           "spatialCoverage": [
@@ -41792,7 +41792,7 @@
         "p0gjgrs3d38": {
           "id": "p0gjgrs3d38",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -41819,7 +41819,7 @@
         "p0gjgrs45g4": {
           "id": "p0gjgrs45g4",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "note": "Can be split into Early and Late.",
@@ -41847,7 +41847,7 @@
         "p0gjgrs4xgm": {
           "id": "p0gjgrs4xgm",
           "label": "Late Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Mesolithic"
           },
           "spatialCoverage": [
@@ -41874,7 +41874,7 @@
         "p0gjgrs52f5": {
           "id": "p0gjgrs52f5",
           "label": "Late Bronze",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze"
           },
           "spatialCoverage": [
@@ -41901,7 +41901,7 @@
         "p0gjgrs69ws": {
           "id": "p0gjgrs69ws",
           "label": "Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman"
           },
           "note": "Can be split into Early and Late.",
@@ -41929,7 +41929,7 @@
         "p0gjgrs6qb2": {
           "id": "p0gjgrs6qb2",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "spatialCoverage": [
@@ -41956,7 +41956,7 @@
         "p0gjgrs6sgx": {
           "id": "p0gjgrs6sgx",
           "label": "Post-Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Post-Medieval"
           },
           "note": "Early post-medieval is generally used for the 16th century and sometimes for the 17th century. The term 'middle post-medieval' is not used, and there is debate as to what constitutes the late post-medieval period. For the 18th century, it is best to stick simply to 'post-medieval' and qualify it using calendar dates.",
@@ -41984,7 +41984,7 @@
         "p0gjgrs6zcf": {
           "id": "p0gjgrs6zcf",
           "label": "Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Palaeolithic"
           },
           "note": "Generally split into Lower, Middle and Upper, which we will translate into Early, Middle and Late.",
@@ -42012,7 +42012,7 @@
         "p0gjgrs72vn": {
           "id": "p0gjgrs72vn",
           "label": "Early Early Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Early Medieval"
           },
           "spatialCoverage": [
@@ -42039,7 +42039,7 @@
         "p0gjgrs9f7f": {
           "id": "p0gjgrs9f7f",
           "label": "Late Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Neolithic"
           },
           "spatialCoverage": [
@@ -42066,7 +42066,7 @@
         "p0gjgrs9v5b": {
           "id": "p0gjgrs9v5b",
           "label": "Early Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iron Age"
           },
           "spatialCoverage": [
@@ -42093,7 +42093,7 @@
         "p0gjgrsbb25": {
           "id": "p0gjgrsbb25",
           "label": "Late Early Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Early Medieval"
           },
           "spatialCoverage": [
@@ -42120,7 +42120,7 @@
         "p0gjgrsc7mt": {
           "id": "p0gjgrsc7mt",
           "label": "Middle Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Palaeolithic"
           },
           "spatialCoverage": [
@@ -42147,7 +42147,7 @@
         "p0gjgrscrzm": {
           "id": "p0gjgrscrzm",
           "label": "Early Bronze",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze"
           },
           "spatialCoverage": [
@@ -42174,7 +42174,7 @@
         "p0gjgrsdb9z": {
           "id": "p0gjgrsdb9z",
           "label": "Late Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Iron Age"
           },
           "spatialCoverage": [
@@ -42201,7 +42201,7 @@
         "p0gjgrsfprj": {
           "id": "p0gjgrsfprj",
           "label": "Early Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Roman"
           },
           "spatialCoverage": [
@@ -42228,7 +42228,7 @@
         "p0gjgrsg24g": {
           "id": "p0gjgrsg24g",
           "label": "Byzantine",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Byzantine"
           },
           "note": "This period does not appear in the EH timeline. When this broad period is used, the database will automatically map it onto either Iron Age (for the earlier coins) or Roman (for the later coins) depending on the precise years entered.",
@@ -42256,7 +42256,7 @@
         "p0gjgrsgn96": {
           "id": "p0gjgrsgn96",
           "label": "Modern",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern"
           },
           "spatialCoverage": [
@@ -42283,7 +42283,7 @@
         "p0gjgrshhcw": {
           "id": "p0gjgrshhcw",
           "label": "Early Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Medieval"
           },
           "note": "This period is diverse and must be qualified wherever possible with Early, Middle or Late. The currently accepted chronology (spring 2013) is given below, but this is likely to change in the near future. English Heritage do not specify the boundaries of these sub-periods.",
@@ -42311,7 +42311,7 @@
         "p0gjgrsmhnc": {
           "id": "p0gjgrsmhnc",
           "label": "Greek and Roman Provincial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Greek and Roman Provincial"
           },
           "note": "This period does not appear in the EH timeline. When this broad period is used, the database will automatically map it onto either Iron Age (for the earlier coins) or Roman (for the later coins) depending on the precise years entered.",
@@ -42345,7 +42345,7 @@
           },
           "id": "p0gjgrsn5zn",
           "label": "Lower (Early) Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lower (Early) Palaeolithic"
           },
           "spatialCoverage": [
@@ -42372,7 +42372,7 @@
         "p0gjgrsnfdp": {
           "id": "p0gjgrsnfdp",
           "label": "Middle Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Iron Age"
           },
           "spatialCoverage": [
@@ -42399,7 +42399,7 @@
         "p0gjgrsp9j4": {
           "id": "p0gjgrsp9j4",
           "label": "Middle Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Neolithic"
           },
           "spatialCoverage": [
@@ -42426,7 +42426,7 @@
         "p0gjgrsr3qh": {
           "id": "p0gjgrsr3qh",
           "label": "Late Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Roman"
           },
           "spatialCoverage": [
@@ -42453,7 +42453,7 @@
         "p0gjgrsrj82": {
           "id": "p0gjgrsrj82",
           "label": "Middle Early Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Early Medieval"
           },
           "spatialCoverage": [
@@ -42480,7 +42480,7 @@
         "p0gjgrst8ft": {
           "id": "p0gjgrst8ft",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -42507,7 +42507,7 @@
         "p0gjgrsvxp3": {
           "id": "p0gjgrsvxp3",
           "label": "Early Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Mesolithic"
           },
           "spatialCoverage": [
@@ -42540,7 +42540,7 @@
           },
           "id": "p0gjgrswcr8",
           "label": "Upper (Late) Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Upper (Late) Palaeolithic"
           },
           "spatialCoverage": [
@@ -42567,7 +42567,7 @@
         "p0gjgrsws3g": {
           "id": "p0gjgrsws3g",
           "label": "Early Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Neolithic"
           },
           "spatialCoverage": [
@@ -42594,7 +42594,7 @@
         "p0gjgrsxwzx": {
           "id": "p0gjgrsxwzx",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval"
           },
           "note": "English Heritage do not specify the boundaries of any sub-periods within the Medieval period.",
@@ -42645,7 +42645,7 @@
           "editorialNote": "Come back later to this source to mine / match to formal p.175-222 & Celtic art periods p.431-450 (SB scanned) though the latter is mainly references to other writers.",
           "id": "p0hrtx5dm4p",
           "label": "Cultura de Hallstatt",
-          "localizedLabel": {
+          "originalLabel": {
             "spa-latn": "Cultura de Hallstatt"
           },
           "spatialCoverage": [
@@ -42702,7 +42702,7 @@
         "p0hvcwrjpsf": {
           "id": "p0hvcwrjpsf",
           "label": "Early Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iron Age"
           },
           "note": "Contemporary with Hallstatt B-D (S. Germany). Overlaps LBA III/ Tartessian period, 750-600 B.C. (- cf. M. Diaz-Andreu & S. Keay, 1997. The Archaeology of Iberia.); includes Iberian I (600-500 B.C.) and II (500-450 B.C.) (ibid.). See also T. Chapa & M. Belen, 1997. La Edad del Hierro.",
@@ -42750,7 +42750,7 @@
           "editorialNote": "Removed due to inferences in GeoDia: al-'Ubaid (5500-4000 B.C.), Uruk (4000-3250 B.C.), Jamdat Nasr periods (3250-3000 B.C.), and Ur of the Chaldees (1150-800 B.C.). Note this quote p.15: \"At an archaeological congress of excavators held at Baghdad in 1929 it was agreed that the early stages of human settlement in south Mesopotamia could be classified n successive phases which should be called, after the places where the evidence for each was first discovered, the al-'Ubaid period, the Uruk period, the Jamdat Nasr period, and then the Early Dynastic period, towards the end of which (in IIIb) comes the First Dynasty of Ur.\" p.16: \"Archaeological excavation ... does not of itself offer an absolute chronology in years B.C./A.D.\"",
           "id": "p0j5frx3hh2",
           "label": "Akkadian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Akkadian"
           },
           "source": {
@@ -42786,7 +42786,7 @@
           "editorialNote": "Removed due to inferences in GeoDia: al-'Ubaid (5500-4000 B.C.), Uruk (4000-3250 B.C.), Jamdat Nasr periods (3250-3000 B.C.), and Ur of the Chaldees (1150-800 B.C.). Note this quote p.15: \"At an archaeological congress of excavators held at Baghdad in 1929 it was agreed that the early stages of human settlement in south Mesopotamia could be classified n successive phases which should be called, after the places where the evidence for each was first discovered, the al-'Ubaid period, the Uruk period, the Jamdat Nasr period, and then the Early Dynastic period, towards the end of which (in IIIb) comes the First Dynasty of Ur.\" p.16: \"Archaeological excavation ... does not of itself offer an absolute chronology in years B.C./A.D.\"",
           "id": "p0j5frxkb96",
           "label": "Early Dynastic IIIa",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic IIIa"
           },
           "source": {
@@ -42827,7 +42827,7 @@
           "editorialNote": "Removed due to inferences in GeoDia: al-'Ubaid (5500-4000 B.C.), Uruk (4000-3250 B.C.), Jamdat Nasr periods (3250-3000 B.C.), and Ur of the Chaldees (1150-800 B.C.). Note this quote p.15: \"At an archaeological congress of excavators held at Baghdad in 1929 it was agreed that the early stages of human settlement in south Mesopotamia could be classified n successive phases which should be called, after the places where the evidence for each was first discovered, the al-'Ubaid period, the Uruk period, the Jamdat Nasr period, and then the Early Dynastic period, towards the end of which (in IIIb) comes the First Dynasty of Ur.\" p.16: \"Archaeological excavation ... does not of itself offer an absolute chronology in years B.C./A.D.\"",
           "id": "p0j5frxvrwg",
           "label": "Early Dynastic period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic period"
           },
           "note": "These are approximate dates.",
@@ -42858,7 +42858,7 @@
           "editorialNote": "unsure why GeoDia dates are 2130-2055 B.C.",
           "id": "p0j5frxvzk8",
           "label": "Isin-Larsa",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Isin-Larsa"
           },
           "note": "Robins' chronology is being used in preference to Freeman's, since it seems to represent the general textbook situation more accurately.",
@@ -42927,7 +42927,7 @@
           },
           "id": "p0jtbzw33x8",
           "label": "Late Bronze Age (Late Cypriot) IB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age (Late Cypriot) IB"
           },
           "spatialCoverage": [
@@ -42959,7 +42959,7 @@
           },
           "id": "p0jtbzw3p99",
           "label": "Middle Bronze Age (Middle Cypriot) I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age (Middle Cypriot) I"
           },
           "spatialCoverage": [
@@ -42991,7 +42991,7 @@
           },
           "id": "p0jtbzw6f7b",
           "label": "Late Bronze Age (Late Cypriot) IIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age (Late Cypriot) IIA"
           },
           "spatialCoverage": [
@@ -43023,7 +43023,7 @@
           },
           "id": "p0jtbzw727b",
           "label": "Middle Bronze Age (Middle Cypriot) III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age (Middle Cypriot) III"
           },
           "spatialCoverage": [
@@ -43055,7 +43055,7 @@
           },
           "id": "p0jtbzw8gr5",
           "label": "Geometric (Cypro-Geometric) I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Geometric (Cypro-Geometric) I"
           },
           "spatialCoverage": [
@@ -43087,7 +43087,7 @@
           },
           "id": "p0jtbzw8xcb",
           "label": "Archaic (Cypro-Archaic) II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic (Cypro-Archaic) II"
           },
           "spatialCoverage": [
@@ -43119,7 +43119,7 @@
           },
           "id": "p0jtbzw932g",
           "label": "Geometric (Cypro-Geometric) III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Geometric (Cypro-Geometric) III"
           },
           "spatialCoverage": [
@@ -43145,7 +43145,7 @@
         "p0jtbzw9jwb": {
           "id": "p0jtbzw9jwb",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -43177,7 +43177,7 @@
           },
           "id": "p0jtbzwcs2w",
           "label": "Middle Bronze Age (Middle Cypriot) II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age (Middle Cypriot) II"
           },
           "spatialCoverage": [
@@ -43203,7 +43203,7 @@
         "p0jtbzwf4x5": {
           "id": "p0jtbzwf4x5",
           "label": "Roman II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman II"
           },
           "spatialCoverage": [
@@ -43235,7 +43235,7 @@
           },
           "id": "p0jtbzwfmq9",
           "label": "Late Bronze Age (Late Cypriot) IIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age (Late Cypriot) IIB"
           },
           "spatialCoverage": [
@@ -43267,7 +43267,7 @@
           },
           "id": "p0jtbzwfv22",
           "label": "Late Bronze Age (Late Cypriot) IIIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age (Late Cypriot) IIIB"
           },
           "spatialCoverage": [
@@ -43299,7 +43299,7 @@
           },
           "id": "p0jtbzwg63z",
           "label": "Archaic (Cypro-Archaic) I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic (Cypro-Archaic) I"
           },
           "spatialCoverage": [
@@ -43331,7 +43331,7 @@
           },
           "id": "p0jtbzwgxd7",
           "label": "Classical (Cypro-Classical) I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classical (Cypro-Classical) I"
           },
           "spatialCoverage": [
@@ -43363,7 +43363,7 @@
           },
           "id": "p0jtbzwhwbh",
           "label": "Transitional (Philia Culture)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Transitional (Philia Culture)"
           },
           "spatialCoverage": [
@@ -43390,7 +43390,7 @@
         "p0jtbzwjsrv": {
           "id": "p0jtbzwjsrv",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "spatialCoverage": [
@@ -43422,7 +43422,7 @@
           },
           "id": "p0jtbzwkp48",
           "label": "Late Bronze Age (Late Cypriot) IA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age (Late Cypriot) IA"
           },
           "spatialCoverage": [
@@ -43448,7 +43448,7 @@
         "p0jtbzwmmjw": {
           "id": "p0jtbzwmmjw",
           "label": "Hellenistic I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic I"
           },
           "spatialCoverage": [
@@ -43480,7 +43480,7 @@
           },
           "id": "p0jtbzwnc5f",
           "label": "Early Bronze Age (Early Cypriot) III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age (Early Cypriot) III"
           },
           "spatialCoverage": [
@@ -43512,7 +43512,7 @@
           },
           "id": "p0jtbzwp3dn",
           "label": "Geometric (Cypro-Geometric) II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Geometric (Cypro-Geometric) II"
           },
           "spatialCoverage": [
@@ -43544,7 +43544,7 @@
           },
           "id": "p0jtbzwr3rh",
           "label": "Classical (Cypro-Classical) II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Classical (Cypro-Classical) II"
           },
           "spatialCoverage": [
@@ -43576,7 +43576,7 @@
           },
           "id": "p0jtbzwr5gf",
           "label": "Early Bronze Age (Early Cypriot) I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age (Early Cypriot) I"
           },
           "spatialCoverage": [
@@ -43602,7 +43602,7 @@
         "p0jtbzwrxbm": {
           "id": "p0jtbzwrxbm",
           "label": "Proto-Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Proto-Neolithic"
           },
           "spatialCoverage": [
@@ -43629,7 +43629,7 @@
         "p0jtbzwsrd3": {
           "id": "p0jtbzwsrd3",
           "label": "Chalcolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Chalcolithic"
           },
           "spatialCoverage": [
@@ -43656,7 +43656,7 @@
         "p0jtbzwsxnv": {
           "id": "p0jtbzwsxnv",
           "label": "Roman I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman I"
           },
           "spatialCoverage": [
@@ -43688,7 +43688,7 @@
           },
           "id": "p0jtbzwt8d6",
           "label": "Early Bronze Age (Early Cypriot) II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age (Early Cypriot) II"
           },
           "spatialCoverage": [
@@ -43720,7 +43720,7 @@
           },
           "id": "p0jtbzwtk9t",
           "label": "Late Bronze Age (Late Cypriot) IIIC",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age (Late Cypriot) IIIC"
           },
           "spatialCoverage": [
@@ -43746,7 +43746,7 @@
         "p0jtbzww6pr": {
           "id": "p0jtbzww6pr",
           "label": "Hellenistic II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic II"
           },
           "spatialCoverage": [
@@ -43778,7 +43778,7 @@
           },
           "id": "p0jtbzww7hd",
           "label": "Late Bronze Age (Late Cypriot) IIIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age (Late Cypriot) IIIA"
           },
           "spatialCoverage": [
@@ -43810,7 +43810,7 @@
           },
           "id": "p0jtbzwwmnz",
           "label": "Late Bronze Age (Late Cypriot) IIC",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age (Late Cypriot) IIC"
           },
           "spatialCoverage": [
@@ -43836,7 +43836,7 @@
         "p0jtbzwxgdq": {
           "id": "p0jtbzwxgdq",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -43885,7 +43885,7 @@
         "p0k7ktvkb43": {
           "id": "p0k7ktvkb43",
           "label": "Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic"
           },
           "spatialCoverage": [
@@ -44010,7 +44010,7 @@
         "p0kc8t67rhg": {
           "id": "p0kc8t67rhg",
           "label": "Jemdet Nasr Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Jemdet Nasr Period"
           },
           "spatialCoverage": [
@@ -44037,7 +44037,7 @@
         "p0kc8t6cw6p": {
           "id": "p0kc8t6cw6p",
           "label": "Early Dynastic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic Period"
           },
           "spatialCoverage": [
@@ -44064,7 +44064,7 @@
         "p0kc8t6d2b6": {
           "id": "p0kc8t6d2b6",
           "label": "Isin-Larsa Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Isin-Larsa Period"
           },
           "spatialCoverage": [
@@ -44091,7 +44091,7 @@
         "p0kc8t6fk57": {
           "id": "p0kc8t6fk57",
           "label": "Neo-Sumerian Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Sumerian Period"
           },
           "spatialCoverage": [
@@ -44124,7 +44124,7 @@
           },
           "id": "p0kc8t6g2xc",
           "label": "Uruk (Warka) Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Uruk (Warka) Period"
           },
           "spatialCoverage": [
@@ -44152,7 +44152,7 @@
           "editorialNote": "Neo-Assyrian 717-612 B.C. was listed in GeoDia but not found in the book on page 20.",
           "id": "p0kc8t6hzwz",
           "label": "Ubaid Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ubaid Period"
           },
           "spatialCoverage": [
@@ -44179,7 +44179,7 @@
         "p0kc8t6n8fr": {
           "id": "p0kc8t6n8fr",
           "label": "Akkad Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Akkad Period"
           },
           "spatialCoverage": [
@@ -44206,7 +44206,7 @@
         "p0kc8t6vm8m": {
           "id": "p0kc8t6vm8m",
           "label": "Neo-Babylonian Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Babylonian Period"
           },
           "spatialCoverage": [
@@ -44265,7 +44265,7 @@
           "editorialNote": "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"",
           "id": "p0kgptq9qvc",
           "label": "Middle Canaanite Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Canaanite Age"
           },
           "source": {
@@ -44318,7 +44318,7 @@
           "editorialNote": "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"",
           "id": "p0kgptqfs5b",
           "label": "Israelite Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Israelite Age"
           },
           "source": {
@@ -44371,7 +44371,7 @@
           "editorialNote": "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"",
           "id": "p0kgptqgcs2",
           "label": "Early Canaanite Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Canaanite Age"
           },
           "source": {
@@ -44424,7 +44424,7 @@
           "editorialNote": "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"",
           "id": "p0kgptqv6b3",
           "label": "Canaanite Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Canaanite Age"
           },
           "source": {
@@ -44503,7 +44503,7 @@
         "p0kh9ds2pnp": {
           "id": "p0kh9ds2pnp",
           "label": "Late 20th Century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late 20th Century"
           },
           "note": "The final third of the 20th century.",
@@ -44532,7 +44532,7 @@
         "p0kh9ds3566": {
           "id": "p0kh9ds3566",
           "label": "First World War",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "First World War"
           },
           "note": "Used to record buildings, defensive monuments and sites dating to, and associated with, the First World War. For other types of building, such as houses, built during this period use EARLY 20TH CENTURY.",
@@ -44561,7 +44561,7 @@
         "p0kh9ds3whd": {
           "id": "p0kh9ds3whd",
           "label": "Jacobean",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Jacobean"
           },
           "note": "Dating to the reign of James I of England (VI of Scotland)",
@@ -44590,7 +44590,7 @@
         "p0kh9ds4hjq": {
           "id": "p0kh9ds4hjq",
           "label": "Late Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Neolithic"
           },
           "note": "The third and latest subdivision of the Neolithic, or New Stone Age.",
@@ -44619,7 +44619,7 @@
         "p0kh9ds5x8v": {
           "id": "p0kh9ds5x8v",
           "label": "Second World War",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Second World War"
           },
           "note": "Used to record buildings, defensive monuments and sites dating to, and associated with, the Second World War. For other types of building, such as houses, built during this period use MID 20TH CENTURY.",
@@ -44648,7 +44648,7 @@
         "p0kh9ds6f4n": {
           "id": "p0kh9ds6f4n",
           "label": "Stuart",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Stuart"
           },
           "note": "Dating to the reign of the Stuart kings of England (including the Commonwealth inter-regnum)",
@@ -44677,7 +44677,7 @@
         "p0kh9ds6t9k": {
           "id": "p0kh9ds6t9k",
           "label": "Early Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Mesolithic"
           },
           "note": "The earliest subdivision of the Mesolithic, or Middle Stone Age.",
@@ -44706,7 +44706,7 @@
         "p0kh9ds785r": {
           "id": "p0kh9ds785r",
           "label": "Later Prehistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Later Prehistoric"
           },
           "note": "For monuments that can be identifed only to a date range from Neolithic to Iron Age.",
@@ -44735,7 +44735,7 @@
         "p0kh9ds7jvs": {
           "id": "p0kh9ds7jvs",
           "label": "Tudor",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Tudor"
           },
           "note": "Dating to the reign of the Tudor monarchs",
@@ -44764,7 +44764,7 @@
         "p0kh9ds7q8m": {
           "id": "p0kh9ds7q8m",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "note": "This period follows on from the Neolithic and is characterized by the increasing use of Bronzework. It is subdivided in the Early,Middle and Late Bronze Age.",
@@ -44793,7 +44793,7 @@
         "p0kh9ds8p8k": {
           "id": "p0kh9ds8p8k",
           "label": "Late Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Iron Age"
           },
           "note": "The third and latest subdivision of the Iron Age.",
@@ -44822,7 +44822,7 @@
         "p0kh9ds9nsj": {
           "id": "p0kh9ds9nsj",
           "label": "Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman"
           },
           "note": "Traditionally begins with the Roman invasion in 43AD and ends with the emperor Honorius directing Britain to see to its own defence in 410AD.",
@@ -44851,7 +44851,7 @@
         "p0kh9dsbd33": {
           "id": "p0kh9dsbd33",
           "label": "Cold War",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cold War"
           },
           "note": "The period of political and military opposition betwen the major Superpowers (USA and USSR) and their allies. Known as the Cold War as there were no direct military conflicts between the two main protagonists.",
@@ -44880,7 +44880,7 @@
         "p0kh9dsbm2h": {
           "id": "p0kh9dsbm2h",
           "label": "Middle Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Neolithic"
           },
           "note": "The second subdivision of the Neolithic, or New Stone Age.",
@@ -44909,7 +44909,7 @@
         "p0kh9dsbnzg": {
           "id": "p0kh9dsbnzg",
           "label": "Early Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Neolithic"
           },
           "note": "The earliest subdivision of the Neolithic, or New Stone Age.",
@@ -44938,7 +44938,7 @@
         "p0kh9dsbz2g": {
           "id": "p0kh9dsbz2g",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "note": "The New Stone Age, this period follows on from the Palaeolithic and the Mesolithc and is itself suceeded by the Bronze Age. This period is characterized by the practice of a farming ecomony and extensive monumental constructions.",
@@ -44967,7 +44967,7 @@
         "p0kh9dscbkd": {
           "id": "p0kh9dscbkd",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval"
           },
           "note": "The Medieval period or Middle Ages begins with the Norman invasion and ends with the dissolution of the monasteries.",
@@ -44996,7 +44996,7 @@
         "p0kh9dscmjf": {
           "id": "p0kh9dscmjf",
           "label": "Late Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Mesolithic"
           },
           "note": "The latest subdivision of the Mesolithic, or Middle Stone Age.",
@@ -45025,7 +45025,7 @@
         "p0kh9dsctsj": {
           "id": "p0kh9dsctsj",
           "label": "Post Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Post Medieval"
           },
           "note": "Begins with the dissolution of the monasteries and ends with the death of Queen Victoria. Use more specific period where known.",
@@ -45054,7 +45054,7 @@
         "p0kh9dsdf5j": {
           "id": "p0kh9dsdf5j",
           "label": "Early Prehistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Prehistoric"
           },
           "note": "For monuments which are characteristic of the Paleolithic to Mesolithic but cannot be specifically assigned.",
@@ -45083,7 +45083,7 @@
         "p0kh9dshs59": {
           "id": "p0kh9dshs59",
           "label": "Early Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
           "note": "The earliest subdivision of the Bronze Age.",
@@ -45112,7 +45112,7 @@
         "p0kh9dsj33x": {
           "id": "p0kh9dsj33x",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "note": "This period follows on from the Bronze Age and is characterized by the use of iron for making tools and monuments such as hillforts and oppida. The Iron Age is taken to end with the Roman invasion.",
@@ -45141,7 +45141,7 @@
         "p0kh9dsk4zt": {
           "id": "p0kh9dsk4zt",
           "label": "Mid 20th Century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mid 20th Century"
           },
           "note": "The mid third of the 20th Century",
@@ -45170,7 +45170,7 @@
         "p0kh9dskb4m": {
           "id": "p0kh9dskb4m",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "note": "The Middle Stone Age, falling between the Palaeolithic and the Neolithic; marks the beginning of a move from a hunter gatherer society towards food producing society.",
@@ -45199,7 +45199,7 @@
         "p0kh9dsmf3f": {
           "id": "p0kh9dsmf3f",
           "label": "Early Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Medieval"
           },
           "note": "This dates from the breakdown of Roman rule in Britain to the Norman invasion in 1066 and is to be used for monuments of post Roman, Saxon and Viking date.",
@@ -45228,7 +45228,7 @@
         "p0kh9dsnrhc": {
           "id": "p0kh9dsnrhc",
           "label": "Middle Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Palaeolithic"
           },
           "note": "The second subdivision of the Paleolithic or Old Stone Age. Characterized by the fine flake tools of the Mousterian tradition and economically by a hunter gatherer society.",
@@ -45257,7 +45257,7 @@
         "p0kh9dsqfgv": {
           "id": "p0kh9dsqfgv",
           "label": "Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Palaeolithic"
           },
           "note": "The Old Stone Age defined by the practice of hunting and gathering and the use of chipped flint tools. This period is usually divided up into the Lower, Middle and Upper Palaeolithic.",
@@ -45286,7 +45286,7 @@
         "p0kh9dsqkbq": {
           "id": "p0kh9dsqkbq",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "note": "The third and latest subdivision of the Bronze Age.",
@@ -45315,7 +45315,7 @@
         "p0kh9dsqpzm": {
           "id": "p0kh9dsqpzm",
           "label": "Middle Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
           "note": "The second subdivision of the Bronze Age.",
@@ -45344,7 +45344,7 @@
         "p0kh9dsqx6c": {
           "id": "p0kh9dsqx6c",
           "label": "Middle Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Iron Age"
           },
           "note": "The second subdivision of the Iron Age.",
@@ -45373,7 +45373,7 @@
         "p0kh9dst3vc": {
           "id": "p0kh9dst3vc",
           "label": "Georgian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Georgian"
           },
           "note": "Dating to or characteristic of the reigns of any of the first four kings of Great Britain called George",
@@ -45402,7 +45402,7 @@
         "p0kh9dst7t7": {
           "id": "p0kh9dst7t7",
           "label": "Prehistoric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Prehistoric"
           },
           "note": "For monuments that can be identifed only to a date range from Palaeolithic to Iron Age.",
@@ -45431,7 +45431,7 @@
         "p0kh9dstffb": {
           "id": "p0kh9dstffb",
           "label": "Early 20th Century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early 20th Century"
           },
           "note": "The first third of the 20th century.",
@@ -45460,7 +45460,7 @@
         "p0kh9dstg2x": {
           "id": "p0kh9dstg2x",
           "label": "20th Century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "20th Century"
           },
           "note": "Previously recorded as 'Modern'",
@@ -45489,7 +45489,7 @@
         "p0kh9dstmtg": {
           "id": "p0kh9dstmtg",
           "label": "Lower Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lower Palaeolithic"
           },
           "note": "The earliest subdivision of the Palaeolithic, or Old Stone Age; when the earliest use of flint tools appears in the current archaeological record. A hunter gatherer society is a defining characteristic.",
@@ -45518,7 +45518,7 @@
         "p0kh9dstr3n": {
           "id": "p0kh9dstr3n",
           "label": "Elizabethan",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Elizabethan"
           },
           "note": "Dating to the reign of Elizabeth 1st of England.",
@@ -45547,7 +45547,7 @@
         "p0kh9dsts5m": {
           "id": "p0kh9dsts5m",
           "label": "Upper Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Upper Palaeolithic"
           },
           "note": "The third and last subdivision of the Paleolithic or Old Stone Age; characterized by the development of projectile points made from bony materials and the development of fine blade flint tools.",
@@ -45576,7 +45576,7 @@
         "p0kh9dsvcdn": {
           "id": "p0kh9dsvcdn",
           "label": "Hanoverian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hanoverian"
           },
           "note": "Dating to the reign of the Hanoverian kings.",
@@ -45605,7 +45605,7 @@
         "p0kh9dsw3zv": {
           "id": "p0kh9dsw3zv",
           "label": "Edwardian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Edwardian"
           },
           "note": "The period covering the reign of Edward VII. Do not use for the reigns of Edwards I-VI.",
@@ -45634,7 +45634,7 @@
         "p0kh9dsxp46": {
           "id": "p0kh9dsxp46",
           "label": "Victorian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Victorian"
           },
           "note": "Dating to the reign of Queen Victoria",
@@ -45663,7 +45663,7 @@
         "p0kh9dszj78": {
           "id": "p0kh9dszj78",
           "label": "21st Century",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "21st Century"
           },
           "note": "Twenty first century phases and events.",
@@ -45692,7 +45692,7 @@
         "p0kh9dszskn": {
           "id": "p0kh9dszskn",
           "label": "Early Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iron Age"
           },
           "note": "The earliest subdivision of the Iron Age.",
@@ -45744,7 +45744,7 @@
           },
           "id": "p0kj6dj4bzp",
           "label": "Fourth Armenian Monarchy",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Fourth Armenian Monarchy"
           },
           "source": {
@@ -45799,7 +45799,7 @@
         "p0kj6dj554g": {
           "id": "p0kj6dj554g",
           "label": "Abbasid Caliphate",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Abbasid Caliphate"
           },
           "source": {
@@ -45859,7 +45859,7 @@
           },
           "id": "p0kj6dj68rm",
           "label": "Arsacid period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Arsacid period"
           },
           "source": {
@@ -45920,7 +45920,7 @@
           "editorialNote": "Deleted Kingdom of Commagene (163 B.C.-72 A.D.) on 10/20/14 due to problem with this end-date. Found these from the index entry for Armenia.",
           "id": "p0kj6dj7pzf",
           "label": "proto-Armenian Satrapy of Greater Armenia",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "proto-Armenian Satrapy of Greater Armenia"
           },
           "note": "Kingdom was ruled by Romans between 17 A.D.-43 A.D.",
@@ -45976,7 +45976,7 @@
         "p0kj6dj8rr9": {
           "id": "p0kj6dj8rr9",
           "label": "Seleucid Monarchy",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Seleucid Monarchy"
           },
           "source": {
@@ -46031,7 +46031,7 @@
         "p0kj6dj9kn3": {
           "id": "p0kj6dj9kn3",
           "label": "Third Armenian Monarchy",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Third Armenian Monarchy"
           },
           "source": {
@@ -46091,7 +46091,7 @@
           },
           "id": "p0kj6djj5cn",
           "label": "post-Arsacid period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "post-Arsacid period"
           },
           "source": {
@@ -46146,7 +46146,7 @@
         "p0kj6djkj9h": {
           "id": "p0kj6djkj9h",
           "label": "Arab period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Arab period"
           },
           "source": {
@@ -46206,7 +46206,7 @@
           },
           "id": "p0kj6djr5rv",
           "label": "Artaxiad Monarchy",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Artaxiad Monarchy"
           },
           "source": {
@@ -46266,7 +46266,7 @@
           },
           "id": "p0kj6djwt67",
           "label": "Orontid First Monarchy",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Orontid First Monarchy"
           },
           "source": {
@@ -46343,7 +46343,7 @@
           },
           "id": "p0m63nj24nd",
           "label": "Iron Age I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age I"
           },
           "spatialCoverage": [
@@ -46371,7 +46371,7 @@
         "p0m63nj29k7": {
           "id": "p0m63nj29k7",
           "label": "Chalcolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Chalcolithic"
           },
           "spatialCoverage": [
@@ -46411,7 +46411,7 @@
         "p0m63nj2pms": {
           "id": "p0m63nj2pms",
           "label": "First Intermediate Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "First Intermediate Period"
           },
           "spatialCoverage": [
@@ -46439,7 +46439,7 @@
         "p0m63nj32kd": {
           "id": "p0m63nj32kd",
           "label": "Ceramic Neolithic B",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ceramic Neolithic B"
           },
           "spatialCoverage": [
@@ -46467,7 +46467,7 @@
         "p0m63nj3bbf": {
           "id": "p0m63nj3bbf",
           "label": "Persian Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Persian Period"
           },
           "spatialCoverage": [
@@ -46512,7 +46512,7 @@
           },
           "id": "p0m63nj3kjh",
           "label": "Iron Age III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age III"
           },
           "spatialCoverage": [
@@ -46545,7 +46545,7 @@
           },
           "id": "p0m63nj3pm3",
           "label": "Late Hellenistic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Hellenistic Period"
           },
           "spatialCoverage": [
@@ -46573,7 +46573,7 @@
         "p0m63nj3t8w": {
           "id": "p0m63nj3t8w",
           "label": "Second Intermediate Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Second Intermediate Period"
           },
           "spatialCoverage": [
@@ -46606,7 +46606,7 @@
           },
           "id": "p0m63nj4dkm",
           "label": "Middle Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Kingdom"
           },
           "spatialCoverage": [
@@ -46634,7 +46634,7 @@
         "p0m63nj4p8z": {
           "id": "p0m63nj4p8z",
           "label": "Ceramic Neolithic B",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ceramic Neolithic B"
           },
           "spatialCoverage": [
@@ -46667,7 +46667,7 @@
           },
           "id": "p0m63nj4skv",
           "label": "Cypro Geometric I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cypro Geometric I"
           },
           "spatialCoverage": [
@@ -46700,7 +46700,7 @@
           },
           "id": "p0m63nj575d",
           "label": "Late Hellenistic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Hellenistic Period"
           },
           "spatialCoverage": [
@@ -46737,7 +46737,7 @@
           },
           "id": "p0m63nj57xq",
           "label": "Neo Babylonian Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo Babylonian Period"
           },
           "spatialCoverage": [
@@ -46782,7 +46782,7 @@
           },
           "id": "p0m63nj5pzw",
           "label": "Intermediate Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Intermediate Bronze Age"
           },
           "spatialCoverage": [
@@ -46815,7 +46815,7 @@
           },
           "id": "p0m63nj633s",
           "label": "Early Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Roman Period"
           },
           "spatialCoverage": [
@@ -46848,7 +46848,7 @@
           },
           "id": "p0m63nj65bq",
           "label": "Byzantine Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Byzantine Period"
           },
           "spatialCoverage": [
@@ -46881,7 +46881,7 @@
           },
           "id": "p0m63nj66cc",
           "label": "Ottoman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ottoman Period"
           },
           "spatialCoverage": [
@@ -46926,7 +46926,7 @@
           },
           "id": "p0m63nj699k",
           "label": "Early Islamic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Islamic Period"
           },
           "spatialCoverage": [
@@ -46971,7 +46971,7 @@
           },
           "id": "p0m63nj6qws",
           "label": "Late Cypriot II A-B",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Cypriot II A-B"
           },
           "spatialCoverage": [
@@ -46999,7 +46999,7 @@
         "p0m63nj6xtw": {
           "id": "p0m63nj6xtw",
           "label": "Pottery Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pottery Neolithic"
           },
           "spatialCoverage": [
@@ -47032,7 +47032,7 @@
           },
           "id": "p0m63nj78xj",
           "label": "Iron Age I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age I"
           },
           "spatialCoverage": [
@@ -47077,7 +47077,7 @@
           },
           "id": "p0m63nj7tfm",
           "label": "Early Hellenistic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Hellenistic Period"
           },
           "spatialCoverage": [
@@ -47110,7 +47110,7 @@
           },
           "id": "p0m63nj7v3k",
           "label": "Fatimid/Mameluke Periods",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Fatimid/Mameluke Periods"
           },
           "spatialCoverage": [
@@ -47155,7 +47155,7 @@
           },
           "id": "p0m63nj7zfs",
           "label": "Iron Age IIC",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age IIC"
           },
           "spatialCoverage": [
@@ -47200,7 +47200,7 @@
           },
           "id": "p0m63nj833b",
           "label": "Middle Hellenistic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Hellenistic Period"
           },
           "spatialCoverage": [
@@ -47233,7 +47233,7 @@
           },
           "id": "p0m63nj83wz",
           "label": "Early Bronze Age IV",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age IV"
           },
           "spatialCoverage": [
@@ -47278,7 +47278,7 @@
           },
           "id": "p0m63nj8jfh",
           "label": "Middle Bronze Age II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age II"
           },
           "spatialCoverage": [
@@ -47318,7 +47318,7 @@
         "p0m63nj8xzr": {
           "id": "p0m63nj8xzr",
           "label": "Frankish",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Frankish"
           },
           "spatialCoverage": [
@@ -47346,7 +47346,7 @@
         "p0m63nj9bsb": {
           "id": "p0m63nj9bsb",
           "label": "PPNB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "PPNB"
           },
           "spatialCoverage": [
@@ -47386,7 +47386,7 @@
         "p0m63nj9d68": {
           "id": "p0m63nj9d68",
           "label": "Early Byzantine",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Byzantine"
           },
           "spatialCoverage": [
@@ -47419,7 +47419,7 @@
           },
           "id": "p0m63njb86b",
           "label": "Late Bronze Age I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age I"
           },
           "spatialCoverage": [
@@ -47464,7 +47464,7 @@
           },
           "id": "p0m63njbvnp",
           "label": "Early Bronze Age I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age I"
           },
           "spatialCoverage": [
@@ -47509,7 +47509,7 @@
           },
           "id": "p0m63njbxb9",
           "label": "Early Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Roman Period"
           },
           "spatialCoverage": [
@@ -47541,7 +47541,7 @@
         "p0m63njc38r": {
           "id": "p0m63njc38r",
           "label": "Ceramic Neolithic A",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ceramic Neolithic A"
           },
           "spatialCoverage": [
@@ -47574,7 +47574,7 @@
           },
           "id": "p0m63njc4hd",
           "label": "Early Hellenistic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Hellenistic Period"
           },
           "spatialCoverage": [
@@ -47611,7 +47611,7 @@
           },
           "id": "p0m63njc6qz",
           "label": "Late Cypriot II C",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Cypriot II C"
           },
           "spatialCoverage": [
@@ -47644,7 +47644,7 @@
           },
           "id": "p0m63njcrhq",
           "label": "Early Cypriot",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Cypriot"
           },
           "spatialCoverage": [
@@ -47672,7 +47672,7 @@
         "p0m63njd3g2": {
           "id": "p0m63njd3g2",
           "label": "Cypro Classical II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cypro Classical II"
           },
           "spatialCoverage": [
@@ -47700,7 +47700,7 @@
         "p0m63njd727": {
           "id": "p0m63njd727",
           "label": "Early Chalcolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Chalcolithic"
           },
           "spatialCoverage": [
@@ -47733,7 +47733,7 @@
           },
           "id": "p0m63njdf2z",
           "label": "Hellenistic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic Period"
           },
           "spatialCoverage": [
@@ -47761,7 +47761,7 @@
         "p0m63njdp3d": {
           "id": "p0m63njdp3d",
           "label": "Ceramic Neolithic A",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ceramic Neolithic A"
           },
           "spatialCoverage": [
@@ -47794,7 +47794,7 @@
           },
           "id": "p0m63njdrpn",
           "label": "Late Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Roman Period"
           },
           "spatialCoverage": [
@@ -47835,7 +47835,7 @@
           },
           "id": "p0m63njdz8f",
           "label": "Ottoman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ottoman Period"
           },
           "spatialCoverage": [
@@ -47863,7 +47863,7 @@
         "p0m63njf3rx": {
           "id": "p0m63njf3rx",
           "label": "Persian Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Persian Period"
           },
           "spatialCoverage": [
@@ -47891,7 +47891,7 @@
         "p0m63njf6k6": {
           "id": "p0m63njf6k6",
           "label": "Middle Chalcolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Chalcolithic"
           },
           "spatialCoverage": [
@@ -47919,7 +47919,7 @@
         "p0m63njf9vq": {
           "id": "p0m63njf9vq",
           "label": "Venetian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Venetian"
           },
           "spatialCoverage": [
@@ -47952,7 +47952,7 @@
           },
           "id": "p0m63njfbsc",
           "label": "Early Islamic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Islamic Period"
           },
           "spatialCoverage": [
@@ -47985,7 +47985,7 @@
           },
           "id": "p0m63njfd2x",
           "label": "Middle Bronze Age III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age III"
           },
           "spatialCoverage": [
@@ -48030,7 +48030,7 @@
           },
           "id": "p0m63njfkpf",
           "label": "Cypro Geometric III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cypro Geometric III"
           },
           "spatialCoverage": [
@@ -48063,7 +48063,7 @@
           },
           "id": "p0m63njfmrd",
           "label": "Middle Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Roman Period"
           },
           "spatialCoverage": [
@@ -48100,7 +48100,7 @@
           },
           "id": "p0m63njfppb",
           "label": "Later Islamic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Later Islamic Period"
           },
           "spatialCoverage": [
@@ -48145,7 +48145,7 @@
           },
           "id": "p0m63njfs4v",
           "label": "Early Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Roman Period"
           },
           "spatialCoverage": [
@@ -48178,7 +48178,7 @@
           },
           "id": "p0m63njfv4g",
           "label": "Frankish/Ayyubid Periods",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Frankish/Ayyubid Periods"
           },
           "spatialCoverage": [
@@ -48223,7 +48223,7 @@
           },
           "id": "p0m63njgvtd",
           "label": "Late Hellenistic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Hellenistic Period"
           },
           "spatialCoverage": [
@@ -48255,7 +48255,7 @@
         "p0m63njgxxz": {
           "id": "p0m63njgxxz",
           "label": "Ceramic Neolithic A",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ceramic Neolithic A"
           },
           "spatialCoverage": [
@@ -48288,7 +48288,7 @@
           },
           "id": "p0m63njh7tb",
           "label": "Late Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Period"
           },
           "spatialCoverage": [
@@ -48316,7 +48316,7 @@
         "p0m63njj46p": {
           "id": "p0m63njj46p",
           "label": "Hellenistic I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic I"
           },
           "spatialCoverage": [
@@ -48344,7 +48344,7 @@
         "p0m63njj92t": {
           "id": "p0m63njj92t",
           "label": "Ceramic Neolithic B",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ceramic Neolithic B"
           },
           "spatialCoverage": [
@@ -48377,7 +48377,7 @@
           },
           "id": "p0m63njjcn4",
           "label": "Byzantine Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Byzantine Period"
           },
           "spatialCoverage": [
@@ -48417,7 +48417,7 @@
         "p0m63njjg2b": {
           "id": "p0m63njjg2b",
           "label": "Arab Conflict",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Arab Conflict"
           },
           "spatialCoverage": [
@@ -48445,7 +48445,7 @@
         "p0m63njjggb": {
           "id": "p0m63njjggb",
           "label": "Ottoman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ottoman"
           },
           "spatialCoverage": [
@@ -48478,7 +48478,7 @@
           },
           "id": "p0m63njk6fv",
           "label": "Early Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Roman Period"
           },
           "spatialCoverage": [
@@ -48515,7 +48515,7 @@
           },
           "id": "p0m63njm6n5",
           "label": "Middle Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Roman Period"
           },
           "spatialCoverage": [
@@ -48543,7 +48543,7 @@
         "p0m63njm72r": {
           "id": "p0m63njm72r",
           "label": "British",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "British"
           },
           "spatialCoverage": [
@@ -48571,7 +48571,7 @@
         "p0m63njmmp2": {
           "id": "p0m63njmmp2",
           "label": "Cypro Classical I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cypro Classical I"
           },
           "spatialCoverage": [
@@ -48604,7 +48604,7 @@
           },
           "id": "p0m63njmx32",
           "label": "New Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "New Kingdom"
           },
           "spatialCoverage": [
@@ -48632,7 +48632,7 @@
         "p0m63njn6d3": {
           "id": "p0m63njn6d3",
           "label": "Ceramic Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ceramic Neolithic"
           },
           "spatialCoverage": [
@@ -48665,7 +48665,7 @@
           },
           "id": "p0m63njncbv",
           "label": "Early Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
           "spatialCoverage": [
@@ -48698,7 +48698,7 @@
           },
           "id": "p0m63njnd5h",
           "label": "Cypro Geometric II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cypro Geometric II"
           },
           "spatialCoverage": [
@@ -48731,7 +48731,7 @@
           },
           "id": "p0m63njngrr",
           "label": "Middle Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
           "spatialCoverage": [
@@ -48759,7 +48759,7 @@
         "p0m63njnjsp": {
           "id": "p0m63njnjsp",
           "label": "Hellenistic II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic II"
           },
           "spatialCoverage": [
@@ -48787,7 +48787,7 @@
         "p0m63njp6pz": {
           "id": "p0m63njp6pz",
           "label": "Cypro Archaic I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cypro Archaic I"
           },
           "spatialCoverage": [
@@ -48820,7 +48820,7 @@
           },
           "id": "p0m63njpjkx",
           "label": "Hasmonean Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hasmonean Period"
           },
           "spatialCoverage": [
@@ -48852,7 +48852,7 @@
         "p0m63njpnfh": {
           "id": "p0m63njpnfh",
           "label": "Roman Republic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Republic"
           },
           "spatialCoverage": [
@@ -48880,7 +48880,7 @@
         "p0m63njq3v2": {
           "id": "p0m63njq3v2",
           "label": "PPNA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "PPNA"
           },
           "spatialCoverage": [
@@ -48925,7 +48925,7 @@
           },
           "id": "p0m63njq9qg",
           "label": "Late Bronze Age II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age II"
           },
           "spatialCoverage": [
@@ -48970,7 +48970,7 @@
           },
           "id": "p0m63njqgqx",
           "label": "Old Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Kingdom"
           },
           "spatialCoverage": [
@@ -49003,7 +49003,7 @@
           },
           "id": "p0m63njqrdb",
           "label": "Early Bronze Age II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age II"
           },
           "spatialCoverage": [
@@ -49043,7 +49043,7 @@
         "p0m63njqxz5": {
           "id": "p0m63njqxz5",
           "label": "Chalcolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Chalcolithic"
           },
           "spatialCoverage": [
@@ -49076,7 +49076,7 @@
           },
           "id": "p0m63njrgjj",
           "label": "Intermediate Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Intermediate Bronze Age"
           },
           "spatialCoverage": [
@@ -49121,7 +49121,7 @@
           },
           "id": "p0m63njrhc6",
           "label": "Middle Cypriot I and II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Cypriot I and II"
           },
           "spatialCoverage": [
@@ -49149,7 +49149,7 @@
         "p0m63njrj75": {
           "id": "p0m63njrj75",
           "label": "Late Byzantine",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Byzantine"
           },
           "spatialCoverage": [
@@ -49182,7 +49182,7 @@
           },
           "id": "p0m63njrpgn",
           "label": "Late Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Roman Period"
           },
           "spatialCoverage": [
@@ -49215,7 +49215,7 @@
           },
           "id": "p0m63njrpxz",
           "label": "Ummayyad/Abbasid Periods",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ummayyad/Abbasid Periods"
           },
           "spatialCoverage": [
@@ -49255,7 +49255,7 @@
         "p0m63njrtkt": {
           "id": "p0m63njrtkt",
           "label": "Ceramic Neolithic B",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ceramic Neolithic B"
           },
           "spatialCoverage": [
@@ -49283,7 +49283,7 @@
         "p0m63njs34j": {
           "id": "p0m63njs34j",
           "label": "Cypro Archaic II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cypro Archaic II"
           },
           "spatialCoverage": [
@@ -49316,7 +49316,7 @@
           },
           "id": "p0m63njsg85",
           "label": "Iron Age IIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age IIB"
           },
           "spatialCoverage": [
@@ -49361,7 +49361,7 @@
           },
           "id": "p0m63njsqs7",
           "label": "Middle Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Roman Period"
           },
           "spatialCoverage": [
@@ -49402,7 +49402,7 @@
           },
           "id": "p0m63njt6zp",
           "label": "Iron Age IIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age IIA"
           },
           "spatialCoverage": [
@@ -49442,7 +49442,7 @@
         "p0m63njtk9m": {
           "id": "p0m63njtk9m",
           "label": "Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman"
           },
           "spatialCoverage": [
@@ -49475,7 +49475,7 @@
           },
           "id": "p0m63njtm6w",
           "label": "Byzantine Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Byzantine Period"
           },
           "spatialCoverage": [
@@ -49508,7 +49508,7 @@
           },
           "id": "p0m63njtmv8",
           "label": "Late Roman Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Roman Period"
           },
           "spatialCoverage": [
@@ -49545,7 +49545,7 @@
           },
           "id": "p0m63njtn97",
           "label": "Early Bronze Age III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age III"
           },
           "spatialCoverage": [
@@ -49585,7 +49585,7 @@
         "p0m63njtpk6": {
           "id": "p0m63njtpk6",
           "label": "Ceramic Neolithic A",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ceramic Neolithic A"
           },
           "spatialCoverage": [
@@ -49618,7 +49618,7 @@
           },
           "id": "p0m63njtr7f",
           "label": "Middle Bronze Age I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age I"
           },
           "spatialCoverage": [
@@ -49658,7 +49658,7 @@
         "p0m63njtxw8": {
           "id": "p0m63njtxw8",
           "label": "Late Chalcolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Chalcolithic"
           },
           "spatialCoverage": [
@@ -49686,7 +49686,7 @@
         "p0m63njvpn4": {
           "id": "p0m63njvpn4",
           "label": "Predynastic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Predynastic"
           },
           "spatialCoverage": [
@@ -49719,7 +49719,7 @@
           },
           "id": "p0m63njw2xp",
           "label": "Herodian Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Herodian Period"
           },
           "spatialCoverage": [
@@ -49756,7 +49756,7 @@
           },
           "id": "p0m63njw3sn",
           "label": "Intermediate Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Intermediate Bronze Age"
           },
           "spatialCoverage": [
@@ -49789,7 +49789,7 @@
           },
           "id": "p0m63njw6r7",
           "label": "Early Hellenistic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Hellenistic Period"
           },
           "spatialCoverage": [
@@ -49821,7 +49821,7 @@
         "p0m63njwmxf": {
           "id": "p0m63njwmxf",
           "label": "Philia",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Philia"
           },
           "spatialCoverage": [
@@ -49854,7 +49854,7 @@
           },
           "id": "p0m63njwrjx",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "spatialCoverage": [
@@ -49887,7 +49887,7 @@
           },
           "id": "p0m63njwxjf",
           "label": "Intermediate Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Intermediate Bronze Age"
           },
           "spatialCoverage": [
@@ -49920,7 +49920,7 @@
           },
           "id": "p0m63njx89q",
           "label": "Iron Age II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age II"
           },
           "spatialCoverage": [
@@ -49953,7 +49953,7 @@
           },
           "id": "p0m63njxhf5",
           "label": "Middle Cypriot III/Late Cypriot I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Cypriot III/Late Cypriot I"
           },
           "spatialCoverage": [
@@ -49986,7 +49986,7 @@
           },
           "id": "p0m63njzbxk",
           "label": "Early Dynastic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic"
           },
           "spatialCoverage": [
@@ -50019,7 +50019,7 @@
           },
           "id": "p0m63njzdfh",
           "label": "Late Cypriot III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Cypriot III"
           },
           "spatialCoverage": [
@@ -50047,7 +50047,7 @@
         "p0m63njzg6r": {
           "id": "p0m63njzg6r",
           "label": "Third Intermediate Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Third Intermediate Period"
           },
           "spatialCoverage": [
@@ -50097,7 +50097,7 @@
           },
           "id": "p0ms2ch58wg",
           "label": "DAIII",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "DAIII"
           },
           "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
@@ -50129,7 +50129,7 @@
           },
           "id": "p0ms2ch6k6q",
           "label": "DAI",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "DAI"
           },
           "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
@@ -50161,7 +50161,7 @@
           },
           "id": "p0ms2chfwkv",
           "label": "DAII/III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "DAII/III"
           },
           "spatialCoverage": [
@@ -50187,7 +50187,7 @@
         "p0ms2chk8gk": {
           "id": "p0ms2chk8gk",
           "label": "Late Geometric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Geometric"
           },
           "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
@@ -50219,7 +50219,7 @@
           },
           "id": "p0ms2chvhsq",
           "label": "DAII",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "DAII"
           },
           "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton; note that this period subsumes a separate period \"Dark Age II/III\" that Conlin and Newton drew from McDonald and Coulson, and date 850-800 B.C.",
@@ -50281,7 +50281,7 @@
         "p0njrb42z26": {
           "id": "p0njrb42z26",
           "label": "Mitanni",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mitanni"
           },
           "source": {
@@ -50325,7 +50325,7 @@
           },
           "id": "p0njrb45vw3",
           "label": "Old Babylonian period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Babylonian period"
           },
           "source": {
@@ -50365,7 +50365,7 @@
           },
           "id": "p0njrb4hmpk",
           "label": "Jemdet Nasr period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Jemdet Nasr period"
           },
           "source": {
@@ -50400,7 +50400,7 @@
         "p0njrb4hqj5": {
           "id": "p0njrb4hqj5",
           "label": "Akkadian Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Akkadian Empire"
           },
           "source": {
@@ -50435,7 +50435,7 @@
         "p0njrb4m4w7": {
           "id": "p0njrb4m4w7",
           "label": "Aceramic Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Aceramic Neolithic"
           },
           "source": {
@@ -50470,7 +50470,7 @@
         "p0njrb4nht3": {
           "id": "p0njrb4nht3",
           "label": "Ubaid",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ubaid"
           },
           "source": {
@@ -50510,7 +50510,7 @@
           },
           "id": "p0njrb4pv8x",
           "label": "Early Uruk period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Uruk period"
           },
           "source": {
@@ -50550,7 +50550,7 @@
           },
           "id": "p0njrb4t3cg",
           "label": "Later Uruk period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Later Uruk period"
           },
           "source": {
@@ -50590,7 +50590,7 @@
           },
           "id": "p0njrb4w994",
           "label": "Neo-Assyrian period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Assyrian period"
           },
           "source": {
@@ -50625,7 +50625,7 @@
         "p0njrb4zdmh": {
           "id": "p0njrb4zdmh",
           "label": "Second Dynasty of Isin",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Second Dynasty of Isin"
           },
           "note": "Dynasty IV from Isin",
@@ -50678,7 +50678,7 @@
         "p0pk6scfcf7": {
           "id": "p0pk6scfcf7",
           "label": "Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic"
           },
           "note": "See also Dominguez in C. Sanchez & G.R. Tsetskhladze, 2001. Greek Pottery from the Iberian Peninsula.",
@@ -50731,7 +50731,7 @@
           },
           "id": "p0pqptc2r8x",
           "label": "Romeinse tijd vroeg",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Romeinse tijd vroeg"
           },
           "spatialCoverage": [
@@ -50762,7 +50762,7 @@
           },
           "id": "p0pqptc2sdk",
           "label": "Middeleeuwen vroeg",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Middeleeuwen vroeg"
           },
           "spatialCoverage": [
@@ -50793,7 +50793,7 @@
           },
           "id": "p0pqptc2ww5",
           "label": "Mesolithicum midden",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Mesolithicum midden"
           },
           "spatialCoverage": [
@@ -50824,7 +50824,7 @@
           },
           "id": "p0pqptc49xx",
           "label": "Neolithicum vroeg B",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Neolithicum vroeg B"
           },
           "spatialCoverage": [
@@ -50855,7 +50855,7 @@
           },
           "id": "p0pqptc4xpx",
           "label": "Middeleeuwen laat B",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Middeleeuwen laat B"
           },
           "spatialCoverage": [
@@ -50886,7 +50886,7 @@
           },
           "id": "p0pqptc533f",
           "label": "Neolithicum laat A",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Neolithicum laat A"
           },
           "spatialCoverage": [
@@ -50917,7 +50917,7 @@
           },
           "id": "p0pqptc5cn5",
           "label": "Nieuwe tijd",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Nieuwe tijd"
           },
           "spatialCoverage": [
@@ -50948,7 +50948,7 @@
           },
           "id": "p0pqptc5rvd",
           "label": "Nieuwe tijd B",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Nieuwe tijd B"
           },
           "spatialCoverage": [
@@ -50979,7 +50979,7 @@
           },
           "id": "p0pqptc6vm7",
           "label": "Bronstijd vroeg",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Bronstijd vroeg"
           },
           "spatialCoverage": [
@@ -51010,7 +51010,7 @@
           },
           "id": "p0pqptc7s5j",
           "label": "Middeleeuwen laat",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Middeleeuwen laat"
           },
           "spatialCoverage": [
@@ -51041,7 +51041,7 @@
           },
           "id": "p0pqptc7tx6",
           "label": "Middeleeuwen laat A",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Middeleeuwen laat A"
           },
           "spatialCoverage": [
@@ -51072,7 +51072,7 @@
           },
           "id": "p0pqptc8dj7",
           "label": "Middeleeuwen vroeg D",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Middeleeuwen vroeg D"
           },
           "spatialCoverage": [
@@ -51103,7 +51103,7 @@
           },
           "id": "p0pqptc96jp",
           "label": "Paleolithicum midden",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Paleolithicum midden"
           },
           "spatialCoverage": [
@@ -51134,7 +51134,7 @@
           },
           "id": "p0pqptc976n",
           "label": "Bronstijd midden",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Bronstijd midden"
           },
           "spatialCoverage": [
@@ -51165,7 +51165,7 @@
           },
           "id": "p0pqptcctbj",
           "label": "Romeinse tijd laat",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Romeinse tijd laat"
           },
           "spatialCoverage": [
@@ -51196,7 +51196,7 @@
           },
           "id": "p0pqptcdcrx",
           "label": "IJzertijd vroeg",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "IJzertijd vroeg"
           },
           "spatialCoverage": [
@@ -51227,7 +51227,7 @@
           },
           "id": "p0pqptcdgk6",
           "label": "Nieuwe tijd A",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Nieuwe tijd A"
           },
           "spatialCoverage": [
@@ -51258,7 +51258,7 @@
           },
           "id": "p0pqptcdxp2",
           "label": "Romeinse tijd",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Romeinse tijd"
           },
           "spatialCoverage": [
@@ -51289,7 +51289,7 @@
           },
           "id": "p0pqptcfq9t",
           "label": "Middeleeuwen",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Middeleeuwen"
           },
           "spatialCoverage": [
@@ -51320,7 +51320,7 @@
           },
           "id": "p0pqptcgfpd",
           "label": "Neolithicum vroeg",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Neolithicum vroeg"
           },
           "spatialCoverage": [
@@ -51351,7 +51351,7 @@
           },
           "id": "p0pqptch5g9",
           "label": "Bronstijd midden A",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Bronstijd midden A"
           },
           "spatialCoverage": [
@@ -51382,7 +51382,7 @@
           },
           "id": "p0pqptch797",
           "label": "Middeleeuwen vroeg A",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Middeleeuwen vroeg A"
           },
           "spatialCoverage": [
@@ -51413,7 +51413,7 @@
           },
           "id": "p0pqptchhqk",
           "label": "Romeinse tijd midden A",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Romeinse tijd midden A"
           },
           "spatialCoverage": [
@@ -51444,7 +51444,7 @@
           },
           "id": "p0pqptchk66",
           "label": "Bronstijd",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Bronstijd"
           },
           "spatialCoverage": [
@@ -51475,7 +51475,7 @@
           },
           "id": "p0pqptchpfd",
           "label": "Romeinse tijd vroeg A",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Romeinse tijd vroeg A"
           },
           "spatialCoverage": [
@@ -51507,7 +51507,7 @@
           "editorialNote": "no start date provided: noted only as \"before 8800 B.C.\"",
           "id": "p0pqptcjxw3",
           "label": "Paleolithicum",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Paleolithicum"
           },
           "spatialCoverage": [
@@ -51532,7 +51532,7 @@
           },
           "id": "p0pqptck7qq",
           "label": "Neolithicum laat B",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Neolithicum laat B"
           },
           "spatialCoverage": [
@@ -51563,7 +51563,7 @@
           },
           "id": "p0pqptckbqm",
           "label": "IJzertijd",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "IJzertijd"
           },
           "spatialCoverage": [
@@ -51594,7 +51594,7 @@
           },
           "id": "p0pqptckfbt",
           "label": "Mesolithicum vroeg",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Mesolithicum vroeg"
           },
           "spatialCoverage": [
@@ -51625,7 +51625,7 @@
           },
           "id": "p0pqptcmc4h",
           "label": "Nieuwe tijd C",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Nieuwe tijd C"
           },
           "spatialCoverage": [
@@ -51656,7 +51656,7 @@
           },
           "id": "p0pqptcmfqr",
           "label": "Neolithicum vroeg A",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Neolithicum vroeg A"
           },
           "spatialCoverage": [
@@ -51687,7 +51687,7 @@
           },
           "id": "p0pqptcn452",
           "label": "IJzertijd laat",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "IJzertijd laat"
           },
           "spatialCoverage": [
@@ -51718,7 +51718,7 @@
           },
           "id": "p0pqptcnbbg",
           "label": "Romeinse tijd midden B",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Romeinse tijd midden B"
           },
           "spatialCoverage": [
@@ -51749,7 +51749,7 @@
           },
           "id": "p0pqptcnhrx",
           "label": "Romeinse tijd midden",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Romeinse tijd midden"
           },
           "spatialCoverage": [
@@ -51780,7 +51780,7 @@
           },
           "id": "p0pqptcnpgr",
           "label": "Romeinse tijd vroeg B",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Romeinse tijd vroeg B"
           },
           "spatialCoverage": [
@@ -51811,7 +51811,7 @@
           },
           "id": "p0pqptcnxt6",
           "label": "Neolithicum laat",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Neolithicum laat"
           },
           "spatialCoverage": [
@@ -51842,7 +51842,7 @@
           },
           "id": "p0pqptcp92r",
           "label": "IJzertijd midden",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "IJzertijd midden"
           },
           "spatialCoverage": [
@@ -51873,7 +51873,7 @@
           },
           "id": "p0pqptcpcb2",
           "label": "Middeleeuwen vroeg B",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Middeleeuwen vroeg B"
           },
           "spatialCoverage": [
@@ -51904,7 +51904,7 @@
           },
           "id": "p0pqptcppjp",
           "label": "Paleolithicum laat A",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Paleolithicum laat A"
           },
           "spatialCoverage": [
@@ -51935,7 +51935,7 @@
           },
           "id": "p0pqptcprsm",
           "label": "Romeinse tijd laat B",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Romeinse tijd laat B"
           },
           "spatialCoverage": [
@@ -51966,7 +51966,7 @@
           },
           "id": "p0pqptcq3hk",
           "label": "Bronstijd laat",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Bronstijd laat"
           },
           "spatialCoverage": [
@@ -51998,7 +51998,7 @@
           "editorialNote": "no start date provided: noted only as \"before 300000 BP\"",
           "id": "p0pqptcqkgd",
           "label": "Paleolithicum vroeg",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Paleolithicum vroeg"
           },
           "spatialCoverage": [
@@ -52023,7 +52023,7 @@
           },
           "id": "p0pqptcqq2k",
           "label": "Bronstijd midden B",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Bronstijd midden B"
           },
           "spatialCoverage": [
@@ -52054,7 +52054,7 @@
           },
           "id": "p0pqptcrcx7",
           "label": "Neolithicum midden",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Neolithicum midden"
           },
           "spatialCoverage": [
@@ -52085,7 +52085,7 @@
           },
           "id": "p0pqptcs32r",
           "label": "Neolithicum midden A",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Neolithicum midden A"
           },
           "spatialCoverage": [
@@ -52116,7 +52116,7 @@
           },
           "id": "p0pqptcsn5h",
           "label": "Romeinse tijd laat A",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Romeinse tijd laat A"
           },
           "spatialCoverage": [
@@ -52147,7 +52147,7 @@
           },
           "id": "p0pqptct727",
           "label": "Middeleeuwen vroeg C",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Middeleeuwen vroeg C"
           },
           "spatialCoverage": [
@@ -52178,7 +52178,7 @@
           },
           "id": "p0pqptctdsp",
           "label": "Mesolithicum",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Mesolithicum"
           },
           "spatialCoverage": [
@@ -52209,7 +52209,7 @@
           },
           "id": "p0pqptcvm8q",
           "label": "Paleolithicum laat B",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Paleolithicum laat B"
           },
           "spatialCoverage": [
@@ -52240,7 +52240,7 @@
           },
           "id": "p0pqptcvsg7",
           "label": "Neolithicum",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Neolithicum"
           },
           "spatialCoverage": [
@@ -52271,7 +52271,7 @@
           },
           "id": "p0pqptcw5mg",
           "label": "Neolithicum midden B",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Neolithicum midden B"
           },
           "spatialCoverage": [
@@ -52302,7 +52302,7 @@
           },
           "id": "p0pqptczcmr",
           "label": "Mesolithicum laat",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Mesolithicum laat"
           },
           "spatialCoverage": [
@@ -52333,7 +52333,7 @@
           },
           "id": "p0pqptczm5h",
           "label": "Paleolithicum laat",
-          "localizedLabel": {
+          "originalLabel": {
             "nld-latn": "Paleolithicum laat"
           },
           "spatialCoverage": [
@@ -52379,7 +52379,7 @@
         "p0pt6d8krhh": {
           "id": "p0pt6d8krhh",
           "label": "The Soldier Emperors",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "The Soldier Emperors"
           },
           "source": {
@@ -52417,7 +52417,7 @@
         "p0pt6d8n4tp": {
           "id": "p0pt6d8n4tp",
           "label": "Constantine",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Constantine"
           },
           "source": {
@@ -52455,7 +52455,7 @@
         "p0pt6d8xqgg": {
           "id": "p0pt6d8xqgg",
           "label": "The Tetrarchs",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "The Tetrarchs"
           },
           "source": {
@@ -52517,7 +52517,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76z2n5t",
           "label": "Naqada IIId",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Naqada IIId"
           },
           "spatialCoverage": [
@@ -52545,7 +52545,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76z32s3",
           "label": "Late/Final A-group",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late/Final A-group"
           },
           "spatialCoverage": [
@@ -52578,7 +52578,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76z756b",
           "label": "Macedonian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Macedonian"
           },
           "spatialCoverage": [
@@ -52606,7 +52606,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76z793h",
           "label": "Naqada IIIa",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Naqada IIIa"
           },
           "spatialCoverage": [
@@ -52640,7 +52640,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76z85jw",
           "label": "Badarian (Middle Egypt)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Badarian (Middle Egypt)"
           },
           "spatialCoverage": [
@@ -52669,7 +52669,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76z8nr3",
           "label": "Middle A-group",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle A-group"
           },
           "spatialCoverage": [
@@ -52702,7 +52702,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76z8wds",
           "label": "Epi-palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Epi-palaeolithic"
           },
           "spatialCoverage": [
@@ -52730,7 +52730,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76z92f9",
           "label": "Old Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Old Kingdom"
           },
           "spatialCoverage": [
@@ -52758,7 +52758,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zbqht",
           "label": "Late Naqada II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Naqada II"
           },
           "spatialCoverage": [
@@ -52787,7 +52787,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zbv62",
           "label": "Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman"
           },
           "spatialCoverage": [
@@ -52815,7 +52815,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zd3d2",
           "label": "Buto III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Buto III"
           },
           "spatialCoverage": [
@@ -52844,7 +52844,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zdfbb",
           "label": "Buto V",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Buto V"
           },
           "spatialCoverage": [
@@ -52873,7 +52873,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zgkb2",
           "label": "Naqada IIIb",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Naqada IIIb"
           },
           "spatialCoverage": [
@@ -52901,7 +52901,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zgqb7",
           "label": "Persian Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Persian Period"
           },
           "spatialCoverage": [
@@ -52929,7 +52929,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zh6n2",
           "label": "Late Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Period"
           },
           "spatialCoverage": [
@@ -52957,7 +52957,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zh85x",
           "label": "Upper Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Upper Palaeolithic"
           },
           "spatialCoverage": [
@@ -52991,7 +52991,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zjnwg",
           "label": "Maadi/Buto I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Maadi/Buto I"
           },
           "spatialCoverage": [
@@ -53020,7 +53020,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zkb23",
           "label": "Middle Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Kingdom"
           },
           "spatialCoverage": [
@@ -53048,7 +53048,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zkc72",
           "label": "Early Dynastic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Dynastic"
           },
           "spatialCoverage": [
@@ -53076,7 +53076,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zkr6x",
           "label": "Naqada IIIc",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Naqada IIIc"
           },
           "spatialCoverage": [
@@ -53104,7 +53104,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zmrvj",
           "label": "Buto II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Buto II"
           },
           "spatialCoverage": [
@@ -53133,7 +53133,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zn9c9",
           "label": "Ptolemaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ptolemaic"
           },
           "spatialCoverage": [
@@ -53161,7 +53161,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76znjhp",
           "label": "Second Persian Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Second Persian Period"
           },
           "spatialCoverage": [
@@ -53189,7 +53189,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76znmd9",
           "label": "Naqada I-early II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Naqada I-early II"
           },
           "spatialCoverage": [
@@ -53218,7 +53218,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zp6rb",
           "label": "Early A-group",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early A-group"
           },
           "spatialCoverage": [
@@ -53251,7 +53251,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zpmnv",
           "label": "Third Intermediate Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Third Intermediate Period"
           },
           "spatialCoverage": [
@@ -53279,7 +53279,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zqqr2",
           "label": "First Intermediate Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "First Intermediate Period"
           },
           "spatialCoverage": [
@@ -53307,7 +53307,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zrcfb",
           "label": "Buto IV",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Buto IV"
           },
           "spatialCoverage": [
@@ -53336,7 +53336,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zs7m3",
           "label": "Final Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Final Palaeolithic"
           },
           "spatialCoverage": [
@@ -53364,7 +53364,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76ztp66",
           "label": "Middle Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Palaeolithic"
           },
           "spatialCoverage": [
@@ -53392,7 +53392,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zvjkw",
           "label": "New Kingdom",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "New Kingdom"
           },
           "spatialCoverage": [
@@ -53420,7 +53420,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zvrnc",
           "label": "Predynastic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Predynastic"
           },
           "spatialCoverage": [
@@ -53448,7 +53448,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zw52w",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -53476,7 +53476,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zxgwt",
           "label": "Second Intermediate Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Second Intermediate Period"
           },
           "spatialCoverage": [
@@ -53504,7 +53504,7 @@
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zzcdj",
           "label": "Lower Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Lower Palaeolithic"
           },
           "spatialCoverage": [
@@ -53547,7 +53547,7 @@
         "p0qp9rs2sm8": {
           "id": "p0qp9rs2sm8",
           "label": "Middle Helladic III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Helladic III"
           },
           "source": {
@@ -53581,7 +53581,7 @@
         "p0qp9rs2xrr": {
           "id": "p0qp9rs2xrr",
           "label": "Middle Minoan",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Minoan"
           },
           "source": {
@@ -53615,7 +53615,7 @@
         "p0qp9rs358t": {
           "id": "p0qp9rs358t",
           "label": "Late Helladic IIIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIIB"
           },
           "source": {
@@ -53649,7 +53649,7 @@
         "p0qp9rs3drk": {
           "id": "p0qp9rs3drk",
           "label": "Middle Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
           "source": {
@@ -53683,7 +53683,7 @@
         "p0qp9rs3qgk": {
           "id": "p0qp9rs3qgk",
           "label": "Late Minoan II (palaces)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Minoan II (palaces)"
           },
           "source": {
@@ -53717,7 +53717,7 @@
         "p0qp9rs49w9": {
           "id": "p0qp9rs49w9",
           "label": "Sub-Mycenaean",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Sub-Mycenaean"
           },
           "source": {
@@ -53751,7 +53751,7 @@
         "p0qp9rs4m2x": {
           "id": "p0qp9rs4m2x",
           "label": "Middle Minoan III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Minoan III"
           },
           "source": {
@@ -53785,7 +53785,7 @@
         "p0qp9rs53cr": {
           "id": "p0qp9rs53cr",
           "label": "Late Helladic IIIA2",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIIA2"
           },
           "source": {
@@ -53819,7 +53819,7 @@
         "p0qp9rs5b4h": {
           "id": "p0qp9rs5b4h",
           "label": "Late Helladic IIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIB"
           },
           "source": {
@@ -53853,7 +53853,7 @@
         "p0qp9rs5b5t": {
           "id": "p0qp9rs5b5t",
           "label": "Late Cycladic III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Cycladic III"
           },
           "source": {
@@ -53887,7 +53887,7 @@
         "p0qp9rs6jgv": {
           "id": "p0qp9rs6jgv",
           "label": "Middle Minoan II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Minoan II"
           },
           "source": {
@@ -53921,7 +53921,7 @@
         "p0qp9rs7gcj": {
           "id": "p0qp9rs7gcj",
           "label": "Early Minoan I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Minoan I"
           },
           "source": {
@@ -53955,7 +53955,7 @@
         "p0qp9rs8d27": {
           "id": "p0qp9rs8d27",
           "label": "Late Helladic I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic I"
           },
           "source": {
@@ -53989,7 +53989,7 @@
         "p0qp9rs8f46": {
           "id": "p0qp9rs8f46",
           "label": "Early Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
           "source": {
@@ -54023,7 +54023,7 @@
         "p0qp9rs8fgh": {
           "id": "p0qp9rs8fgh",
           "label": "Early Minoan",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Minoan"
           },
           "source": {
@@ -54057,7 +54057,7 @@
         "p0qp9rsbrrc": {
           "id": "p0qp9rsbrrc",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "source": {
@@ -54091,7 +54091,7 @@
         "p0qp9rsbvgk": {
           "id": "p0qp9rsbvgk",
           "label": "Late Minoan IIIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Minoan IIIB"
           },
           "source": {
@@ -54125,7 +54125,7 @@
         "p0qp9rsc26c": {
           "id": "p0qp9rsc26c",
           "label": "Middle Cycladic II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Cycladic II"
           },
           "source": {
@@ -54159,7 +54159,7 @@
         "p0qp9rsc4wm": {
           "id": "p0qp9rsc4wm",
           "label": "Early Minoan IIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Minoan IIB"
           },
           "source": {
@@ -54193,7 +54193,7 @@
         "p0qp9rsc7gh": {
           "id": "p0qp9rsc7gh",
           "label": "Late Minoan IIIA2",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Minoan IIIA2"
           },
           "source": {
@@ -54227,7 +54227,7 @@
         "p0qp9rsd5rt": {
           "id": "p0qp9rsd5rt",
           "label": "Late Minoan II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Minoan II"
           },
           "source": {
@@ -54261,7 +54261,7 @@
         "p0qp9rsfc6j": {
           "id": "p0qp9rsfc6j",
           "label": "Early Helladic IIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Helladic IIB"
           },
           "source": {
@@ -54295,7 +54295,7 @@
         "p0qp9rsgg72": {
           "id": "p0qp9rsgg72",
           "label": "Middle Minoan IA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Minoan IA"
           },
           "source": {
@@ -54329,7 +54329,7 @@
         "p0qp9rsgjq9": {
           "id": "p0qp9rsgjq9",
           "label": "Late Minoan IA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Minoan IA"
           },
           "source": {
@@ -54363,7 +54363,7 @@
         "p0qp9rsh2hd": {
           "id": "p0qp9rsh2hd",
           "label": "Middle Cycladic I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Cycladic I"
           },
           "source": {
@@ -54397,7 +54397,7 @@
         "p0qp9rsh3b2": {
           "id": "p0qp9rsh3b2",
           "label": "Middle Helladic I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Helladic I"
           },
           "source": {
@@ -54431,7 +54431,7 @@
         "p0qp9rshfxn": {
           "id": "p0qp9rshfxn",
           "label": "Late Minoan III (palaces)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Minoan III (palaces)"
           },
           "source": {
@@ -54465,7 +54465,7 @@
         "p0qp9rsj3dx": {
           "id": "p0qp9rsj3dx",
           "label": "Early Cycladic II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Cycladic II"
           },
           "source": {
@@ -54499,7 +54499,7 @@
         "p0qp9rsk4jt": {
           "id": "p0qp9rsk4jt",
           "label": "Late Helladic IIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIA"
           },
           "source": {
@@ -54533,7 +54533,7 @@
         "p0qp9rskpkw": {
           "id": "p0qp9rskpkw",
           "label": "Middle Cycladic III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Cycladic III"
           },
           "source": {
@@ -54567,7 +54567,7 @@
         "p0qp9rskwh2": {
           "id": "p0qp9rskwh2",
           "label": "Middle Minoan IB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Minoan IB"
           },
           "source": {
@@ -54601,7 +54601,7 @@
         "p0qp9rskwjc": {
           "id": "p0qp9rskwjc",
           "label": "Late Helladic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic"
           },
           "source": {
@@ -54635,7 +54635,7 @@
         "p0qp9rskzxm": {
           "id": "p0qp9rskzxm",
           "label": "Early Helladic I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Helladic I"
           },
           "source": {
@@ -54669,7 +54669,7 @@
         "p0qp9rsm6w2": {
           "id": "p0qp9rsm6w2",
           "label": "Sub-Minoan",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Sub-Minoan"
           },
           "source": {
@@ -54703,7 +54703,7 @@
         "p0qp9rsmm78": {
           "id": "p0qp9rsmm78",
           "label": "Late Helladic II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic II"
           },
           "source": {
@@ -54737,7 +54737,7 @@
         "p0qp9rsnt2m": {
           "id": "p0qp9rsnt2m",
           "label": "Early Minoan III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Minoan III"
           },
           "source": {
@@ -54771,7 +54771,7 @@
         "p0qp9rspbsq": {
           "id": "p0qp9rspbsq",
           "label": "Late Cycladic II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Cycladic II"
           },
           "source": {
@@ -54805,7 +54805,7 @@
         "p0qp9rspbzd": {
           "id": "p0qp9rspbzd",
           "label": "Late Cycladic I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Cycladic I"
           },
           "source": {
@@ -54839,7 +54839,7 @@
         "p0qp9rspvhh": {
           "id": "p0qp9rspvhh",
           "label": "Middle Cycladic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Cycladic"
           },
           "source": {
@@ -54873,7 +54873,7 @@
         "p0qp9rsqst6": {
           "id": "p0qp9rsqst6",
           "label": "Early Cycladic I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Cycladic I"
           },
           "source": {
@@ -54907,7 +54907,7 @@
         "p0qp9rssm67": {
           "id": "p0qp9rssm67",
           "label": "Late Minoan",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Minoan"
           },
           "source": {
@@ -54941,7 +54941,7 @@
         "p0qp9rstbnf": {
           "id": "p0qp9rstbnf",
           "label": "Middle Helladic II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Helladic II"
           },
           "source": {
@@ -54975,7 +54975,7 @@
         "p0qp9rsv4jw": {
           "id": "p0qp9rsv4jw",
           "label": "Late Helladic IIIC",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIIC"
           },
           "source": {
@@ -55009,7 +55009,7 @@
         "p0qp9rsv7rs": {
           "id": "p0qp9rsv7rs",
           "label": "Late Minoan IIIA1",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Minoan IIIA1"
           },
           "source": {
@@ -55043,7 +55043,7 @@
         "p0qp9rsvmqq": {
           "id": "p0qp9rsvmqq",
           "label": "Late Cycladic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Cycladic"
           },
           "source": {
@@ -55077,7 +55077,7 @@
         "p0qp9rsw5vg": {
           "id": "p0qp9rsw5vg",
           "label": "Early Helladic IIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Helladic IIA"
           },
           "source": {
@@ -55111,7 +55111,7 @@
         "p0qp9rsxhs2": {
           "id": "p0qp9rsxhs2",
           "label": "Late Helladic IIIA1",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Helladic IIIA1"
           },
           "source": {
@@ -55145,7 +55145,7 @@
         "p0qp9rsxjpb": {
           "id": "p0qp9rsxjpb",
           "label": "Early Cycladic III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Cycladic III"
           },
           "source": {
@@ -55179,7 +55179,7 @@
         "p0qp9rsxmnk": {
           "id": "p0qp9rsxmnk",
           "label": "Early Helladic III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Helladic III"
           },
           "source": {
@@ -55213,7 +55213,7 @@
         "p0qp9rsxqjg": {
           "id": "p0qp9rsxqjg",
           "label": "Early Cycladic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Cycladic"
           },
           "source": {
@@ -55247,7 +55247,7 @@
         "p0qp9rsz3vd": {
           "id": "p0qp9rsz3vd",
           "label": "Late Minoan IB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Minoan IB"
           },
           "source": {
@@ -55281,7 +55281,7 @@
         "p0qp9rszf4c": {
           "id": "p0qp9rszf4c",
           "label": "Middle Helladic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Helladic"
           },
           "source": {
@@ -55315,7 +55315,7 @@
         "p0qp9rszhbx": {
           "id": "p0qp9rszhbx",
           "label": "Early Minoan IIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Minoan IIA"
           },
           "source": {
@@ -55349,7 +55349,7 @@
         "p0qp9rsznj5": {
           "id": "p0qp9rsznj5",
           "label": "Late Minoan IIIC",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Minoan IIIC"
           },
           "source": {
@@ -55383,7 +55383,7 @@
         "p0qp9rszzw5": {
           "id": "p0qp9rszzw5",
           "label": "Early Helladic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Helladic"
           },
           "source": {
@@ -55440,7 +55440,7 @@
           "editorialNote": "see also Mazar, 1992",
           "id": "p0qwcp63xkk",
           "label": "Persian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Persian"
           },
           "spatialCoverage": [
@@ -55479,7 +55479,7 @@
         "p0qwcp6c8mc": {
           "id": "p0qwcp6c8mc",
           "label": "Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman"
           },
           "spatialCoverage": [
@@ -55524,7 +55524,7 @@
           },
           "id": "p0qwcp6cg65",
           "label": "Iron I-II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron I-II"
           },
           "spatialCoverage": [
@@ -55563,7 +55563,7 @@
         "p0qwcp6m5m9": {
           "id": "p0qwcp6m5m9",
           "label": "Byzantine",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Byzantine"
           },
           "spatialCoverage": [
@@ -55609,7 +55609,7 @@
           },
           "id": "p0qwcp6pkdc",
           "label": "MB I-II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "MB I-II"
           },
           "spatialCoverage": [
@@ -55648,7 +55648,7 @@
         "p0qwcp6wfdq": {
           "id": "p0qwcp6wfdq",
           "label": "Hellenistic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic"
           },
           "spatialCoverage": [
@@ -55708,7 +55708,7 @@
           "editorialNote": "see also Mazar, 1992",
           "id": "p0r2jntpjfd",
           "label": "Hasmonean",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hasmonean"
           },
           "spatialCoverage": [
@@ -55787,7 +55787,7 @@
           "editorialNote": "no date type shown, but context indicates BC",
           "id": "p0rqpwq4prr",
           "label": "Deuxième époque",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Deuxième époque"
           },
           "note": "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)",
@@ -55823,7 +55823,7 @@
           "editorialNote": "no date type shown, but context indicates BC",
           "id": "p0rqpwqb48w",
           "label": "Première époque",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Première époque"
           },
           "note": "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)",
@@ -55858,7 +55858,7 @@
           "editorialNote": "no designation present (BCE, etc.)",
           "id": "p0rqpwqbq39",
           "label": "Quatrième époque",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Quatrième époque"
           },
           "spatialCoverage": [
@@ -55893,7 +55893,7 @@
           "editorialNote": "no date type shown, but context indicates BC",
           "id": "p0rqpwqwxnj",
           "label": "Troisième époque",
-          "localizedLabel": {
+          "originalLabel": {
             "fra-latn": "Troisième époque"
           },
           "note": "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)",
@@ -55943,7 +55943,7 @@
         "p0s7jn85n7t": {
           "id": "p0s7jn85n7t",
           "label": "Late Classical",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Classical"
           },
           "spatialCoverage": [
@@ -55969,7 +55969,7 @@
         "p0s7jn8xtgc": {
           "id": "p0s7jn8xtgc",
           "label": "Hellenistic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic"
           },
           "note": "Period ends with Roman annexation of Sicily, 241 B.C.",
@@ -56020,7 +56020,7 @@
         "p0swbsk732x": {
           "id": "p0swbsk732x",
           "label": "Neo-Hittite",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neo-Hittite"
           },
           "source": {
@@ -56051,7 +56051,7 @@
         "p0swbskg2hs": {
           "id": "p0swbskg2hs",
           "label": "Early Bronze Age II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age II"
           },
           "source": {
@@ -56099,7 +56099,7 @@
         "p0tns5v3j5j": {
           "id": "p0tns5v3j5j",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "source": {
@@ -56150,7 +56150,7 @@
           },
           "id": "p0tns5v4kdf",
           "label": "Iron Age II (Middle Iron Age)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age II (Middle Iron Age)"
           },
           "note": "This period is used to designate the moment of Phoenician colonization in the West before the development of a distinctive Punic identity.",
@@ -56191,7 +56191,7 @@
           "editorialNote": "Hodos notes that the end of the Iron Age \"segues into the Archaic phase of Classical civilization, which coincides with the Punic era of Mediterranean history, the full development of the city-state in the Greek world, and the very beginning of Rome's Republican period\" (4); also notes that \"in the Near East, Iron Age terminology is replaced in the sixth century BC with Persian periodization\" -- so inference is that the Iron Age ceases to apply at some point around the 6th c. BC.",
           "id": "p0tns5v56hf",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "source": {
@@ -56256,7 +56256,7 @@
         "p0tns5v946v": {
           "id": "p0tns5v946v",
           "label": "Assyrian Imperial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Assyrian Imperial"
           },
           "source": {
@@ -56295,7 +56295,7 @@
         "p0tns5vjgfz": {
           "id": "p0tns5vjgfz",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "source": {
@@ -56333,7 +56333,7 @@
           },
           "id": "p0tns5vkwc5",
           "label": "Iron Age I (Early Iron Age)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age I (Early Iron Age)"
           },
           "source": {
@@ -56372,7 +56372,7 @@
         "p0tns5vnk3b": {
           "id": "p0tns5vnk3b",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "source": {
@@ -56434,7 +56434,7 @@
         "p0v28d2jq3m": {
           "id": "p0v28d2jq3m",
           "label": "Early Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iron Age"
           },
           "spatialCoverage": [
@@ -56478,7 +56478,7 @@
           "editorialNote": "added post-GeoDia",
           "id": "p0vhct43bzr",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval"
           },
           "spatialCoverage": [
@@ -56506,7 +56506,7 @@
         "p0vhct44nc2": {
           "id": "p0vhct44nc2",
           "label": "Initial Early Phrygian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Initial Early Phrygian"
           },
           "spatialCoverage": [
@@ -56532,7 +56532,7 @@
         "p0vhct4596n": {
           "id": "p0vhct4596n",
           "label": "Late Phrygian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Phrygian"
           },
           "spatialCoverage": [
@@ -56558,7 +56558,7 @@
         "p0vhct48rsx": {
           "id": "p0vhct48rsx",
           "label": "Early Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iron Age"
           },
           "spatialCoverage": [
@@ -56585,7 +56585,7 @@
           "editorialNote": "added post-GeoDia",
           "id": "p0vhct49h3g",
           "label": "Early Phrygian Destruction",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Phrygian Destruction"
           },
           "spatialCoverage": [
@@ -56612,7 +56612,7 @@
           "editorialNote": "added post-GeoDia",
           "id": "p0vhct4fbq2",
           "label": "Early Phrygian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Phrygian"
           },
           "spatialCoverage": [
@@ -56639,7 +56639,7 @@
           "editorialNote": "added post-GeoDia",
           "id": "p0vhct4fq2x",
           "label": "Later Hellenistic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Later Hellenistic"
           },
           "spatialCoverage": [
@@ -56668,7 +56668,7 @@
           "editorialNote": "added post-GeoDia",
           "id": "p0vhct4j2w4",
           "label": "Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman"
           },
           "spatialCoverage": [
@@ -56696,7 +56696,7 @@
         "p0vhct4m9zc": {
           "id": "p0vhct4m9zc",
           "label": "Middle Phrygian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Phrygian"
           },
           "spatialCoverage": [
@@ -56723,7 +56723,7 @@
           "editorialNote": "added post-GeoDia",
           "id": "p0vhct4mvn4",
           "label": "Middle Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
           "spatialCoverage": [
@@ -56750,7 +56750,7 @@
           "editorialNote": "added post-GeoDia",
           "id": "p0vhct4nnfk",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "spatialCoverage": [
@@ -56778,7 +56778,7 @@
           "editorialNote": "added post-GeoDia",
           "id": "p0vhct4t32g",
           "label": "Early Hellenistic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Hellenistic"
           },
           "spatialCoverage": [
@@ -56805,7 +56805,7 @@
         "p0vhct4x7qr": {
           "id": "p0vhct4x7qr",
           "label": "Early Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
           "spatialCoverage": [
@@ -56851,7 +56851,7 @@
         "p0vm8tz2kqk": {
           "id": "p0vm8tz2kqk",
           "label": "Late Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Roman"
           },
           "spatialCoverage": [
@@ -56879,7 +56879,7 @@
         "p0vm8tzbdkt": {
           "id": "p0vm8tzbdkt",
           "label": "Early Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Roman"
           },
           "spatialCoverage": [
@@ -56907,7 +56907,7 @@
         "p0vm8tzjft2": {
           "id": "p0vm8tzjft2",
           "label": "Late Migrations",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Migrations"
           },
           "spatialCoverage": [
@@ -56940,7 +56940,7 @@
           },
           "id": "p0vm8tztmtk",
           "label": "Early Migrations Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Migrations Period"
           },
           "spatialCoverage": [
@@ -56989,7 +56989,7 @@
           },
           "id": "p0vn2fr2ft3",
           "label": "Yngre mesolitikum",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Yngre mesolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p114",
@@ -57022,7 +57022,7 @@
           },
           "id": "p0vn2fr33s2",
           "label": "Paleolitikum",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Paleolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p111",
@@ -57055,7 +57055,7 @@
           },
           "id": "p0vn2fr45nj",
           "label": "Järnålder",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Järnålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p300",
@@ -57088,7 +57088,7 @@
           },
           "id": "p0vn2fr5tcr",
           "label": "Högmedeltid",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Högmedeltid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p420",
@@ -57121,7 +57121,7 @@
           },
           "id": "p0vn2fr68nx",
           "label": "Bronsålder period iii",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Bronsålder period iii"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p213",
@@ -57154,7 +57154,7 @@
           },
           "id": "p0vn2fr8fmm",
           "label": "Senmedeltid",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Senmedeltid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p430",
@@ -57187,7 +57187,7 @@
           },
           "id": "p0vn2fr8n53",
           "label": "Vikingatid",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Vikingatid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p323",
@@ -57220,7 +57220,7 @@
           },
           "id": "p0vn2fr9whq",
           "label": "Vendeltid",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Vendeltid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p322",
@@ -57254,7 +57254,7 @@
           "editorialNote": "The original entries just had \"Kr. f.\", which I assume means \"birth of Christ\", but I don't know if their system is using year 0 or year -1/year 1 ",
           "id": "p0vn2frbn8k",
           "label": "Romersk järnålder",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Romersk järnålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p312",
@@ -57287,7 +57287,7 @@
           },
           "id": "p0vn2frbvn2",
           "label": "Bronsålder period i",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Bronsålder period i"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p211",
@@ -57320,7 +57320,7 @@
           },
           "id": "p0vn2frc8n8",
           "label": "Tidig medeltid",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Tidig medeltid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p410",
@@ -57353,7 +57353,7 @@
           },
           "id": "p0vn2frcrrd",
           "label": "Tidigneolitikum",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Tidigneolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p121",
@@ -57386,7 +57386,7 @@
           },
           "id": "p0vn2frcz8h",
           "label": "Stenålder",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Stenålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p100",
@@ -57419,7 +57419,7 @@
           },
           "id": "p0vn2frdds2",
           "label": "Äldre mesolitikum",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Äldre mesolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p112",
@@ -57452,7 +57452,7 @@
           },
           "id": "p0vn2frdpb3",
           "label": "Bronsålder period vi",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Bronsålder period vi"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p223",
@@ -57485,7 +57485,7 @@
           },
           "id": "p0vn2frfrzw",
           "label": "Senneolitikum",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Senneolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p123",
@@ -57518,7 +57518,7 @@
           },
           "id": "p0vn2frhrrf",
           "label": "Folkvandringstid",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Folkvandringstid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p321",
@@ -57551,7 +57551,7 @@
           },
           "id": "p0vn2frkqvn",
           "label": "Yngre bronsålder",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Yngre bronsålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p220",
@@ -57584,7 +57584,7 @@
           },
           "id": "p0vn2frn6dd",
           "label": "Äldre bronsålder",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Äldre bronsålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p210",
@@ -57617,7 +57617,7 @@
           },
           "id": "p0vn2frnbfw",
           "label": "Äldre stenålder",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Äldre stenålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p110",
@@ -57651,7 +57651,7 @@
           "editorialNote": "The original entries just had \"Kr. f.\", which I assume means \"birth of Christ\", but I don't know if their system is using year 0 or year -1/year 1 ",
           "id": "p0vn2frnrrg",
           "label": "Förromersk järnålder",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Förromersk järnålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p311",
@@ -57684,7 +57684,7 @@
           },
           "id": "p0vn2frpf43",
           "label": "Medeltid",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Medeltid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p400",
@@ -57717,7 +57717,7 @@
           },
           "id": "p0vn2frpqm4",
           "label": "Mellanmesolitikum",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Mellanmesolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p113",
@@ -57750,7 +57750,7 @@
           },
           "id": "p0vn2frrq4x",
           "label": "Bronsålder period v",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Bronsålder period v"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p222",
@@ -57783,7 +57783,7 @@
           },
           "id": "p0vn2frrx4q",
           "label": "Bronsålder period iv",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Bronsålder period iv"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p221",
@@ -57816,7 +57816,7 @@
           },
           "id": "p0vn2frs9vn",
           "label": "Äldre järnålder",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Äldre järnålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p310",
@@ -57849,7 +57849,7 @@
           },
           "id": "p0vn2frt3sg",
           "label": "Bronsålder",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Bronsålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p200",
@@ -57882,7 +57882,7 @@
           },
           "id": "p0vn2frvjj8",
           "label": "Mellanneolitikum",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Mellanneolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p122",
@@ -57915,7 +57915,7 @@
           },
           "id": "p0vn2frw2cp",
           "label": "Yngre stenålder",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Yngre stenålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p120",
@@ -57948,7 +57948,7 @@
           },
           "id": "p0vn2frwpp2",
           "label": "Nyare tid",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Nyare tid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p500",
@@ -57981,7 +57981,7 @@
           },
           "id": "p0vn2frz2mj",
           "label": "Yngre järnålder",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Yngre järnålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p320",
@@ -58014,7 +58014,7 @@
           },
           "id": "p0vn2frzrfs",
           "label": "Bronsålder period ii",
-          "localizedLabel": {
+          "originalLabel": {
             "swe-latn": "Bronsålder period ii"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p212",
@@ -58060,7 +58060,7 @@
         "p0vpm8v4wff": {
           "id": "p0vpm8v4wff",
           "label": "Pantalica North",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pantalica North"
           },
           "source": {
@@ -58090,7 +58090,7 @@
         "p0vpm8v5dkv": {
           "id": "p0vpm8v5dkv",
           "label": "Early Bronze Age II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age II"
           },
           "source": {
@@ -58120,7 +58120,7 @@
         "p0vpm8v5gds": {
           "id": "p0vpm8v5gds",
           "label": "Iron Age II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age II"
           },
           "source": {
@@ -58150,7 +58150,7 @@
         "p0vpm8v5tz4": {
           "id": "p0vpm8v5tz4",
           "label": "Late Copper Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Copper Age"
           },
           "source": {
@@ -58180,7 +58180,7 @@
         "p0vpm8v6dk5": {
           "id": "p0vpm8v6dk5",
           "label": "Early Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
           "source": {
@@ -58210,7 +58210,7 @@
         "p0vpm8v7f92": {
           "id": "p0vpm8v7f92",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "source": {
@@ -58246,7 +58246,7 @@
           },
           "id": "p0vpm8v82h2",
           "label": "Early Iron Age (I)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Iron Age (I)"
           },
           "source": {
@@ -58276,7 +58276,7 @@
         "p0vpm8v8c6p": {
           "id": "p0vpm8v8c6p",
           "label": "Cassabile",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cassabile"
           },
           "note": "Table 1 lists more phase names by sites",
@@ -58307,7 +58307,7 @@
         "p0vpm8vctxb": {
           "id": "p0vpm8vctxb",
           "label": "Finocchito",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Finocchito"
           },
           "source": {
@@ -58337,7 +58337,7 @@
         "p0vpm8vp7qm": {
           "id": "p0vpm8vp7qm",
           "label": "Castelluccian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Castelluccian"
           },
           "source": {
@@ -58367,7 +58367,7 @@
         "p0vpm8vs28k": {
           "id": "p0vpm8vs28k",
           "label": "Middle Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
           "source": {
@@ -58397,7 +58397,7 @@
         "p0vpm8vs8b2": {
           "id": "p0vpm8vs8b2",
           "label": "Thapsos",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Thapsos"
           },
           "source": {
@@ -58427,7 +58427,7 @@
         "p0vpm8vx992": {
           "id": "p0vpm8vx992",
           "label": "Early Bronze Age I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age I"
           },
           "source": {
@@ -58474,7 +58474,7 @@
         "p0vrf7bbb88": {
           "id": "p0vrf7bbb88",
           "label": "Sasanian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Sasanian"
           },
           "spatialCoverage": [
@@ -58531,7 +58531,7 @@
           "editorialNote": "added",
           "id": "p0wf3wd4vsk",
           "label": "Orientalizing",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Orientalizing"
           },
           "spatialCoverage": [
@@ -58563,7 +58563,7 @@
           "editorialNote": "added",
           "id": "p0wf3wd6p49",
           "label": "Middle Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
           "spatialCoverage": [
@@ -58595,7 +58595,7 @@
           "editorialNote": "added",
           "id": "p0wf3wd88kk",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "spatialCoverage": [
@@ -58626,7 +58626,7 @@
           },
           "id": "p0wf3wd8m8j",
           "label": "Phoenician",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Phoenician"
           },
           "note": "Also known as Nuragic IV (cf. Sardinian)",
@@ -58659,7 +58659,7 @@
           "editorialNote": "added",
           "id": "p0wf3wd9ww6",
           "label": "Geometric",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Geometric"
           },
           "spatialCoverage": [
@@ -58685,7 +58685,7 @@
         "p0wf3wdjmdx": {
           "id": "p0wf3wdjmdx",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "note": "See also G. Lilliu, 2003. La civiltÃ dei Sardi dal paleolitico all'etÃ dei nuraghi; G.S. Webster, 1996. A Prehistory of Sardinia 2300-500BC. Also known as Nuragic III (following Nuragic I = Early Bronze Age, 1800-1500 B.C.; & Nuragic II = Middle Bronze Age, 1500-1200 B.C.)",
@@ -58718,7 +58718,7 @@
           "editorialNote": "added",
           "id": "p0wf3wdkdzr",
           "label": "Final Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Final Bronze Age"
           },
           "spatialCoverage": [
@@ -58751,7 +58751,7 @@
           "editorialNote": "added",
           "id": "p0wf3wdm797",
           "label": "Eneolithic (Copper Age)",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Eneolithic (Copper Age)"
           },
           "spatialCoverage": [
@@ -58777,7 +58777,7 @@
         "p0wf3wdnm6q": {
           "id": "p0wf3wdnm6q",
           "label": "Late Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Iron Age"
           },
           "note": "Also known as Nuragic V, or final Nuragic (cf. Late Iron Age & Iron Age Sardinian) = period of Carthaginian hegemony, ending in Roman annexation of Sardinia, 238 B.C.",
@@ -58810,7 +58810,7 @@
           "editorialNote": "added",
           "id": "p0wf3wdp4xt",
           "label": "Imperial",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Imperial"
           },
           "spatialCoverage": [
@@ -58842,7 +58842,7 @@
           "editorialNote": "added",
           "id": "p0wf3wdpr8t",
           "label": "Early Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
           "spatialCoverage": [
@@ -58874,7 +58874,7 @@
           "editorialNote": "added",
           "id": "p0wf3wdq7bb",
           "label": "Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic"
           },
           "spatialCoverage": [
@@ -58906,7 +58906,7 @@
           "editorialNote": "added",
           "id": "p0wf3wdv7pp",
           "label": "Republican",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Republican"
           },
           "spatialCoverage": [
@@ -58958,7 +58958,7 @@
         "p0wnvm4rqg9": {
           "id": "p0wnvm4rqg9",
           "label": "Archaic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic"
           },
           "note": "See also van Dommelen et al. (2008)",
@@ -59006,7 +59006,7 @@
         "p0wswdm64w7": {
           "id": "p0wswdm64w7",
           "label": "Tufa Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Tufa Period"
           },
           "source": {
@@ -59036,7 +59036,7 @@
         "p0wswdmjzww": {
           "id": "p0wswdmjzww",
           "label": "Early Roman Colony",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Roman Colony"
           },
           "source": {
@@ -59066,7 +59066,7 @@
         "p0wswdms24p": {
           "id": "p0wswdms24p",
           "label": "Julio-Claudian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Julio-Claudian"
           },
           "source": {
@@ -59114,7 +59114,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skm2r46",
           "label": "Iron IIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron IIA"
           },
           "source": {
@@ -59150,7 +59150,7 @@
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skm32t6",
           "label": "Chalcolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Chalcolithic"
           },
           "source": {
@@ -59186,7 +59186,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skm3tsc",
           "label": "Late Bronze IIA-B",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze IIA-B"
           },
           "source": {
@@ -59222,7 +59222,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skm4b3s",
           "label": "Middle Bronze IIB-C",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze IIB-C"
           },
           "source": {
@@ -59264,7 +59264,7 @@
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skm5c7p",
           "label": "Middle Bronze",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze"
           },
           "source": {
@@ -59305,7 +59305,7 @@
           "editorialNote": "removed Neo-Assyrian (722-586 B.C.) and Neo-Babylonian (586-539 B.C.) since not explicit, and added new sources Amitai, Barton, Savage, King/Stager, and Richard. ",
           "id": "p0z3skm7q76",
           "label": "Phoenician culture",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Phoenician culture"
           },
           "source": {
@@ -59357,7 +59357,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skm9xgs",
           "label": "Early Bronze IV/Middle Bronze I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze IV/Middle Bronze I"
           },
           "source": {
@@ -59393,7 +59393,7 @@
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skm9z24",
           "label": "Iron I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron I"
           },
           "source": {
@@ -59429,7 +59429,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skmcbfx",
           "label": "Late Bronze I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze I"
           },
           "source": {
@@ -59470,7 +59470,7 @@
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skmgf99",
           "label": "Iron",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron"
           },
           "source": {
@@ -59506,7 +59506,7 @@
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skmhhzg",
           "label": "Pre-Pottery Neolithic B",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pre-Pottery Neolithic B"
           },
           "source": {
@@ -59547,7 +59547,7 @@
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skmhvm4",
           "label": "Late Bronze",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze"
           },
           "source": {
@@ -59588,7 +59588,7 @@
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skmkqhf",
           "label": "Early Bronze",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze"
           },
           "source": {
@@ -59624,7 +59624,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skmksbc",
           "label": "Iron IIC",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron IIC"
           },
           "source": {
@@ -59660,7 +59660,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skmn58v",
           "label": "Iron IA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron IA"
           },
           "source": {
@@ -59701,7 +59701,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skmnss7",
           "label": "Bronze",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze"
           },
           "source": {
@@ -59737,7 +59737,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skmq3t5",
           "label": "Iron IB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron IB"
           },
           "source": {
@@ -59773,7 +59773,7 @@
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skmqqqg",
           "label": "Pottery Neolithic B",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pottery Neolithic B"
           },
           "source": {
@@ -59809,7 +59809,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skmsqwn",
           "label": "Middle Bronze IIA",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze IIA"
           },
           "source": {
@@ -59846,7 +59846,7 @@
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skmt4t7",
           "label": "Iron II",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron II"
           },
           "source": {
@@ -59882,7 +59882,7 @@
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skmtsgh",
           "label": "Pre-Pottery Neolithic A",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pre-Pottery Neolithic A"
           },
           "source": {
@@ -59923,7 +59923,7 @@
           "editorialNote": "removed Neo-Assyrian (722-586 B.C.) and Neo-Babylonian (586-539 B.C.) since not explicit, and added new sources Amitai, Barton, Savage, King/Stager, and Richard. ",
           "id": "p0z3skmvv5c",
           "label": "Canaanite culture",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Canaanite culture"
           },
           "source": {
@@ -59975,7 +59975,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skmxq8p",
           "label": "Early Bronze I",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze I"
           },
           "source": {
@@ -60011,7 +60011,7 @@
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skmxsjx",
           "label": "Pottery Neolithic A",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pottery Neolithic A"
           },
           "source": {
@@ -60047,7 +60047,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skmxw56",
           "label": "Early Bronze II-III",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze II-III"
           },
           "source": {
@@ -60083,7 +60083,7 @@
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skmzq39",
           "label": "Iron IIB",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron IIB"
           },
           "source": {
@@ -60136,7 +60136,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvh24r6",
           "label": "Aegean Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Aegean Bronze Age"
           },
           "source": {
@@ -60167,7 +60167,7 @@
           "editorialNote": "Map on page 235: \"The eastern Mediterranean lands of Canaan and Judaea were centers of Jewish settlement.\"",
           "id": "p0z5nvh25ps",
           "label": "Early Christian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Christian"
           },
           "source": {
@@ -60213,7 +60213,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvh2k9p",
           "label": "High Classical Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "High Classical Period"
           },
           "source": {
@@ -60253,7 +60253,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 235.",
           "id": "p0z5nvh3htc",
           "label": "Early Byzantine Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Byzantine Period"
           },
           "source": {
@@ -60304,7 +60304,7 @@
           "editorialNote": "Map on page 235: \"The eastern Mediterranean lands of Canaan and Judaea were centers of Jewish settlement.\"",
           "id": "p0z5nvh454z",
           "label": "Imperial Christian",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Imperial Christian"
           },
           "source": {
@@ -60348,7 +60348,7 @@
           },
           "id": "p0z5nvh48dj",
           "label": "Gupta Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Gupta Period"
           },
           "source": {
@@ -60404,7 +60404,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 171.",
           "id": "p0z5nvh4nz5",
           "label": "Late Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Empire"
           },
           "source": {
@@ -60471,7 +60471,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 235 and pages 450-1.",
           "id": "p0z5nvh5h5j",
           "label": "Ottonian Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Ottonian Empire"
           },
           "source": {
@@ -60523,7 +60523,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvh5rr9",
           "label": "Late Classical Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Classical Period"
           },
           "source": {
@@ -60558,7 +60558,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvh5t9j",
           "label": "Cycladic Culture",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Cycladic Culture"
           },
           "source": {
@@ -60588,7 +60588,7 @@
         "p0z5nvh8g82": {
           "id": "p0z5nvh8g82",
           "label": "Late Minoan",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Minoan"
           },
           "source": {
@@ -60620,7 +60620,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 171.",
           "id": "p0z5nvh9k86",
           "label": "Roman Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Empire"
           },
           "source": {
@@ -60692,7 +60692,7 @@
           "editorialNote": "See also map on page 85.",
           "id": "p0z5nvh9s8x",
           "label": "Hellenistic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Hellenistic Period"
           },
           "source": {
@@ -60734,7 +60734,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 475.",
           "id": "p0z5nvhbkf4",
           "label": "Romanesque period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Romanesque period"
           },
           "source": {
@@ -60786,7 +60786,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvhbsjv",
           "label": "Proto-Geometric Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Proto-Geometric Period"
           },
           "source": {
@@ -60821,7 +60821,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 235.",
           "id": "p0z5nvhcdk7",
           "label": "Period of Iconoclasm",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Period of Iconoclasm"
           },
           "source": {
@@ -60877,7 +60877,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvhcxgn",
           "label": "Orientalizing Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Orientalizing Period"
           },
           "source": {
@@ -60917,7 +60917,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvhd9kk",
           "label": "Geometric Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Geometric Period"
           },
           "source": {
@@ -60952,7 +60952,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 171.",
           "id": "p0z5nvhdfh4",
           "label": "Roman Republic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman Republic"
           },
           "source": {
@@ -60999,7 +60999,7 @@
           },
           "id": "p0z5nvhjb4k",
           "label": "Minoan New Palace period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Minoan New Palace period"
           },
           "source": {
@@ -61036,7 +61036,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 235.",
           "id": "p0z5nvhk4b3",
           "label": "Middle Byzantine Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Byzantine Period"
           },
           "source": {
@@ -61087,7 +61087,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 171.",
           "id": "p0z5nvhm8d6",
           "label": "High Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "High Empire"
           },
           "source": {
@@ -61159,7 +61159,7 @@
           },
           "id": "p0z5nvhmjhj",
           "label": "Helladic period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Helladic period"
           },
           "source": {
@@ -61190,7 +61190,7 @@
         "p0z5nvhmvkv": {
           "id": "p0z5nvhmvkv",
           "label": "Persian Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Persian Empire"
           },
           "source": {
@@ -61233,7 +61233,7 @@
         "p0z5nvhn6n6": {
           "id": "p0z5nvhn6n6",
           "label": "Periods of the Shungas and Early Andhras",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Periods of the Shungas and Early Andhras"
           },
           "source": {
@@ -61288,7 +61288,7 @@
         "p0z5nvhp6sr": {
           "id": "p0z5nvhp6sr",
           "label": "Etruscan Supremacy",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Etruscan Supremacy"
           },
           "source": {
@@ -61324,7 +61324,7 @@
           },
           "id": "p0z5nvhpjd3",
           "label": "Kushan and Later Andhra Periods",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Kushan and Later Andhra Periods"
           },
           "source": {
@@ -61384,7 +61384,7 @@
           },
           "id": "p0z5nvhpsq5",
           "label": "Maurya Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Maurya Period"
           },
           "source": {
@@ -61445,7 +61445,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvhqwwx",
           "label": "Early Classical Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Classical Period"
           },
           "source": {
@@ -61484,7 +61484,7 @@
           },
           "id": "p0z5nvht3kw",
           "label": "Minoan Old Palace period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Minoan Old Palace period"
           },
           "source": {
@@ -61516,7 +61516,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 235 and pages 450-1.",
           "id": "p0z5nvht7jr",
           "label": "Carolingian Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Carolingian Empire"
           },
           "source": {
@@ -61567,7 +61567,7 @@
           },
           "id": "p0z5nvhtdz8",
           "label": "Vedic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Vedic Period"
           },
           "source": {
@@ -61623,7 +61623,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 171.",
           "id": "p0z5nvhvv7c",
           "label": "Early Empire",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Empire"
           },
           "source": {
@@ -61695,7 +61695,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 235.",
           "id": "p0z5nvhw957",
           "label": "Late Byzantine Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Byzantine Period"
           },
           "source": {
@@ -61751,7 +61751,7 @@
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvhwr6d",
           "label": "Archaic Period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Archaic Period"
           },
           "source": {
@@ -61812,7 +61812,7 @@
         "p0zj6g82bpq": {
           "id": "p0zj6g82bpq",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval"
           },
           "spatialCoverage": [
@@ -61839,7 +61839,7 @@
         "p0zj6g82kq5": {
           "id": "p0zj6g82kq5",
           "label": "Modern",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern"
           },
           "spatialCoverage": [
@@ -61866,7 +61866,7 @@
         "p0zj6g83hwg": {
           "id": "p0zj6g83hwg",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval"
           },
           "spatialCoverage": [
@@ -61893,7 +61893,7 @@
         "p0zj6g84wtb": {
           "id": "p0zj6g84wtb",
           "label": "Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Palaeolithic"
           },
           "spatialCoverage": [
@@ -61920,7 +61920,7 @@
         "p0zj6g86hfw": {
           "id": "p0zj6g86hfw",
           "label": "Post Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Post Medieval"
           },
           "spatialCoverage": [
@@ -61947,7 +61947,7 @@
         "p0zj6g86jn7": {
           "id": "p0zj6g86jn7",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -61974,7 +61974,7 @@
         "p0zj6g877vs": {
           "id": "p0zj6g877vs",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "spatialCoverage": [
@@ -62001,7 +62001,7 @@
         "p0zj6g87fd8": {
           "id": "p0zj6g87fd8",
           "label": "Post Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Post Medieval"
           },
           "spatialCoverage": [
@@ -62028,7 +62028,7 @@
         "p0zj6g886nr": {
           "id": "p0zj6g886nr",
           "label": "Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Palaeolithic"
           },
           "spatialCoverage": [
@@ -62056,7 +62056,7 @@
           "editorialNote": "Visual timeline fades toward the present, indicating no end date.",
           "id": "p0zj6g88v93",
           "label": "Modern",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern"
           },
           "spatialCoverage": [
@@ -62080,7 +62080,7 @@
         "p0zj6g892zt": {
           "id": "p0zj6g892zt",
           "label": "Greek",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Greek"
           },
           "spatialCoverage": [
@@ -62107,7 +62107,7 @@
         "p0zj6g89642": {
           "id": "p0zj6g89642",
           "label": "Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman"
           },
           "spatialCoverage": [
@@ -62134,7 +62134,7 @@
         "p0zj6g8bfcp": {
           "id": "p0zj6g8bfcp",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -62161,7 +62161,7 @@
         "p0zj6g8ccr2": {
           "id": "p0zj6g8ccr2",
           "label": "Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Palaeolithic"
           },
           "spatialCoverage": [
@@ -62188,7 +62188,7 @@
         "p0zj6g8cxhf": {
           "id": "p0zj6g8cxhf",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -62216,7 +62216,7 @@
           "editorialNote": "Visual timeline fades toward the present, indicating no end date.",
           "id": "p0zj6g8dzzb",
           "label": "Modern",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern"
           },
           "spatialCoverage": [
@@ -62240,7 +62240,7 @@
         "p0zj6g8g23s": {
           "id": "p0zj6g8g23s",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "spatialCoverage": [
@@ -62267,7 +62267,7 @@
         "p0zj6g8gb2t": {
           "id": "p0zj6g8gb2t",
           "label": "Palaeolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Palaeolithic"
           },
           "spatialCoverage": [
@@ -62294,7 +62294,7 @@
         "p0zj6g8gdr4": {
           "id": "p0zj6g8gdr4",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -62321,7 +62321,7 @@
         "p0zj6g8h995": {
           "id": "p0zj6g8h995",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "spatialCoverage": [
@@ -62348,7 +62348,7 @@
         "p0zj6g8hh8k": {
           "id": "p0zj6g8hh8k",
           "label": "Early Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Medieval"
           },
           "spatialCoverage": [
@@ -62376,7 +62376,7 @@
           "editorialNote": "Visual timeline fades out before the -6000 tick on the timeline, indicating no clear start date.",
           "id": "p0zj6g8hpfq",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "spatialCoverage": [
@@ -62397,7 +62397,7 @@
         "p0zj6g8jw9f": {
           "id": "p0zj6g8jw9f",
           "label": "Post Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Post Medieval"
           },
           "spatialCoverage": [
@@ -62424,7 +62424,7 @@
         "p0zj6g8jwvr": {
           "id": "p0zj6g8jwvr",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "spatialCoverage": [
@@ -62451,7 +62451,7 @@
         "p0zj6g8kfph": {
           "id": "p0zj6g8kfph",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -62478,7 +62478,7 @@
         "p0zj6g8ks9s": {
           "id": "p0zj6g8ks9s",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "spatialCoverage": [
@@ -62506,7 +62506,7 @@
           "editorialNote": "Visual timeline fades toward the present, indicating no end date.",
           "id": "p0zj6g8ktnf",
           "label": "Modern",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern"
           },
           "spatialCoverage": [
@@ -62530,7 +62530,7 @@
         "p0zj6g8m7nn": {
           "id": "p0zj6g8m7nn",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval"
           },
           "spatialCoverage": [
@@ -62558,7 +62558,7 @@
           "editorialNote": "Visual timeline fades toward the present, indicating no end date.",
           "id": "p0zj6g8p57k",
           "label": "Modern",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Modern"
           },
           "spatialCoverage": [
@@ -62582,7 +62582,7 @@
         "p0zj6g8p8bg": {
           "id": "p0zj6g8p8bg",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -62609,7 +62609,7 @@
         "p0zj6g8pr5x": {
           "id": "p0zj6g8pr5x",
           "label": "Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman"
           },
           "spatialCoverage": [
@@ -62636,7 +62636,7 @@
         "p0zj6g8q32k": {
           "id": "p0zj6g8q32k",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval"
           },
           "spatialCoverage": [
@@ -62663,7 +62663,7 @@
         "p0zj6g8qpxx": {
           "id": "p0zj6g8qpxx",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval"
           },
           "spatialCoverage": [
@@ -62690,7 +62690,7 @@
         "p0zj6g8rbvk": {
           "id": "p0zj6g8rbvk",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "spatialCoverage": [
@@ -62717,7 +62717,7 @@
         "p0zj6g8rr45": {
           "id": "p0zj6g8rr45",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -62744,7 +62744,7 @@
         "p0zj6g8s3vr": {
           "id": "p0zj6g8s3vr",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "spatialCoverage": [
@@ -62771,7 +62771,7 @@
         "p0zj6g8tckq": {
           "id": "p0zj6g8tckq",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -62799,7 +62799,7 @@
           "editorialNote": "Visual timeline fades toward the present, indicating no end date.",
           "id": "p0zj6g8tddc",
           "label": "Post Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Post Medieval"
           },
           "spatialCoverage": [
@@ -62823,7 +62823,7 @@
         "p0zj6g8ttsk": {
           "id": "p0zj6g8ttsk",
           "label": "Mesolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Mesolithic"
           },
           "spatialCoverage": [
@@ -62850,7 +62850,7 @@
         "p0zj6g8vpfb": {
           "id": "p0zj6g8vpfb",
           "label": "Roman",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman"
           },
           "spatialCoverage": [
@@ -62877,7 +62877,7 @@
         "p0zj6g8vsz7": {
           "id": "p0zj6g8vsz7",
           "label": "Iron Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Iron Age"
           },
           "spatialCoverage": [
@@ -62904,7 +62904,7 @@
         "p0zj6g8w7zq": {
           "id": "p0zj6g8w7zq",
           "label": "Early Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Medieval"
           },
           "spatialCoverage": [
@@ -62931,7 +62931,7 @@
         "p0zj6g8w8z2": {
           "id": "p0zj6g8w8z2",
           "label": "Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Medieval"
           },
           "spatialCoverage": [
@@ -62958,7 +62958,7 @@
         "p0zj6g8wbgx": {
           "id": "p0zj6g8wbgx",
           "label": "Post Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Post Medieval"
           },
           "spatialCoverage": [
@@ -62985,7 +62985,7 @@
         "p0zj6g8wft6": {
           "id": "p0zj6g8wft6",
           "label": "Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Bronze Age"
           },
           "spatialCoverage": [
@@ -63012,7 +63012,7 @@
         "p0zj6g8wxtb": {
           "id": "p0zj6g8wxtb",
           "label": "Early Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Medieval"
           },
           "spatialCoverage": [
@@ -63039,7 +63039,7 @@
         "p0zj6g8zpn4": {
           "id": "p0zj6g8zpn4",
           "label": "Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Neolithic"
           },
           "spatialCoverage": [
@@ -63067,7 +63067,7 @@
           "editorialNote": "Visual timeline fades out before the 1000 tick on the timeline, indicating no clear start date.",
           "id": "p0zj6g8ztv9",
           "label": "Early Medieval",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Medieval"
           },
           "spatialCoverage": [
@@ -63108,7 +63108,7 @@
         "p0zmdxz5fx6": {
           "id": "p0zmdxz5fx6",
           "label": "Early Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
           "spatialCoverage": [
@@ -63135,7 +63135,7 @@
         "p0zmdxz65fd": {
           "id": "p0zmdxz65fd",
           "label": "Middle Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
           "spatialCoverage": [
@@ -63168,7 +63168,7 @@
           },
           "id": "p0zmdxzbnh8",
           "label": "\"Ubaid\"",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "\"Ubaid\""
           },
           "spatialCoverage": [
@@ -63202,7 +63202,7 @@
           },
           "id": "p0zmdxzd9wg",
           "label": "\"Halaf\" Chalcolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "\"Halaf\" Chalcolithic"
           },
           "spatialCoverage": [
@@ -63230,7 +63230,7 @@
         "p0zmdxzf369": {
           "id": "p0zmdxzf369",
           "label": "Pre-pottery Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pre-pottery Neolithic"
           },
           "spatialCoverage": [
@@ -63257,7 +63257,7 @@
         "p0zmdxzhvxb": {
           "id": "p0zmdxzhvxb",
           "label": "Persian period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Persian period"
           },
           "spatialCoverage": [
@@ -63286,7 +63286,7 @@
         "p0zmdxzj35q": {
           "id": "p0zmdxzj35q",
           "label": "Late Bronze Age",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
           "spatialCoverage": [
@@ -63314,7 +63314,7 @@
         "p0zmdxzmdt8": {
           "id": "p0zmdxzmdt8",
           "label": "Pottery Neolithic",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Pottery Neolithic"
           },
           "spatialCoverage": [
@@ -63341,7 +63341,7 @@
         "p0zmdxzn9g9": {
           "id": "p0zmdxzn9g9",
           "label": "Roman period",
-          "localizedLabel": {
+          "originalLabel": {
             "eng-latn": "Roman period"
           },
           "spatialCoverage": [

--- a/data.json
+++ b/data.json
@@ -6,7 +6,6 @@
     "abstract": "http://purl.org/dc/terms/abstract",
     "alternateLabel": {
       "@id": "http://www.w3.org/2004/02/skos/core#altLabel",
-      "@language": "eng-latn"
     },
     "contributors": "http://purl.org/dc/terms/contributor",
     "creators": "http://purl.org/dc/terms/creator",
@@ -382,14 +381,16 @@
     "p03wskd": {
       "definitions": {
         "p03wskd23gj": {
-          "alternateLabel": [
-            "Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mesolithic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd23gj",
           "label": "Mesolithic Middle East (18000-9000 BC)",
           "localizedLabel": {
-            "eng-latn": "Mesolithic"
+            "eng-latn": "Mesolithic Middle East (18000-9000 BC)"
           },
           "note": "Epipaleolithic-Protoneolithic ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/mesolithic-middle-east",
@@ -428,14 +429,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/mesolithic-middle-east"
         },
         "p03wskd25c5": {
-          "alternateLabel": [
-            "Mongol"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mongol"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd25c5",
           "label": "Mongol Middle East (AD 1258-1501)",
           "localizedLabel": {
-            "eng-latn": "Mongol"
+            "eng-latn": "Mongol Middle East (AD 1258-1501)"
           },
           "note": "ME, Central Asia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/mongol-middle-east",
@@ -498,14 +501,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/mongol-middle-east"
         },
         "p03wskd29mn": {
-          "alternateLabel": [
-            "Urartian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Urartian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd29mn",
           "label": "Urartian Eastern Anatolia (900-600 BC)",
           "localizedLabel": {
-            "eng-latn": "Urartian"
+            "eng-latn": "Urartian Eastern Anatolia (900-600 BC)"
           },
           "note": "eastern Anatolia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/urartian-eastern-anatolia",
@@ -536,14 +541,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/urartian-eastern-anatolia"
         },
         "p03wskd2cfk": {
-          "alternateLabel": [
-            "Ottoman Rise"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ottoman Rise"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd2cfk",
           "label": "Ottoman Rise (AD 1300-1453)",
           "localizedLabel": {
-            "eng-latn": "Ottoman Rise"
+            "eng-latn": "Ottoman Rise (AD 1300-1453)"
           },
           "note": "ends with the conquest of Constantinople",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ottoman-rise",
@@ -589,14 +596,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/ottoman-rise"
         },
         "p03wskd2rhh": {
-          "alternateLabel": [
-            "Khwarezmian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Khwarezmian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd2rhh",
           "label": "Khwarezmian Middle East (AD 1077-1258)",
           "localizedLabel": {
-            "eng-latn": "Khwarezmian"
+            "eng-latn": "Khwarezmian Middle East (AD 1077-1258)"
           },
           "note": "Khwarezmid",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/khwarezmian-middle-east",
@@ -639,14 +648,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/khwarezmian-middle-east"
         },
         "p03wskd389m": {
-          "alternateLabel": [
-            "Classical"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Classical"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd389m",
           "label": "Classical (Greco-Roman; 550 BC-330 BC)",
           "localizedLabel": {
-            "eng-latn": "Classical"
+            "eng-latn": "Classical (Greco-Roman; 550 BC-330 BC)"
           },
           "note": "The Classical period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 550 and end in the year 330 before the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/classical",
@@ -900,14 +911,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/classical"
         },
         "p03wskd47fw": {
-          "alternateLabel": [
-            "Late Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Period"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd47fw",
           "label": "Late Period Egypt (664-332)",
           "localizedLabel": {
-            "eng-latn": "Late Period"
+            "eng-latn": "Late Period Egypt (664-332)"
           },
           "note": "The Late Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-period-egypt",
@@ -934,14 +947,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/late-period-egypt"
         },
         "p03wskd4mmt": {
-          "alternateLabel": [
-            "2nd Millennium BCE"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "2nd Millennium BCE"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd4mmt",
           "label": "2nd Millenium BCE",
           "localizedLabel": {
-            "eng-latn": "2nd Millennium BCE"
+            "eng-latn": "2nd Millenium BCE"
           },
           "note": "The second millenium BCE as defined at http://en.wikipedia.org/wiki/2nd_millennium_BC",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/2nd-millenium-bce",
@@ -1011,14 +1026,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/2nd-millenium-bce"
         },
         "p03wskd4n95": {
-          "alternateLabel": [
-            "Samanid-Ghaznavid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Samanid-Ghaznavid"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd4n95",
           "label": "Samanid-Ghaznavid Iran (AD 819-1186)",
           "localizedLabel": {
-            "eng-latn": "Samanid-Ghaznavid"
+            "eng-latn": "Samanid-Ghaznavid Iran (AD 819-1186)"
           },
           "note": "Iran",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/samanid-ghaznavid-iran",
@@ -1085,14 +1102,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/samanid-ghaznavid-iran"
         },
         "p03wskd4rpp": {
-          "alternateLabel": [
-            "Hellenistic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hellenistic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd4rpp",
           "label": "Hellenistic Middle East (330-140 BC)",
           "localizedLabel": {
-            "eng-latn": "Hellenistic"
+            "eng-latn": "Hellenistic Middle East (330-140 BC)"
           },
           "note": "Macedonian-Seleucid/Ptolemaic/Attalid/Greco-Bactrian",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-middle-east",
@@ -1167,14 +1186,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-middle-east"
         },
         "p03wskd5222": {
-          "alternateLabel": [
-            "Crusader-Ottoman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Crusader-Ottoman"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd5222",
           "label": "Crusader-Ottoman Levant (AD 1099-1750)",
           "localizedLabel": {
-            "eng-latn": "Crusader-Ottoman"
+            "eng-latn": "Crusader-Ottoman Levant (AD 1099-1750)"
           },
           "note": "Crusader-Seljuq-Ayyubid-Mamluk-Ottoman Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/crusader-ottoman-levant",
@@ -1201,15 +1222,18 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/crusader-ottoman-levant"
         },
         "p03wskd55sw": {
-          "alternateLabel": [
-            "Hellenistic Greek",
-            " Roman Republic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hellenistic Greek",
+              " Roman Republic",
+              "Hellenistic Greek, Roman Republic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd55sw",
           "label": "Hellenistic Greek, Roman Republic (330 BC-30 BC)",
           "localizedLabel": {
-            "eng-latn": "Hellenistic Greek, Roman Republic"
+            "eng-latn": "Hellenistic Greek, Roman Republic (330 BC-30 BC)"
           },
           "note": "The Hellenistic period in Greek history and the middle-to-late Republican period in Roman history. For the purposes of Pleiades, this period is said to begin in the year 330 and end in the year 30 before the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-republican",
@@ -1535,14 +1559,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-republican"
         },
         "p03wskd5dbn": {
-          "alternateLabel": [
-            "Late Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd5dbn",
           "label": "Late Bronze Age Southern Levant (1400-1200 BC)",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age"
+            "eng-latn": "Late Bronze Age Southern Levant (1400-1200 BC)"
           },
           "note": "southern Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-bronze-age-southern-levant",
@@ -1581,14 +1607,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/late-bronze-age-southern-levant"
         },
         "p03wskd5mwr": {
-          "alternateLabel": [
-            "Transition Early-Middle Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Transition Early-Middle Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd5mwr",
           "label": "Transition Early-Middle Bronze Age Southern Levant (2100-1900 BC)",
           "localizedLabel": {
-            "eng-latn": "Transition Early-Middle Bronze Age"
+            "eng-latn": "Transition Early-Middle Bronze Age Southern Levant (2100-1900 BC)"
           },
           "note": "southern Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/transition-early-middle-bronze-age-southern-levant",
@@ -1627,14 +1655,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/transition-early-middle-bronze-age-southern-levant"
         },
         "p03wskd5v96": {
-          "alternateLabel": [
-            "Transition Roman Early Empire-Late Antique"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Transition Roman Early Empire-Late Antique"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd5v96",
           "label": "Transition Roman Early Empire-Late Antique (AD 284-337)",
           "localizedLabel": {
-            "eng-latn": "Transition Roman Early Empire-Late Antique"
+            "eng-latn": "Transition Roman Early Empire-Late Antique (AD 284-337)"
           },
           "note": "Mediterranean",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/transition-roman-early-empire-late-antique",
@@ -1712,14 +1742,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/transition-roman-early-empire-late-antique"
         },
         "p03wskd69hp": {
-          "alternateLabel": [
-            "Khedivate"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Khedivate"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd69hp",
           "label": "Khedivate Egypt (AD 1800-1922)",
           "localizedLabel": {
-            "eng-latn": "Khedivate"
+            "eng-latn": "Khedivate Egypt (AD 1800-1922)"
           },
           "note": "Muhammed Ali-Khedivate Egypt, Alawiyya Egypt, Anglo-Egyptian",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/khedivate-egypt",
@@ -1798,14 +1830,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/khedivate-egypt"
         },
         "p03wskd6hw5": {
-          "alternateLabel": [
-            "Egyptian/Hittite"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Egyptian/Hittite"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd6hw5",
           "label": "Egyptian/Hittite Levant (1344-1212 BC)",
           "localizedLabel": {
-            "eng-latn": "Egyptian/Hittite"
+            "eng-latn": "Egyptian/Hittite Levant (1344-1212 BC)"
           },
           "note": "Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/egyptian-hittite-levant",
@@ -1852,14 +1886,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/egyptian-hittite-levant"
         },
         "p03wskd6nrz": {
-          "alternateLabel": [
-            "Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd6nrz",
           "label": "Iron Age Britain (ca. 800 BC/BCE - ca. 100 AD/CE)",
           "localizedLabel": {
-            "eng-latn": "Iron Age"
+            "eng-latn": "Iron Age Britain (ca. 800 BC/BCE - ca. 100 AD/CE)"
           },
           "note": "A long time period associated with Iron Age Britain.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/iron-age-britain",
@@ -1890,14 +1926,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/iron-age-britain"
         },
         "p03wskd6psm": {
-          "alternateLabel": [
-            "Late Antique"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Antique"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd6psm",
           "label": "Late Antique (AD 300-AD 640)",
           "localizedLabel": {
-            "eng-latn": "Late Antique"
+            "eng-latn": "Late Antique (AD 300-AD 640)"
           },
           "note": "The Late Antique period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 300 and to end in the year 640 after the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-antique",
@@ -2255,14 +2293,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/late-antique"
         },
         "p03wskd6vvr": {
-          "alternateLabel": [
-            "Middle Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Byzantine"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd6vvr",
           "label": "Middle Byzantine (AD 850-1200)",
           "localizedLabel": {
-            "eng-latn": "Middle Byzantine"
+            "eng-latn": "Middle Byzantine (AD 850-1200)"
           },
           "note": "Middle Byzantine period in areas where such designations are appropriate.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-byzantine",
@@ -2332,14 +2372,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/middle-byzantine"
         },
         "p03wskd7s5r": {
-          "alternateLabel": [
-            "Perso-Ottoman-Russian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Perso-Ottoman-Russian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd7s5r",
           "label": "Perso-Ottoman-Russian Caucasus (AD 1500-1918)",
           "localizedLabel": {
-            "eng-latn": "Perso-Ottoman-Russian"
+            "eng-latn": "Perso-Ottoman-Russian Caucasus (AD 1500-1918)"
           },
           "note": "Safavid-Qajar-Ottoman Empire-Russian Empire Caucasus",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/perso-ottoman-russian-caucasus",
@@ -2386,14 +2428,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/perso-ottoman-russian-caucasus"
         },
         "p03wskd825s": {
-          "alternateLabel": [
-            "Hellenistic-Roman Early Empire"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hellenistic-Roman Early Empire"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd825s",
           "label": "Hellenistic-Roman Early Empire (330 BC - AD 300)",
           "localizedLabel": {
-            "eng-latn": "Hellenistic-Roman Early Empire"
+            "eng-latn": "Hellenistic-Roman Early Empire (330 BC - AD 300)"
           },
           "note": "Mediterranean",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-roman-early-empire",
@@ -2487,14 +2531,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-roman-early-empire"
         },
         "p03wskd82ps": {
-          "alternateLabel": [
-            "Middle Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd82ps",
           "label": "Middle Bronze Age Anatolia (1750-1450 BC)",
           "localizedLabel": {
-            "eng-latn": "Middle Bronze Age"
+            "eng-latn": "Middle Bronze Age Anatolia (1750-1450 BC)"
           },
           "note": "Anatolia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-age-anatolia",
@@ -2525,14 +2571,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-age-anatolia"
         },
         "p03wskd83qf": {
-          "alternateLabel": [
-            "Late Antique/Sasanian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Antique/Sasanian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd83qf",
           "label": "Late Antique/Sasanian Middle East (AD 300-640)",
           "localizedLabel": {
-            "eng-latn": "Late Antique/Sasanian"
+            "eng-latn": "Late Antique/Sasanian Middle East (AD 300-640)"
           },
           "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-antique-sasanian-middle-east",
@@ -2611,14 +2659,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/late-antique-sasanian-middle-east"
         },
         "p03wskd93hp": {
-          "alternateLabel": [
-            "Parthian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Parthian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd93hp",
           "label": "Parthian Middle East (140 BC - AD 226)",
           "localizedLabel": {
-            "eng-latn": "Parthian"
+            "eng-latn": "Parthian Middle East (140 BC - AD 226)"
           },
           "note": "Arsacid ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/parthian-middle-east",
@@ -2645,14 +2695,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/parthian-middle-east"
         },
         "p03wskd95m9": {
-          "alternateLabel": [
-            "Ptolemaic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ptolemaic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd95m9",
           "label": "Ptolemaic Egypt (304-30 BCE/BC)",
           "localizedLabel": {
-            "eng-latn": "Ptolemaic"
+            "eng-latn": "Ptolemaic Egypt (304-30 BCE/BC)"
           },
           "note": "The Ptolemaic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ptolemaic-egypt",
@@ -2679,14 +2731,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/ptolemaic-egypt"
         },
         "p03wskd97z7": {
-          "alternateLabel": [
-            "Ottoman Empire"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ottoman Empire"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd97z7",
           "label": "Ottoman Empire (AD 1513-1918)",
           "localizedLabel": {
-            "eng-latn": "Ottoman Empire"
+            "eng-latn": "Ottoman Empire (AD 1513-1918)"
           },
           "note": "ME, Balkan, Northern Africa",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ottoman-empire",
@@ -2760,14 +2814,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/ottoman-empire"
         },
         "p03wskd98jh": {
-          "alternateLabel": [
-            "Early Medieval"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Medieval"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd98jh",
           "label": "Early Medieval Caucasus (AD 850-1200)",
           "localizedLabel": {
-            "eng-latn": "Early Medieval"
+            "eng-latn": "Early Medieval Caucasus (AD 850-1200)"
           },
           "note": "Bagratid, Kingdom of Armenia/Kingdom of Georgia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-medieval-caucasus",
@@ -2814,14 +2870,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/early-medieval-caucasus"
         },
         "p03wskd9h8w": {
-          "alternateLabel": [
-            "1500 AD"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "1500 AD"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd9h8w",
           "label": "1500 AD Middle East (AD 1500-1500)",
           "localizedLabel": {
-            "eng-latn": "1500 AD"
+            "eng-latn": "1500 AD Middle East (AD 1500-1500)"
           },
           "note": "ME, Greece, Indus",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/1500-ad-middle-east",
@@ -2924,14 +2982,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/1500-ad-middle-east"
         },
         "p03wskd9szx": {
-          "alternateLabel": [
-            "Chalcolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Chalcolithic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd9szx",
           "label": "Chalcolithic Iran (5000-2500 BC)",
           "localizedLabel": {
-            "eng-latn": "Chalcolithic"
+            "eng-latn": "Chalcolithic Iran (5000-2500 BC)"
           },
           "note": "Iran",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/chalcolithic-iran",
@@ -2962,14 +3022,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/chalcolithic-iran"
         },
         "p03wskdbftw": {
-          "alternateLabel": [
-            "Safavid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Safavid"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdbftw",
           "label": "Safavid Middle East (AD 1501-1725)",
           "localizedLabel": {
-            "eng-latn": "Safavid"
+            "eng-latn": "Safavid Middle East (AD 1501-1725)"
           },
           "note": "Eastern ME, Central Asia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/safavid-middle-east",
@@ -3016,14 +3078,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/safavid-middle-east"
         },
         "p03wskdbh6h": {
-          "alternateLabel": [
-            "4th millennium BCE"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "4th millennium BCE"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdbh6h",
           "label": "4th millenium BCE",
           "localizedLabel": {
-            "eng-latn": "4th millennium BCE"
+            "eng-latn": "4th millenium BCE"
           },
           "note": "The fourth millenium BCE as defined at http://en.wikipedia.org/wiki/4th_millennium_BC",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/4th-millenium-bce",
@@ -3073,14 +3137,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/4th-millenium-bce"
         },
         "p03wskdbvmg": {
-          "alternateLabel": [
-            "Akkadian-Ur III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Akkadian-Ur III"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdbvmg",
           "label": "Akkadian-Ur III Mesopotamia (2335-2000 BC)",
           "localizedLabel": {
-            "eng-latn": "Akkadian-Ur III"
+            "eng-latn": "Akkadian-Ur III Mesopotamia (2335-2000 BC)"
           },
           "note": "Akkadian-Neo-Sumerian Mesopotamia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/akkadian-ur-iii-mesopotamia",
@@ -3115,14 +3181,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/akkadian-ur-iii-mesopotamia"
         },
         "p03wskdc5xs": {
-          "alternateLabel": [
-            "Middle Nubian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Nubian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdc5xs",
           "label": "Middle Nubian (2300-1600 BC)",
           "localizedLabel": {
-            "eng-latn": "Middle Nubian"
+            "eng-latn": "Middle Nubian (2300-1600 BC)"
           },
           "note": "C-Group-Kerma-Middle Nubian-Pan-Grave-MK",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-nubian",
@@ -3148,14 +3216,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/middle-nubian"
         },
         "p03wskdc6nf": {
-          "alternateLabel": [
-            "Middle Bronze-Early Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze-Early Iron Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdc6nf",
           "label": "Middle Bronze-Early Iron Age Iran (2000-650 BC)",
           "localizedLabel": {
-            "eng-latn": "Middle Bronze-Early Iron Age"
+            "eng-latn": "Middle Bronze-Early Iron Age Iran (2000-650 BC)"
           },
           "note": "Iran",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-early-iron-age-iran",
@@ -3194,14 +3264,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-early-iron-age-iran"
         },
         "p03wskdccmk": {
-          "alternateLabel": [
-            "Colonial-Modern"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Colonial-Modern"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdccmk",
           "label": "Colonial-Modern Middle East (AD 1800-2000)",
           "localizedLabel": {
-            "eng-latn": "Colonial-Modern"
+            "eng-latn": "Colonial-Modern Middle East (AD 1800-2000)"
           },
           "note": "Late Ottoman-Colonial-Mandate Modern Middle east",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/colonial-modern-middle-east",
@@ -3244,14 +3316,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/colonial-modern-middle-east"
         },
         "p03wskdcctk": {
-          "alternateLabel": [
-            "Roman Early Empire-Late Antique"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman Early Empire-Late Antique"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdcctk",
           "label": "Roman Early Empire-Late Antique (30 BC - AD 640)",
           "localizedLabel": {
-            "eng-latn": "Roman Early Empire-Late Antique"
+            "eng-latn": "Roman Early Empire-Late Antique (30 BC - AD 640)"
           },
           "note": "Mediterranean",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/roman-early-empire-late-antique",
@@ -3353,14 +3427,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/roman-early-empire-late-antique"
         },
         "p03wskdcdz7": {
-          "alternateLabel": [
-            "Mediaeval/Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mediaeval/Byzantine"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdcdz7",
           "label": "Mediaeval/Byzantine (AD 641-AD 1453)",
           "localizedLabel": {
-            "eng-latn": "Mediaeval/Byzantine"
+            "eng-latn": "Mediaeval/Byzantine (AD 641-AD 1453)"
           },
           "note": "The Mediaeval period in the West, or the period from the end of Late Antiquity (640) to the fall of Constantinople in the East (1453).",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/mediaeval-byzantine",
@@ -3466,14 +3542,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/mediaeval-byzantine"
         },
         "p03wskdcmjz": {
-          "alternateLabel": [
-            "Middle Hittite"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Hittite"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdcmjz",
           "label": "Middle Hittite Anatolia (1450-1200 BC)",
           "localizedLabel": {
-            "eng-latn": "Middle Hittite"
+            "eng-latn": "Middle Hittite Anatolia (1450-1200 BC)"
           },
           "note": "New Kingdom Hittite",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-hittite-anatolia",
@@ -3508,14 +3586,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/middle-hittite-anatolia"
         },
         "p03wskdcpjk": {
-          "alternateLabel": [
-            "Proto-Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Proto-Byzantine"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdcpjk",
           "label": "Proto-Byzantine (AD 500-650)",
           "localizedLabel": {
-            "eng-latn": "Proto-Byzantine"
+            "eng-latn": "Proto-Byzantine (AD 500-650)"
           },
           "note": "Early Byzantine; includes Justinian I",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/proto-byzantine",
@@ -3581,14 +3661,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/proto-byzantine"
         },
         "p03wskdd2st": {
-          "alternateLabel": [
-            "Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neolithic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdd2st",
           "label": "Neolithic Egypt (6000-4500 BCE/BC)",
           "localizedLabel": {
-            "eng-latn": "Neolithic"
+            "eng-latn": "Neolithic Egypt (6000-4500 BCE/BC)"
           },
           "note": "The Neolithic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-egypt",
@@ -3619,14 +3701,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-egypt"
         },
         "p03wskddb3j": {
-          "alternateLabel": [
-            "New Kingdom"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "New Kingdom"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddb3j",
           "label": "New Kingdom Egypt (1548-1086)",
           "localizedLabel": {
-            "eng-latn": "New Kingdom"
+            "eng-latn": "New Kingdom Egypt (1548-1086)"
           },
           "note": "The New Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/new-kingdom-egypt",
@@ -3661,14 +3745,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/new-kingdom-egypt"
         },
         "p03wskddbqj": {
-          "alternateLabel": [
-            "Elamite"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Elamite"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddbqj",
           "label": "Elamite Western Iran (3200-540 BC)",
           "localizedLabel": {
-            "eng-latn": "Elamite"
+            "eng-latn": "Elamite Western Iran (3200-540 BC)"
           },
           "note": "Proto-Old-Middle-Neo-Elamite",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/elamite-western-iran",
@@ -3703,14 +3789,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/elamite-western-iran"
         },
         "p03wskddc9t": {
-          "alternateLabel": [
-            "Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neolithic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddc9t",
           "label": "Neolithic Period on Malta (ca. 5,000-2,500BC)",
           "localizedLabel": {
-            "eng-latn": "Neolithic"
+            "eng-latn": "Neolithic Period on Malta (ca. 5,000-2,500BC)"
           },
           "note": "The neolithic or so-called \"New Stone Age\" as expressed in remains of physical culture on the island of Malta, where it appears to have lasted from around 5,000 to 2,500 BC",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-malta",
@@ -3737,14 +3825,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-malta"
         },
         "p03wskddvwn": {
-          "alternateLabel": [
-            "Achaemenid-Roman Republic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Achaemenid-Roman Republic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddvwn",
           "label": "Achaemenid-Roman Republic Middle East (540-30 BC)",
           "localizedLabel": {
-            "eng-latn": "Achaemenid-Roman Republic"
+            "eng-latn": "Achaemenid-Roman Republic Middle East (540-30 BC)"
           },
           "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/achaemenid-roman-republic-middle-east",
@@ -3879,14 +3969,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/achaemenid-roman-republic-middle-east"
         },
         "p03wskddwzm": {
-          "alternateLabel": [
-            "Hellenistic-Parthian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hellenistic-Parthian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddwzm",
           "label": "Hellenistic-Parthian Middle East (330 BC - AD 226)",
           "localizedLabel": {
-            "eng-latn": "Hellenistic-Parthian"
+            "eng-latn": "Hellenistic-Parthian Middle East (330 BC - AD 226)"
           },
           "note": "Seleucid-Early Roman-Arsacid Middle East",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-parthian-middle-east",
@@ -3913,14 +4005,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-parthian-middle-east"
         },
         "p03wskdf7wk": {
-          "alternateLabel": [
-            "Early Ottoman Empire"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Ottoman Empire"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdf7wk",
           "label": "Early Ottoman Empire (AD 1453-1683)",
           "localizedLabel": {
-            "eng-latn": "Early Ottoman Empire"
+            "eng-latn": "Early Ottoman Empire (AD 1453-1683)"
           },
           "note": "ends with the siege of Vienna",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-ottoman-empire",
@@ -4006,14 +4100,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/early-ottoman-empire"
         },
         "p03wskdfbcg": {
-          "alternateLabel": [
-            "Late Ottoman Empire"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Ottoman Empire"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfbcg",
           "label": "Late Ottoman Empire (AD 1683-1918)",
           "localizedLabel": {
-            "eng-latn": "Late Ottoman Empire"
+            "eng-latn": "Late Ottoman Empire (AD 1683-1918)"
           },
           "note": "ME, Balkan, Northern Africa",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-ottoman-empire",
@@ -4115,14 +4211,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/late-ottoman-empire"
         },
         "p03wskdfd83": {
-          "alternateLabel": [
-            "Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfd83",
           "label": "Bronze Age Britain (ca. 2500 - ca. 800 BC/BCE)",
           "localizedLabel": {
-            "eng-latn": "Bronze Age"
+            "eng-latn": "Bronze Age Britain (ca. 2500 - ca. 800 BC/BCE)"
           },
           "note": "A long time period associated with Bronze Age Britain.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/bronze-age-britain",
@@ -4149,14 +4247,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/bronze-age-britain"
         },
         "p03wskdfnrs": {
-          "alternateLabel": [
-            "Late Nubian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Nubian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfnrs",
           "label": "Late Nubian (1600-350 BC)",
           "localizedLabel": {
-            "eng-latn": "Late Nubian"
+            "eng-latn": "Late Nubian (1600-350 BC)"
           },
           "note": "NK-Kushite-Meroitic",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-nubian",
@@ -4182,14 +4282,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/late-nubian"
         },
         "p03wskdfpqr": {
-          "alternateLabel": [
-            "Later 2nd Millennium BC"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Later 2nd Millennium BC"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfpqr",
           "label": "Later 2nd Millennium BC Mesopotamia (1600-1000 BC)",
           "localizedLabel": {
-            "eng-latn": "Later 2nd Millennium BC"
+            "eng-latn": "Later 2nd Millennium BC Mesopotamia (1600-1000 BC)"
           },
           "note": "Middle Assyrian/Middle Babylonian/Kassite Mesopotamia, LBA-Early Iron Age Mesopotamia, incl. Sea Peoples",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/later-2nd-millennium-bc-mesopotamia",
@@ -4228,14 +4330,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/later-2nd-millennium-bc-mesopotamia"
         },
         "p03wskdfrrp": {
-          "alternateLabel": [
-            "Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mesolithic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfrrp",
           "label": "Mesolithic Levant (18000-9500 BC)",
           "localizedLabel": {
-            "eng-latn": "Mesolithic"
+            "eng-latn": "Mesolithic Levant (18000-9500 BC)"
           },
           "note": "Epipaleolithic-Protoneolithic Levant, Kebaran-Natufian",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/mesolithic-levant",
@@ -4270,14 +4374,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/mesolithic-levant"
         },
         "p03wskdftkm": {
-          "alternateLabel": [
-            "Ptolemaic-Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ptolemaic-Roman"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdftkm",
           "label": "Ptolemaic-Roman Egypt (304 BC - AD 640)",
           "localizedLabel": {
-            "eng-latn": "Ptolemaic-Roman"
+            "eng-latn": "Ptolemaic-Roman Egypt (304 BC - AD 640)"
           },
           "note": "Egypt",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ptolemaic-roman-egypt",
@@ -4320,14 +4426,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/ptolemaic-roman-egypt"
         },
         "p03wskdg8s5": {
-          "alternateLabel": [
-            "Crusader/Seljuq-Ayyubid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Crusader/Seljuq-Ayyubid"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdg8s5",
           "label": "Crusader/Seljuq-Ayyubid Levant (AD 1099-1291)",
           "localizedLabel": {
-            "eng-latn": "Crusader/Seljuq-Ayyubid"
+            "eng-latn": "Crusader/Seljuq-Ayyubid Levant (AD 1099-1291)"
           },
           "note": "Latin",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/crusader-seljuq-ayyubid-levant",
@@ -4386,14 +4494,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/crusader-seljuq-ayyubid-levant"
         },
         "p03wskdgh6j": {
-          "alternateLabel": [
-            "Modern"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgh6j",
           "label": "Modern (AD 1700-Present)",
           "localizedLabel": {
-            "eng-latn": "Modern"
+            "eng-latn": "Modern (AD 1700-Present)"
           },
           "note": "Our present, modern era.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/modern",
@@ -4715,14 +4825,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/modern"
         },
         "p03wskdgmtf": {
-          "alternateLabel": [
-            "Old Kingdom"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Old Kingdom"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgmtf",
           "label": "Old Kingdom Egypt (2670-2168 BCE/BC)",
           "localizedLabel": {
-            "eng-latn": "Old Kingdom"
+            "eng-latn": "Old Kingdom Egypt (2670-2168 BCE/BC)"
           },
           "note": "The Old Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/old-kingdom-egypt",
@@ -4749,14 +4861,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/old-kingdom-egypt"
         },
         "p03wskdgn3q": {
-          "alternateLabel": [
-            "Pre-Pottery Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Pre-Pottery Neolithic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgn3q",
           "label": "Pre-Pottery Neolithic Middle East (9000-6000 BC)",
           "localizedLabel": {
-            "eng-latn": "Pre-Pottery Neolithic"
+            "eng-latn": "Pre-Pottery Neolithic Middle East (9000-6000 BC)"
           },
           "note": "Aceramic Neolithic ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/pre-pottery-neolithic-middle-east",
@@ -4787,14 +4901,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/pre-pottery-neolithic-middle-east"
         },
         "p03wskdgpzc": {
-          "alternateLabel": [
-            "Timurid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Timurid"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgpzc",
           "label": "Timurid Middle East (AD 1370-1501)",
           "localizedLabel": {
-            "eng-latn": "Timurid"
+            "eng-latn": "Timurid Middle East (AD 1370-1501)"
           },
           "note": "Eastern ME, Central Asia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/timurid-middle-east",
@@ -4857,14 +4973,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/timurid-middle-east"
         },
         "p03wskdgq4n": {
-          "alternateLabel": [
-            "Middle Kingdom"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Kingdom"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgq4n",
           "label": "Middle Kingdom Egypt (2010-1640 BCE/BC)",
           "localizedLabel": {
-            "eng-latn": "Middle Kingdom"
+            "eng-latn": "Middle Kingdom Egypt (2010-1640 BCE/BC)"
           },
           "note": "The Middle Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-kingdom-egypt",
@@ -4895,14 +5013,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/middle-kingdom-egypt"
         },
         "p03wskdh9h2": {
-          "alternateLabel": [
-            "Ubaid-Early Dynastic II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ubaid-Early Dynastic II"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdh9h2",
           "label": "Ubaid-Early Dynastic II Mesopotamia (5500-2600 BC)",
           "localizedLabel": {
-            "eng-latn": "Ubaid-Early Dynastic II"
+            "eng-latn": "Ubaid-Early Dynastic II Mesopotamia (5500-2600 BC)"
           },
           "note": "Late Chalcolithic-ED II Mesopotamia, Ubaid-Uruk-Jemdet Nasr-ED Mesopotamia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ubaid-early-dynastic-ii-mesopotamia",
@@ -4941,14 +5061,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/ubaid-early-dynastic-ii-mesopotamia"
         },
         "p03wskdhc9m": {
-          "alternateLabel": [
-            "Early Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdhc9m",
           "label": "Early Bronze Age Southern Levant (3300-2000 BC)",
           "localizedLabel": {
-            "eng-latn": "Early Bronze Age"
+            "eng-latn": "Early Bronze Age Southern Levant (3300-2000 BC)"
           },
           "note": "southern Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-bronze-age-southern-levant",
@@ -4987,14 +5109,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/early-bronze-age-southern-levant"
         },
         "p03wskdhqrw": {
-          "alternateLabel": [
-            "Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdhqrw",
           "label": "Roman Middle East (140 BC - AD 640)",
           "localizedLabel": {
-            "eng-latn": "Roman"
+            "eng-latn": "Roman Middle East (140 BC - AD 640)"
           },
           "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/roman-middle-east",
@@ -5065,14 +5189,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/roman-middle-east"
         },
         "p03wskdj3g6": {
-          "alternateLabel": [
-            "Caliphate-Umayyad"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Caliphate-Umayyad"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdj3g6",
           "label": "Caliphate-Umayyad Middle East (AD 632-750)",
           "localizedLabel": {
-            "eng-latn": "Caliphate-Umayyad"
+            "eng-latn": "Caliphate-Umayyad Middle East (AD 632-750)"
           },
           "note": "Early Islamic, Rashidun-Umayyad (starts with death of Muhammed who only controlled Arabia)",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/caliphate-umayyad-middle-east",
@@ -5159,14 +5285,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/caliphate-umayyad-middle-east"
         },
         "p03wskdj8bb": {
-          "alternateLabel": [
-            "Seljuq-Khwarezmian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Seljuq-Khwarezmian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdj8bb",
           "label": "Seljuq-Khwarezmian Middle East (AD 1037-1258)",
           "localizedLabel": {
-            "eng-latn": "Seljuq-Khwarezmian"
+            "eng-latn": "Seljuq-Khwarezmian Middle East (AD 1037-1258)"
           },
           "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/seljuq-khwarezmian-middle-east",
@@ -5209,14 +5337,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/seljuq-khwarezmian-middle-east"
         },
         "p03wskdjbp8": {
-          "alternateLabel": [
-            "Early Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Byzantine"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjbp8",
           "label": "Early Byzantine (AD 650-850)",
           "localizedLabel": {
-            "eng-latn": "Early Byzantine"
+            "eng-latn": "Early Byzantine (AD 650-850)"
           },
           "note": "Early Byzantine Period in areas where such designations are appropriate.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-byzantine",
@@ -5282,14 +5412,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/early-byzantine"
         },
         "p03wskdjcqv": {
-          "alternateLabel": [
-            "Middle Geometric"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Geometric"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjcqv",
           "label": "Middle Geometric (Greek; 850-750 BC)",
           "localizedLabel": {
-            "eng-latn": "Middle Geometric"
+            "eng-latn": "Middle Geometric (Greek; 850-750 BC)"
           },
           "note": "The Middle Geometric period in ancient Greece, from 850-750 before the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-geometric",
@@ -5323,14 +5455,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/middle-geometric"
         },
         "p03wskdjhsq": {
-          "alternateLabel": [
-            "Pottery Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Pottery Neolithic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjhsq",
           "label": "Pottery Neolithic Middle East (6000-4500 BC)",
           "localizedLabel": {
-            "eng-latn": "Pottery Neolithic"
+            "eng-latn": "Pottery Neolithic Middle East (6000-4500 BC)"
           },
           "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/pottery-neolithic-middle-east",
@@ -5381,14 +5515,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/pottery-neolithic-middle-east"
         },
         "p03wskdjqsh": {
-          "alternateLabel": [
-            "Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjqsh",
           "label": "Bronze Age Malta (ca. 2,500-700 BC)",
           "localizedLabel": {
-            "eng-latn": "Bronze Age"
+            "eng-latn": "Bronze Age Malta (ca. 2,500-700 BC)"
           },
           "note": "The Bronze age as represented in the remains of physical culture from the island of Malta.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/bronze-age-malta",
@@ -5415,14 +5551,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/bronze-age-malta"
         },
         "p03wskdjrcs": {
-          "alternateLabel": [
-            "Middle-Late Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle-Late Iron Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjrcs",
           "label": "Middle-Late Iron Age Anatolia (700-500 BC)",
           "localizedLabel": {
-            "eng-latn": "Middle-Late Iron Age"
+            "eng-latn": "Middle-Late Iron Age Anatolia (700-500 BC)"
           },
           "note": "Anatolia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-late-iron-age-anatolia",
@@ -5461,14 +5599,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/middle-late-iron-age-anatolia"
         },
         "p03wskdjw3b": {
-          "alternateLabel": [
-            "Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neolithic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjw3b",
           "label": "Neolithic Middle East (9000-4500 BC)",
           "localizedLabel": {
-            "eng-latn": "Neolithic"
+            "eng-latn": "Neolithic Middle East (9000-4500 BC)"
           },
           "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-middle-east",
@@ -5503,14 +5643,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-middle-east"
         },
         "p03wskdk2k5": {
-          "alternateLabel": [
-            "Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdk2k5",
           "label": "Iron Age Italy (Latial Culture I, 1000-900 BC)",
           "localizedLabel": {
-            "eng-latn": "Iron Age"
+            "eng-latn": "Iron Age Italy (Latial Culture I, 1000-900 BC)"
           },
           "note": "Latial I is concentrated around Rome, the Alban Hills, and the Monti della Tolfa.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/iron-age-italy-latial-culture-i-1000-900-bc",
@@ -5537,14 +5679,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/iron-age-italy-latial-culture-i-1000-900-bc"
         },
         "p03wskdk582": {
-          "alternateLabel": [
-            "Ilkhanate"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ilkhanate"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdk582",
           "label": "Ilkhanate Middle East (AD 1258-1335)",
           "localizedLabel": {
-            "eng-latn": "Ilkhanate"
+            "eng-latn": "Ilkhanate Middle East (AD 1258-1335)"
           },
           "note": "Ilkhanid, Hulagu, Early Mongol",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ilkhanate-middle-east",
@@ -5615,14 +5759,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/ilkhanate-middle-east"
         },
         "p03wskdm4tb": {
-          "alternateLabel": [
-            "Early Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Iron Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdm4tb",
           "label": "Early Iron Age Anatolia (1200-700 BC)",
           "localizedLabel": {
-            "eng-latn": "Early Iron Age"
+            "eng-latn": "Early Iron Age Anatolia (1200-700 BC)"
           },
           "note": "incl. Mitanni",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-iron-age-anatolia",
@@ -5665,14 +5811,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/early-iron-age-anatolia"
         },
         "p03wskdm62k": {
-          "alternateLabel": [
-            "Old Nubian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Old Nubian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdm62k",
           "label": "Old Nubian (3800-2300 BC)",
           "localizedLabel": {
-            "eng-latn": "Old Nubian"
+            "eng-latn": "Old Nubian (3800-2300 BC)"
           },
           "note": "A-Group/Old Nubian-Middle Nubian-OK",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/old-nubian",
@@ -5698,14 +5846,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/old-nubian"
         },
         "p03wskdmzfr": {
-          "alternateLabel": [
-            "Third Intermediate"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Third Intermediate"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdmzfr",
           "label": "Third Intermediate Period Egypt (1086-664)",
           "localizedLabel": {
-            "eng-latn": "Third Intermediate"
+            "eng-latn": "Third Intermediate Period Egypt (1086-664)"
           },
           "note": "The Third Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/third-intermediate-period-egypt",
@@ -5736,14 +5886,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/third-intermediate-period-egypt"
         },
         "p03wskdnjq5": {
-          "alternateLabel": [
-            "1200 BC"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "1200 BC"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnjq5",
           "label": "1200 BC Middle East",
           "localizedLabel": {
-            "eng-latn": "1200 BC"
+            "eng-latn": "1200 BC Middle East"
           },
           "note": "ME, Greece",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/1200-bc-middle-east",
@@ -5838,14 +5990,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/1200-bc-middle-east"
         },
         "p03wskdnnpp": {
-          "alternateLabel": [
-            "Ummayad"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ummayad"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnnpp",
           "label": "Ummayad Period (661-750CE)",
           "localizedLabel": {
-            "eng-latn": "Ummayad"
+            "eng-latn": "Ummayad Period (661-750CE)"
           },
           "note": "The period of the Umayyad Caliphate as defined by http://en.wikipedia.org/wiki/Umayyad_Caliphate",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ummayad",
@@ -5879,14 +6033,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/ummayad"
         },
         "p03wskdnwd4": {
-          "alternateLabel": [
-            "Archaic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Archaic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnwd4",
           "label": "Archaic (Greco-Roman; 750-550 BCE/BC)",
           "localizedLabel": {
-            "eng-latn": "Archaic"
+            "eng-latn": "Archaic (Greco-Roman; 750-550 BCE/BC)"
           },
           "note": "The Archaic period in Greek and Roman history. For the purposes of Pleiades, this period is seen to begin in the year 750 and end in the year 550 before the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/archaic",
@@ -6056,14 +6212,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/archaic"
         },
         "p03wskdnxfq": {
-          "alternateLabel": [
-            "2nd Millennium BC"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "2nd Millennium BC"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnxfq",
           "label": "2nd Millennium BC Egypt (2000-1000 BC)",
           "localizedLabel": {
-            "eng-latn": "2nd Millennium BC"
+            "eng-latn": "2nd Millennium BC Egypt (2000-1000 BC)"
           },
           "note": "Egypt",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/2nd-millennium-bc-egypt",
@@ -6098,14 +6256,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/2nd-millennium-bc-egypt"
         },
         "p03wskdnzgc": {
-          "alternateLabel": [
-            "Early Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnzgc",
           "label": "Early Bronze Age Anatolia (2000-1750 BC)",
           "localizedLabel": {
-            "eng-latn": "Early Bronze Age"
+            "eng-latn": "Early Bronze Age Anatolia (2000-1750 BC)"
           },
           "note": "Karum Anatolia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-bronze-age-anatolia",
@@ -6132,14 +6292,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/early-bronze-age-anatolia"
         },
         "p03wskdp535": {
-          "alternateLabel": [
-            "Mamluk"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mamluk"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdp535",
           "label": "Mamluk Middle East (AD 1258-1516)",
           "localizedLabel": {
-            "eng-latn": "Mamluk"
+            "eng-latn": "Mamluk Middle East (AD 1258-1516)"
           },
           "note": "Western ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/mamluk-middle-east",
@@ -6166,14 +6328,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/mamluk-middle-east"
         },
         "p03wskdpj3d": {
-          "alternateLabel": [
-            "Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neolithic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpj3d",
           "label": "Neolithic Period (British Isles; 4,000-2,500 BC)",
           "localizedLabel": {
-            "eng-latn": "Neolithic"
+            "eng-latn": "Neolithic Period (British Isles; 4,000-2,500 BC)"
           },
           "note": "The Neolithic period in the British Isles, after Wikipedia, Neolithic British Isles, http://en.wikipedia.org/wiki/Neolithic_British_Isles.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-british",
@@ -6200,14 +6364,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-british"
         },
         "p03wskdpjk3": {
-          "alternateLabel": [
-            "Late Antique-Late Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Antique-Late Byzantine"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpjk3",
           "label": "Late Antique-Late Byzantine (AD 300-1450)",
           "localizedLabel": {
-            "eng-latn": "Late Antique-Late Byzantine"
+            "eng-latn": "Late Antique-Late Byzantine (AD 300-1450)"
           },
           "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-antique-late-byzantine",
@@ -6249,14 +6415,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/late-antique-late-byzantine"
         },
         "p03wskdpqmv": {
-          "alternateLabel": [
-            "2nd Millennium BC"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "2nd Millennium BC"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpqmv",
           "label": "2nd Millennium BC Levant (2000-1000 BC)",
           "localizedLabel": {
-            "eng-latn": "2nd Millennium BC"
+            "eng-latn": "2nd Millennium BC Levant (2000-1000 BC)"
           },
           "note": "MBA Levant-LBA Levant-Iron Age I Levant (not sure as these are all taken from southern Levant periodisation)",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/2nd-millennium-bc-levant",
@@ -6307,14 +6475,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/2nd-millennium-bc-levant"
         },
         "p03wskdpxwb": {
-          "alternateLabel": [
-            "Abassid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Abassid"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpxwb",
           "label": "Abassid Middle East (AD 750-940)",
           "localizedLabel": {
-            "eng-latn": "Abassid"
+            "eng-latn": "Abassid Middle East (AD 750-940)"
           },
           "note": "ME, northern Africa",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/abassid-middle-east",
@@ -6397,14 +6567,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/abassid-middle-east"
         },
         "p03wskdpzn9": {
-          "alternateLabel": [
-            "Roman-Early Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman-Early Byzantine"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpzn9",
           "label": "Roman-Early Byzantine Middle East (140 BC - AD 850)",
           "localizedLabel": {
-            "eng-latn": "Roman-Early Byzantine"
+            "eng-latn": "Roman-Early Byzantine Middle East (140 BC - AD 850)"
           },
           "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/roman-early-byzantine-middle-east",
@@ -6439,14 +6611,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/roman-early-byzantine-middle-east"
         },
         "p03wskdq5md": {
-          "alternateLabel": [
-            "Late Byzantine/Ottoman Rise"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Byzantine/Ottoman Rise"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdq5md",
           "label": "Late Byzantine/Ottoman Rise (AD 1200-1453)",
           "localizedLabel": {
-            "eng-latn": "Late Byzantine/Ottoman Rise"
+            "eng-latn": "Late Byzantine/Ottoman Rise (AD 1200-1453)"
           },
           "note": "Aegean, Balkan & Anatolia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-byzantine-ottoman-rise",
@@ -6496,14 +6670,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/late-byzantine-ottoman-rise"
         },
         "p03wskdqq4g": {
-          "alternateLabel": [
-            "Crusader/Byzantine/Seljuq"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Crusader/Byzantine/Seljuq"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdqq4g",
           "label": "Crusader/Byzantine/Seljuq Middle East (AD 1081-1204)",
           "localizedLabel": {
-            "eng-latn": "Crusader/Byzantine/Seljuq"
+            "eng-latn": "Crusader/Byzantine/Seljuq Middle East (AD 1081-1204)"
           },
           "note": "Latin/1st-4th Crusades-end of Middle Byzantine-Rum/Seljuq",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/crusader-byzantine-seljuq-middle-east",
@@ -6550,14 +6726,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/crusader-byzantine-seljuq-middle-east"
         },
         "p03wskdqzgv": {
-          "alternateLabel": [
-            "Middle Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdqzgv",
           "label": "Middle Bronze Age Southern Levant (2000-1400 BC)",
           "localizedLabel": {
-            "eng-latn": "Middle Bronze Age"
+            "eng-latn": "Middle Bronze Age Southern Levant (2000-1400 BC)"
           },
           "note": "southern Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-age-southern-levant",
@@ -6592,14 +6770,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-age-southern-levant"
         },
         "p03wskdr3vd": {
-          "alternateLabel": [
-            "Early Geometric"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Geometric"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdr3vd",
           "label": "Early Geometric (Greek; 900-850 BC)",
           "localizedLabel": {
-            "eng-latn": "Early Geometric"
+            "eng-latn": "Early Geometric (Greek; 900-850 BC)"
           },
           "note": "The Early Geometric period in ancient Greece, from 900-850 before the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-geometric",
@@ -6637,14 +6817,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/early-geometric"
         },
         "p03wskdr7sw": {
-          "alternateLabel": [
-            "Old Babylonian/Assyrian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Old Babylonian/Assyrian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdr7sw",
           "label": "Old Babylonian/Assyrian Mesopotamia (2000-1600 BC)",
           "localizedLabel": {
-            "eng-latn": "Old Babylonian/Assyrian"
+            "eng-latn": "Old Babylonian/Assyrian Mesopotamia (2000-1600 BC)"
           },
           "note": "Mesopotamia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/old-babylonian-assyrian-mesopotamia",
@@ -6687,14 +6869,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/old-babylonian-assyrian-mesopotamia"
         },
         "p03wskdrh3m": {
-          "alternateLabel": [
-            "Ottoman Decline-Mandate"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ottoman Decline-Mandate"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrh3m",
           "label": "Ottoman Decline-Mandate Middle East (AD 1900-1950)",
           "localizedLabel": {
-            "eng-latn": "Ottoman Decline-Mandate"
+            "eng-latn": "Ottoman Decline-Mandate Middle East (AD 1900-1950)"
           },
           "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ottoman-decline-mandate-middle-east",
@@ -6777,14 +6961,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/ottoman-decline-mandate-middle-east"
         },
         "p03wskdrkh7": {
-          "alternateLabel": [
-            "Ubaid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ubaid"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrkh7",
           "label": "Ubaid period in Mesopotamia (ca. 6500 to 3800 BC)",
           "localizedLabel": {
-            "eng-latn": "Ubaid"
+            "eng-latn": "Ubaid period in Mesopotamia (ca. 6500 to 3800 BC)"
           },
           "note": "The prehistoric Ubaid period of Mesopotamia, as defined by Wikipedia following Carter, Robert A. and Philip, Graham Beyond the Ubaid: Transformation and Integration in the Late Prehistoric Societies of the Middle East (Studies in Ancient Oriental Civilization, Number 63) The Oriental Institute of the University of Chicago (2010) ISBN 978-1-885923-66-0 p.2, at http://oi.uchicago.edu/research/pubs/catalog/saoc/saoc63.html",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ubaid",
@@ -6815,14 +7001,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/ubaid"
         },
         "p03wskdrtx9": {
-          "alternateLabel": [
-            "Rum/Crusader"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Rum/Crusader"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrtx9",
           "label": "Rum/Crusader Anatolia (AD 1077-1307)",
           "localizedLabel": {
-            "eng-latn": "Rum/Crusader"
+            "eng-latn": "Rum/Crusader Anatolia (AD 1077-1307)"
           },
           "note": "Seljuk-Latin States/Francocracy",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/rum-crusader-anatolia",
@@ -6861,14 +7049,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/rum-crusader-anatolia"
         },
         "p03wskdrv58": {
-          "alternateLabel": [
-            "13th Century AD"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "13th Century AD"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrv58",
           "label": "13th Century AD Eastern Mediterranean (AD 1200-1300)",
           "localizedLabel": {
-            "eng-latn": "13th Century AD"
+            "eng-latn": "13th Century AD Eastern Mediterranean (AD 1200-1300)"
           },
           "note": "Late Byzantine-Ayyubid-Mamluk Western Middle East",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/13th-century-ad-eastern-mediterranean",
@@ -6895,14 +7085,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/13th-century-ad-eastern-mediterranean"
         },
         "p03wskdrx4h": {
-          "alternateLabel": [
-            "Late Helladic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Helladic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrx4h",
           "label": "Late Helladic (Mainland Greece; 1600-1200 BC)",
           "localizedLabel": {
-            "eng-latn": "Late Helladic"
+            "eng-latn": "Late Helladic (Mainland Greece; 1600-1200 BC)"
           },
           "note": "The Late Helladic period in the Greek mainland, after Preziosi and Hitchcock, Aegean Art and Architecture, Oxford History of Art, 1998.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-helladic",
@@ -6929,14 +7121,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/late-helladic"
         },
         "p03wskds7zt": {
-          "alternateLabel": [
-            "Modern"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskds7zt",
           "label": "Modern Middle East (AD 1918-2000)",
           "localizedLabel": {
-            "eng-latn": "Modern"
+            "eng-latn": "Modern Middle East (AD 1918-2000)"
           },
           "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/modern-middle-east",
@@ -7043,14 +7237,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/modern-middle-east"
         },
         "p03wskds845": {
-          "alternateLabel": [
-            "Sassanian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Sassanian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskds845",
           "label": "Sassanian Middle East (AD 262-700)",
           "localizedLabel": {
-            "eng-latn": "Sassanian"
+            "eng-latn": "Sassanian Middle East (AD 262-700)"
           },
           "note": "Sassanid",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/sassanian-middle-east",
@@ -7077,14 +7273,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/sassanian-middle-east"
         },
         "p03wskdsdnb": {
-          "alternateLabel": [
-            "Early Dynastic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Dynastic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdsdnb",
           "label": "Early Dynastic Mesopotamia (2950-2350 BC)",
           "localizedLabel": {
-            "eng-latn": "Early Dynastic"
+            "eng-latn": "Early Dynastic Mesopotamia (2950-2350 BC)"
           },
           "note": "Mesopotamia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-dynastic-mesopotamia",
@@ -7127,14 +7325,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/early-dynastic-mesopotamia"
         },
         "p03wskdtg2h": {
-          "alternateLabel": [
-            "Middle Minoan"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Minoan"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdtg2h",
           "label": "Middle Minoan (Crete; 2000-1600 BC/BCE)",
           "localizedLabel": {
-            "eng-latn": "Middle Minoan"
+            "eng-latn": "Middle Minoan (Crete; 2000-1600 BC/BCE)"
           },
           "note": "The Middle Minoan period on Crete, as defined in C. Shelmerdine, The Cambridge Companion to the Aegean Bronze Age (2008), p. 4, figure 1.1.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middleminoan",
@@ -7161,14 +7361,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/middleminoan"
         },
         "p03wskdtn5z": {
-          "alternateLabel": [
-            "Fatimid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Fatimid"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdtn5z",
           "label": "Fatimid Middle East (AD 950-1150)",
           "localizedLabel": {
-            "eng-latn": "Fatimid"
+            "eng-latn": "Fatimid Middle East (AD 950-1150)"
           },
           "note": "Western ME, northern Africa",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/fatimid-middle-east",
@@ -7195,14 +7397,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/fatimid-middle-east"
         },
         "p03wskdtwrq": {
-          "alternateLabel": [
-            "Chalcolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Chalcolithic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdtwrq",
           "label": "Chalcolithic Mesopotamia (6200-3750 BC)",
           "localizedLabel": {
-            "eng-latn": "Chalcolithic"
+            "eng-latn": "Chalcolithic Mesopotamia (6200-3750 BC)"
           },
           "note": "Copper Age Mesopotamia, Halaf-Ubaid-Early Uruk Mesopotamia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/chalcolithic-mesopotamia",
@@ -7241,14 +7445,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/chalcolithic-mesopotamia"
         },
         "p03wskdv8qb": {
-          "alternateLabel": [
-            "Neo-Hittite"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neo-Hittite"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdv8qb",
           "label": "Neo-Hittite Northern Levant (1200-700 BC)",
           "localizedLabel": {
-            "eng-latn": "Neo-Hittite"
+            "eng-latn": "Neo-Hittite Northern Levant (1200-700 BC)"
           },
           "note": "Syro-Hittite Northern Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neo-hittite-northern-levant",
@@ -7275,14 +7481,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/neo-hittite-northern-levant"
         },
         "p03wskdvds6": {
-          "alternateLabel": [
-            "Persian-Medieval"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Persian-Medieval"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdvds6",
           "label": "Persian-Medieval Caucasus (AD 600-1500)",
           "localizedLabel": {
-            "eng-latn": "Persian-Medieval"
+            "eng-latn": "Persian-Medieval Caucasus (AD 600-1500)"
           },
           "note": "Persian-Arabic-Early Medieval-Middle Medieval-Turco-Mongol/Late Medieval Caucasus",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/persian-medieval-caucasus",
@@ -7399,14 +7607,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/3rd-millennium-bc"
         },
         "p03wskdw46d": {
-          "alternateLabel": [
-            "Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neolithic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdw46d",
           "label": "Neolithic Period in the Eastern Mediterranean (ca. 10,000-3,300 BC)",
           "localizedLabel": {
-            "eng-latn": "Neolithic"
+            "eng-latn": "Neolithic Period in the Eastern Mediterranean (ca. 10,000-3,300 BC)"
           },
           "note": "The so-called \"Neolithic\" or \"New Stone Age\" period as defined in the Eastern portion of the Mediterranean basin, lasting roughly from 10,000 - 3,300 BC. See further: http://ancienthistory.about.com/od/artarchaeologyarchitect/g/neolithic.htm",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-eastern-med",
@@ -7441,14 +7651,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-eastern-med"
         },
         "p03wskdwdtr": {
-          "alternateLabel": [
-            "Early-Middle Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early-Middle Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdwdtr",
           "label": "Early-Middle Bronze Age Iran (2500-1500 BC)",
           "localizedLabel": {
-            "eng-latn": "Early-Middle Bronze Age"
+            "eng-latn": "Early-Middle Bronze Age Iran (2500-1500 BC)"
           },
           "note": "Iran",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-middle-bronze-age-iran",
@@ -7475,14 +7687,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/early-middle-bronze-age-iran"
         },
         "p03wskdxgnx": {
-          "alternateLabel": [
-            "Neo-Assyrian/Babylonian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neo-Assyrian/Babylonian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxgnx",
           "label": "Neo-Assyrian/Babylonian Middle East (720-540 BC)",
           "localizedLabel": {
-            "eng-latn": "Neo-Assyrian/Babylonian"
+            "eng-latn": "Neo-Assyrian/Babylonian Middle East (720-540 BC)"
           },
           "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neo-assyrian-babylonian-middle-east",
@@ -7545,14 +7759,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/neo-assyrian-babylonian-middle-east"
         },
         "p03wskdxjnj": {
-          "alternateLabel": [
-            "First Intermediate Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "First Intermediate Period"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxjnj",
           "label": "First Intermediate Period Egypt (2168-2010 BCE/BC)",
           "localizedLabel": {
-            "eng-latn": "First Intermediate Period"
+            "eng-latn": "First Intermediate Period Egypt (2168-2010 BCE/BC)"
           },
           "note": "The First Intermediate Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/first-intermediate-period-egypt",
@@ -7579,14 +7795,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/first-intermediate-period-egypt"
         },
         "p03wskdxnwr": {
-          "alternateLabel": [
-            "Macedonian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Macedonian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxnwr",
           "label": "Macedonian Egypt (332-304 BCE/BC)",
           "localizedLabel": {
-            "eng-latn": "Macedonian"
+            "eng-latn": "Macedonian Egypt (332-304 BCE/BC)"
           },
           "note": "The Macedonian period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/macedonian-egypt",
@@ -7613,15 +7831,18 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/macedonian-egypt"
         },
         "p03wskdxnzf": {
-          "alternateLabel": [
-            "Roman",
-            " early Empire"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman",
+              " early Empire",
+              "Roman, early Empire"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxnzf",
           "label": "Roman, early Empire (30 BC-AD 300)",
           "localizedLabel": {
-            "eng-latn": "Roman, early Empire"
+            "eng-latn": "Roman, early Empire (30 BC-AD 300)"
           },
           "note": "The Roman period (i.e., the early Roman Empire) in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 30 before the birth of Christ and to end in the year 300 after the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/roman",
@@ -7995,14 +8216,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/roman"
         },
         "p03wskdxvtv": {
-          "alternateLabel": [
-            "Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxvtv",
           "label": "Iron Age Southern Levant",
           "localizedLabel": {
-            "eng-latn": "Iron Age"
+            "eng-latn": "Iron Age Southern Levant"
           },
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/iron-age-southern-levant",
           "spatialCoverage": [
@@ -8048,14 +8271,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/iron-age-southern-levant"
         },
         "p03wskdxwnh": {
-          "alternateLabel": [
-            "Roman Early Empire/Parthian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman Early Empire/Parthian"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxwnh",
           "label": "Roman Early Empire/Parthian Middle East (30 BC - AD 226)",
           "localizedLabel": {
-            "eng-latn": "Roman Early Empire/Parthian"
+            "eng-latn": "Roman Early Empire/Parthian Middle East (30 BC - AD 226)"
           },
           "note": "Early Roman/Parthian",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/roman-early-empire-parthian-middle-east",
@@ -8130,14 +8355,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/roman-early-empire-parthian-middle-east"
         },
         "p03wskdz28z": {
-          "alternateLabel": [
-            "Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Paleolithic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdz28z",
           "label": "Paleolithic Middle East (2600000-18000 BC)",
           "localizedLabel": {
-            "eng-latn": "Paleolithic"
+            "eng-latn": "Paleolithic Middle East (2600000-18000 BC)"
           },
           "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/paleolithic-middle-east",
@@ -8192,14 +8419,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/paleolithic-middle-east"
         },
         "p03wskdzc7b": {
-          "alternateLabel": [
-            "Predynastic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Predynastic"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdzc7b",
           "label": "Predynastic Egypt (4500-2950 BCE/BC)",
           "localizedLabel": {
-            "eng-latn": "Predynastic"
+            "eng-latn": "Predynastic Egypt (4500-2950 BCE/BC)"
           },
           "note": "The predynastic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/predynastic-egypt",
@@ -8226,14 +8455,16 @@
           "url": "http://pleiades.stoa.org/vocabularies/time-periods/predynastic-egypt"
         },
         "p03wskdzd99": {
-          "alternateLabel": [
-            "Second Intermediate"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Second Intermediate"
+            ]
+          },
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdzd99",
           "label": "Second Intermediate Period Egypt (1640-1548)",
           "localizedLabel": {
-            "eng-latn": "Second Intermediate"
+            "eng-latn": "Second Intermediate Period Egypt (1640-1548)"
           },
           "note": "The Second Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/second-intermediate-period-egypt",
@@ -8469,14 +8700,16 @@
           "type": "PeriodDefinition"
         },
         "p047fhm4kqv": {
-          "alternateLabel": [
-            "Susa II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Susa II"
+            ]
+          },
           "editorialNote": "unsure why listed in GeoDia with dates 3700-3500 B.C.",
           "id": "p047fhm4kqv",
           "label": "Susa II archaeological period",
           "localizedLabel": {
-            "eng-latn": "Susa II"
+            "eng-latn": "Susa II archaeological period"
           },
           "note": "Prehistoric Susa II, corresponds to Mesopotamian Ubaid period.",
           "source": {
@@ -8591,14 +8824,16 @@
           "type": "PeriodDefinition"
         },
         "p047fhm6zwb": {
-          "alternateLabel": [
-            "Susa I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Susa I"
+            ]
+          },
           "editorialNote": "GeoDia listed the two archaeological periods of Susa I (4200-3700 B.C.) and Susa II (3700-3500 B.C.).",
           "id": "p047fhm6zwb",
           "label": "Susa I archaeological period",
           "localizedLabel": {
-            "eng-latn": "Susa I"
+            "eng-latn": "Susa I archaeological period"
           },
           "note": "This period designates prehistoric Susa and corresponds to Ubaid period in Mesopotamia.",
           "source": {
@@ -9259,15 +9494,17 @@
           "type": "PeriodDefinition"
         },
         "p047fhmxww6": {
-          "alternateLabel": [
-            "Protoliterate",
-            "Proto-Elamite"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Protoliterate",
+              "Proto-Elamite"
+            ]
+          },
           "editorialNote": "Listed as historic period, not archaeological period.",
           "id": "p047fhmxww6",
           "label": "Protoliterate: Proto-Elamite",
           "localizedLabel": {
-            "eng-latn": "Protoliterate"
+            "eng-latn": "Protoliterate: Proto-Elamite"
           },
           "note": "This period corresponds to Proto-Literate period in Mesopotamia.",
           "source": {
@@ -9417,13 +9654,15 @@
     "p05krdx": {
       "definitions": {
         "p05krdx2khc": {
-          "alternateLabel": [
-            "Geometric"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Geometric"
+            ]
+          },
           "id": "p05krdx2khc",
           "label": "Geometric Period",
           "localizedLabel": {
-            "eng-latn": "Geometric"
+            "eng-latn": "Geometric Period"
           },
           "source": {
             "locator": "page 308",
@@ -9482,9 +9721,11 @@
           "type": "PeriodDefinition"
         },
         "p05krdx3c5h": {
-          "alternateLabel": [
-            "Middle Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age"
+            ]
+          },
           "id": "p05krdx3c5h",
           "label": "Middle Helladic",
           "localizedLabel": {
@@ -9517,13 +9758,15 @@
           "type": "PeriodDefinition"
         },
         "p05krdx4jg8": {
-          "alternateLabel": [
-            "Hellenistic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hellenistic"
+            ]
+          },
           "id": "p05krdx4jg8",
           "label": "Hellenistic Period",
           "localizedLabel": {
-            "eng-latn": "Hellenistic"
+            "eng-latn": "Hellenistic Period"
           },
           "source": {
             "locator": "page 308",
@@ -9582,13 +9825,15 @@
           "type": "PeriodDefinition"
         },
         "p05krdx596r": {
-          "alternateLabel": [
-            "Archaic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Archaic"
+            ]
+          },
           "id": "p05krdx596r",
           "label": "Archaic Period",
           "localizedLabel": {
-            "eng-latn": "Archaic"
+            "eng-latn": "Archaic Period"
           },
           "source": {
             "locator": "page 308",
@@ -9616,13 +9861,15 @@
           "type": "PeriodDefinition"
         },
         "p05krdx9f8n": {
-          "alternateLabel": [
-            "Frankish"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Frankish"
+            ]
+          },
           "id": "p05krdx9f8n",
           "label": "Frankish Period",
           "localizedLabel": {
-            "eng-latn": "Frankish"
+            "eng-latn": "Frankish Period"
           },
           "source": {
             "locator": "page 309",
@@ -9743,14 +9990,16 @@
           "type": "PeriodDefinition"
         },
         "p05krdxh5gt": {
-          "alternateLabel": [
-            "Submycenaean and Early Iron Age",
-            "Dark Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Submycenaean and Early Iron Age",
+              "Dark Age"
+            ]
+          },
           "id": "p05krdxh5gt",
           "label": "Submycenaean and Early Iron Age or Dark Age",
           "localizedLabel": {
-            "eng-latn": "Submycenaean and Early Iron Age"
+            "eng-latn": "Submycenaean and Early Iron Age or Dark Age"
           },
           "source": {
             "locator": "page 308",
@@ -9872,13 +10121,15 @@
           "type": "PeriodDefinition"
         },
         "p05krdxk56p": {
-          "alternateLabel": [
-            "Late Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Roman"
+            ]
+          },
           "id": "p05krdxk56p",
           "label": "Late Roman Period",
           "localizedLabel": {
-            "eng-latn": "Late Roman"
+            "eng-latn": "Late Roman Period"
           },
           "source": {
             "locator": "page 308",
@@ -9937,13 +10188,15 @@
           "type": "PeriodDefinition"
         },
         "p05krdxktwz": {
-          "alternateLabel": [
-            "Classical"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Classical"
+            ]
+          },
           "id": "p05krdxktwz",
           "label": "Classical Period",
           "localizedLabel": {
-            "eng-latn": "Classical"
+            "eng-latn": "Classical Period"
           },
           "source": {
             "locator": "page 308",
@@ -9971,13 +10224,15 @@
           "type": "PeriodDefinition"
         },
         "p05krdxmbs4": {
-          "alternateLabel": [
-            "Second Ottoman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Second Ottoman"
+            ]
+          },
           "id": "p05krdxmbs4",
           "label": "Second Ottoman Period",
           "localizedLabel": {
-            "eng-latn": "Second Ottoman"
+            "eng-latn": "Second Ottoman Period"
           },
           "source": {
             "locator": "pages 247, 261, 309",
@@ -10131,13 +10386,15 @@
           "type": "PeriodDefinition"
         },
         "p05krdxs4dx": {
-          "alternateLabel": [
-            "Late Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Byzantine"
+            ]
+          },
           "id": "p05krdxs4dx",
           "label": "Late Byzantine Period",
           "localizedLabel": {
-            "eng-latn": "Late Byzantine"
+            "eng-latn": "Late Byzantine Period"
           },
           "source": {
             "locator": "page 309",
@@ -10165,13 +10422,15 @@
           "type": "PeriodDefinition"
         },
         "p05krdxsdbn": {
-          "alternateLabel": [
-            "Early Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Byzantine"
+            ]
+          },
           "id": "p05krdxsdbn",
           "label": "Early Byzantine Period",
           "localizedLabel": {
-            "eng-latn": "Early Byzantine"
+            "eng-latn": "Early Byzantine Period"
           },
           "source": {
             "locator": "page 212",
@@ -10199,14 +10458,16 @@
           "type": "PeriodDefinition"
         },
         "p05krdxst2j": {
-          "alternateLabel": [
-            "First Ottoman",
-            "Turkish Messenia"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "First Ottoman",
+              "Turkish Messenia"
+            ]
+          },
           "id": "p05krdxst2j",
           "label": "First Ottoman Period",
           "localizedLabel": {
-            "eng-latn": "First Ottoman"
+            "eng-latn": "First Ottoman Period"
           },
           "source": {
             "locator": "pages 226, 309",
@@ -10265,13 +10526,15 @@
           "type": "PeriodDefinition"
         },
         "p05krdxx73v": {
-          "alternateLabel": [
-            "Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman"
+            ]
+          },
           "id": "p05krdxx73v",
           "label": "Roman Period",
           "localizedLabel": {
-            "eng-latn": "Roman"
+            "eng-latn": "Roman Period"
           },
           "source": {
             "locator": "page 308",
@@ -10361,13 +10624,15 @@
           "type": "PeriodDefinition"
         },
         "p05krdxzrdk": {
-          "alternateLabel": [
-            "Upper Palaeolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Upper Palaeolithic"
+            ]
+          },
           "id": "p05krdxzrdk",
           "label": "Upper Paleolithic",
           "localizedLabel": {
-            "eng-latn": "Upper Palaeolithic"
+            "eng-latn": "Upper Paleolithic"
           },
           "source": {
             "locator": "page 307",
@@ -10447,13 +10712,15 @@
     "p05xnzq": {
       "definitions": {
         "p05xnzq8jrm": {
-          "alternateLabel": [
-            "Flavians"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Flavians"
+            ]
+          },
           "id": "p05xnzq8jrm",
           "label": "The Flavians",
           "localizedLabel": {
-            "eng-latn": "Flavians"
+            "eng-latn": "The Flavians"
           },
           "source": {
             "locator": "page 16",
@@ -10481,13 +10748,15 @@
           "type": "PeriodDefinition"
         },
         "p05xnzq944b": {
-          "alternateLabel": [
-            "Severans"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Severans"
+            ]
+          },
           "id": "p05xnzq944b",
           "label": "The Severans",
           "localizedLabel": {
-            "eng-latn": "Severans"
+            "eng-latn": "The Severans"
           },
           "source": {
             "locator": "page 20",
@@ -10675,13 +10944,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E162%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w42hjz": {
-          "alternateLabel": [
-            "Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neolithic"
+            ]
+          },
           "id": "p06v8w42hjz",
           "label": "Neolítico",
           "localizedLabel": {
-            "eng-latn": "Neolithic",
             "spa-latn": "Neolítico"
           },
           "spatialCoverage": [
@@ -10787,13 +11057,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E79%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w42zft": {
-          "alternateLabel": [
-            "Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neolithic"
+            ]
+          },
           "id": "p06v8w42zft",
           "label": "Néolithique",
           "localizedLabel": {
-            "eng-latn": "Neolithic",
             "fra-latn": "Néolithique"
           },
           "spatialCoverage": [
@@ -10818,13 +11089,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E38%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w42zp6": {
-          "alternateLabel": [
-            "Medieval"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Medieval"
+            ]
+          },
           "id": "p06v8w42zp6",
           "label": "Medievale",
           "localizedLabel": {
-            "eng-latn": "Medieval",
             "fra-latn": "Medievale"
           },
           "spatialCoverage": [
@@ -10849,13 +11121,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E45%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w433p2": {
-          "alternateLabel": [
-            "Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mesolithic"
+            ]
+          },
           "id": "p06v8w433p2",
           "label": "Mesolithique",
           "localizedLabel": {
-            "eng-latn": "Mesolithic",
             "fra-latn": "Mesolithique"
           },
           "spatialCoverage": [
@@ -10988,13 +11261,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E151%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w43r5n": {
-          "alternateLabel": [
-            "Contemporary"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Contemporary"
+            ]
+          },
           "id": "p06v8w43r5n",
           "label": "Contemporáneo",
           "localizedLabel": {
-            "eng-latn": "Contemporary",
             "spa-latn": "Contemporáneo"
           },
           "spatialCoverage": [
@@ -11073,14 +11347,16 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E183%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w44bj2": {
-          "alternateLabel": [
-            "Classic illyrian",
-            "Urban illyrian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Classic illyrian",
+              "Urban illyrian"
+            ]
+          },
           "id": "p06v8w44bj2",
           "label": "Classic/Urban illyrian",
           "localizedLabel": {
-            "eng-latn": "Classic illyrian"
+            "eng-latn": "Classic/Urban illyrian"
           },
           "spatialCoverage": [
             {
@@ -11104,13 +11380,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E150%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w44ckn": {
-          "alternateLabel": [
-            "Contemporary"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Contemporary"
+            ]
+          },
           "id": "p06v8w44ckn",
           "label": "Contermporary",
           "localizedLabel": {
-            "eng-latn": "Contemporary"
+            "eng-latn": "Contermporary"
           },
           "spatialCoverage": [
             {
@@ -11161,13 +11439,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E28%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w44jbs": {
-          "alternateLabel": [
-            "Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neolithic"
+            ]
+          },
           "id": "p06v8w44jbs",
           "label": "Неоліт",
           "localizedLabel": {
-            "eng-latn": "Neolithic",
             "ukr-cyrl": "Неоліт"
           },
           "spatialCoverage": [
@@ -11191,13 +11470,14 @@
           "type": "PeriodDefinition"
         },
         "p06v8w44qmx": {
-          "alternateLabel": [
-            "Late Antique"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Antique"
+            ]
+          },
           "id": "p06v8w44qmx",
           "label": "Tardoantiguo",
           "localizedLabel": {
-            "eng-latn": "Late Antique",
             "spa-latn": "Tardoantiguo"
           },
           "spatialCoverage": [
@@ -11222,13 +11502,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E125%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w44qsm": {
-          "alternateLabel": [
-            "Final Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Final Paleolithic"
+            ]
+          },
           "id": "p06v8w44qsm",
           "label": "Фінальний палеоліт",
           "localizedLabel": {
-            "eng-latn": "Final Paleolithic",
             "ukr-cyrl": "Фінальний палеоліт"
           },
           "spatialCoverage": [
@@ -11333,13 +11614,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E56%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w45hnr": {
-          "alternateLabel": [
-            "Hunnic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hunnic"
+            ]
+          },
           "id": "p06v8w45hnr",
           "label": "Гуни",
           "localizedLabel": {
-            "eng-latn": "Hunnic",
             "ukr-cyrl": "Гуни"
           },
           "spatialCoverage": [
@@ -11390,13 +11672,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E26%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w45rp6": {
-          "alternateLabel": [
-            "Gothic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Gothic"
+            ]
+          },
           "id": "p06v8w45rp6",
           "label": "Готи",
           "localizedLabel": {
-            "eng-latn": "Gothic",
             "ukr-cyrl": "Готи"
           },
           "spatialCoverage": [
@@ -11528,13 +11811,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E171%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w46crt": {
-          "alternateLabel": [
-            "Roman Imperial"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman Imperial"
+            ]
+          },
           "id": "p06v8w46crt",
           "label": "Romaine",
           "localizedLabel": {
-            "eng-latn": "Roman Imperial",
             "fra-latn": "Romaine"
           },
           "spatialCoverage": [
@@ -11559,13 +11843,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E43%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w46cth": {
-          "alternateLabel": [
-            "Ancient Rus`"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ancient Rus`"
+            ]
+          },
           "id": "p06v8w46cth",
           "label": "Давня Русь",
           "localizedLabel": {
-            "eng-latn": "Ancient Rus`",
             "ukr-cyrl": "Давня Русь"
           },
           "spatialCoverage": [
@@ -11805,14 +12090,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E73%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w47jcw": {
-          "alternateLabel": [
-            "Late Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age"
+            ]
+          },
           "id": "p06v8w47jcw",
           "label": "Bronz i vonë",
           "localizedLabel": {
-            "als-latn": "Bronz i vonë",
-            "eng-latn": "Late Bronze Age"
+            "als-latn": "Bronz i vonë"
           },
           "spatialCoverage": [
             {
@@ -11863,14 +12149,16 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E109%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w47m8h": {
-          "alternateLabel": [
-            "Archaic illyrian",
-            "Protourban illyrian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Archaic illyrian",
+              "Protourban illyrian"
+            ]
+          },
           "id": "p06v8w47m8h",
           "label": "Archaic/Protourban illyrian",
           "localizedLabel": {
-            "eng-latn": "Archaic illyrian"
+            "eng-latn": "Archaic/Protourban illyrian"
           },
           "spatialCoverage": [
             {
@@ -12029,14 +12317,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E102%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w48qxz": {
-          "alternateLabel": [
-            "Upper Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Upper Paleolithic"
+            ]
+          },
           "id": "p06v8w48qxz",
           "label": "Paleolit i vonë",
           "localizedLabel": {
-            "als-latn": "Paleolit i vonë",
-            "eng-latn": "Upper Paleolithic"
+            "als-latn": "Paleolit i vonë"
           },
           "spatialCoverage": [
             {
@@ -12087,14 +12376,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E16%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w496hs": {
-          "alternateLabel": [
-            "Modern"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern"
+            ]
+          },
           "id": "p06v8w496hs",
           "label": "Moderne",
           "localizedLabel": {
-            "als-latn": "Moderne",
-            "eng-latn": "Modern"
+            "als-latn": "Moderne"
           },
           "spatialCoverage": [
             {
@@ -12145,14 +12435,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E176%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w49hzs": {
-          "alternateLabel": [
-            "Early Imperial"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Imperial"
+            ]
+          },
           "id": "p06v8w49hzs",
           "label": "Perandorake e hershme",
           "localizedLabel": {
-            "als-latn": "Perandorake e hershme",
-            "eng-latn": "Early Imperial"
+            "als-latn": "Perandorake e hershme"
           },
           "spatialCoverage": [
             {
@@ -12176,15 +12467,16 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E130%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w49mp2": {
-          "alternateLabel": [
-            "Classic illyrian",
-            "Urban Illyrian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Classic illyrian",
+              "Urban Illyrian"
+            ]
+          },
           "id": "p06v8w49mp2",
           "label": "Klasike/Qytetare ilire",
           "localizedLabel": {
-            "als-latn": "Klasike/Qytetare ilire",
-            "eng-latn": "Classic illyrian"
+            "als-latn": "Klasike/Qytetare ilire"
           },
           "spatialCoverage": [
             {
@@ -12262,14 +12554,16 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E142%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4b3x6": {
-          "alternateLabel": [
-            "Classic illyrian",
-            "Urban illyrian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Classic illyrian",
+              "Urban illyrian"
+            ]
+          },
           "id": "p06v8w4b3x6",
           "label": "Classic/Urban illyrian",
           "localizedLabel": {
-            "eng-latn": "Classic illyrian"
+            "eng-latn": "Classic/Urban illyrian"
           },
           "spatialCoverage": [
             {
@@ -12374,14 +12668,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E74%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4bjgp": {
-          "alternateLabel": [
-            "Middle Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Paleolithic"
+            ]
+          },
           "id": "p06v8w4bjgp",
           "label": "Paleolit i mesëm",
           "localizedLabel": {
-            "als-latn": "Paleolit i mesëm",
-            "eng-latn": "Middle Paleolithic"
+            "als-latn": "Paleolit i mesëm"
           },
           "spatialCoverage": [
             {
@@ -12405,13 +12700,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E2%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4bk7n": {
-          "alternateLabel": [
-            "Middle Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age"
+            ]
+          },
           "id": "p06v8w4bk7n",
           "label": "Доба середньої бронзи",
           "localizedLabel": {
-            "eng-latn": "Middle Bronze Age",
             "ukr-cyrl": "Доба середньої бронзи"
           },
           "spatialCoverage": [
@@ -12462,13 +12758,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E52%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4bnqw": {
-          "alternateLabel": [
-            "Contemporary"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Contemporary"
+            ]
+          },
           "id": "p06v8w4bnqw",
           "label": "Новітня доба",
           "localizedLabel": {
-            "eng-latn": "Contemporary",
             "ukr-cyrl": "Новітня доба"
           },
           "spatialCoverage": [
@@ -12492,14 +12789,15 @@
           "type": "PeriodDefinition"
         },
         "p06v8w4bnsk": {
-          "alternateLabel": [
-            "Early Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Bronze Age"
+            ]
+          },
           "id": "p06v8w4bnsk",
           "label": "Bronz i hershëm",
           "localizedLabel": {
-            "als-latn": "Bronz i hershëm",
-            "eng-latn": "Early Bronze Age"
+            "als-latn": "Bronz i hershëm"
           },
           "spatialCoverage": [
             {
@@ -12523,14 +12821,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E7%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4br75": {
-          "alternateLabel": [
-            "Eneolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Eneolithic"
+            ]
+          },
           "id": "p06v8w4br75",
           "label": "Eneolit",
           "localizedLabel": {
-            "als-latn": "Eneolit",
-            "eng-latn": "Eneolithic"
+            "als-latn": "Eneolit"
           },
           "spatialCoverage": [
             {
@@ -12608,13 +12907,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E48%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4bz9k": {
-          "alternateLabel": [
-            "Bronze age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze age"
+            ]
+          },
           "id": "p06v8w4bz9k",
           "label": "Age de Bronze",
           "localizedLabel": {
-            "eng-latn": "Bronze age",
             "fra-latn": "Age de Bronze"
           },
           "spatialCoverage": [
@@ -12693,13 +12993,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E84%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4cgf2": {
-          "alternateLabel": [
-            "Late Antiquity"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Antiquity"
+            ]
+          },
           "id": "p06v8w4cgf2",
           "label": "Пізньоантичний період",
           "localizedLabel": {
-            "eng-latn": "Late Antiquity",
             "ukr-cyrl": "Пізньоантичний період"
           },
           "spatialCoverage": [
@@ -12804,15 +13105,16 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E167%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4d6vw": {
-          "alternateLabel": [
-            "Archaic Illyrian",
-            "Protourban Illyrian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Archaic Illyrian",
+              "Protourban Illyrian"
+            ]
+          },
           "id": "p06v8w4d6vw",
           "label": "Arkaike/Para qytetare ilire",
           "localizedLabel": {
-            "als-latn": "Arkaike/Para qytetare ilire",
-            "eng-latn": "Archaic Illyrian"
+            "als-latn": "Arkaike/Para qytetare ilire"
           },
           "spatialCoverage": [
             {
@@ -12863,13 +13165,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E63%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4dbcf": {
-          "alternateLabel": [
-            "Early Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Roman"
+            ]
+          },
           "id": "p06v8w4dbcf",
           "label": "Ранньоримський період",
           "localizedLabel": {
-            "eng-latn": "Early Roman",
             "ukr-cyrl": "Ранньоримський період"
           },
           "spatialCoverage": [
@@ -13001,13 +13304,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E170%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4f854": {
-          "alternateLabel": [
-            "Late Roman and Hunnic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Roman and Hunnic"
+            ]
+          },
           "id": "p06v8w4f854",
           "label": "Пізньоримський та гунський період",
           "localizedLabel": {
-            "eng-latn": "Late Roman and Hunnic",
             "ukr-cyrl": "Пізньоримський та гунський період"
           },
           "spatialCoverage": [
@@ -13031,13 +13335,14 @@
           "type": "PeriodDefinition"
         },
         "p06v8w4fpkn": {
-          "alternateLabel": [
-            "Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mesolithic"
+            ]
+          },
           "id": "p06v8w4fpkn",
           "label": "Мезоліт",
           "localizedLabel": {
-            "eng-latn": "Mesolithic",
             "ukr-cyrl": "Мезоліт"
           },
           "spatialCoverage": [
@@ -13061,13 +13366,14 @@
           "type": "PeriodDefinition"
         },
         "p06v8w4ft2t": {
-          "alternateLabel": [
-            "Mauretanian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mauretanian"
+            ]
+          },
           "id": "p06v8w4ft2t",
           "label": "Mauretaine",
           "localizedLabel": {
-            "eng-latn": "Mauretanian",
             "fra-latn": "Mauretaine"
           },
           "spatialCoverage": [
@@ -13119,13 +13425,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E82%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4g2dw": {
-          "alternateLabel": [
-            "Early Medieval"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Medieval"
+            ]
+          },
           "id": "p06v8w4g2dw",
           "label": "Раннє Середньовіччя",
           "localizedLabel": {
-            "eng-latn": "Early Medieval",
             "ukr-cyrl": "Раннє Середньовіччя"
           },
           "spatialCoverage": [
@@ -13203,13 +13510,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E57%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4gj5q": {
-          "alternateLabel": [
-            "Classical Antiquity"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Classical Antiquity"
+            ]
+          },
           "id": "p06v8w4gj5q",
           "label": "Класичний період",
           "localizedLabel": {
-            "eng-latn": "Classical Antiquity",
             "ukr-cyrl": "Класичний період"
           },
           "spatialCoverage": [
@@ -13233,10 +13541,14 @@
           "type": "PeriodDefinition"
         },
         "p06v8w4gm4z": {
+          "alternateLabel": {
+            "eng-latn": [
+              "Medieval"
+            ]
+          },
           "id": "p06v8w4gm4z",
           "label": "Medieval",
           "localizedLabel": {
-            "eng-latn": "Medieval",
             "spa-latn": "Medieval"
           },
           "spatialCoverage": [
@@ -13315,13 +13627,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E25%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4gw62": {
-          "alternateLabel": [
-            "Modern"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern"
+            ]
+          },
           "id": "p06v8w4gw62",
           "label": "Нова доба",
           "localizedLabel": {
-            "eng-latn": "Modern",
             "ukr-cyrl": "Нова доба"
           },
           "spatialCoverage": [
@@ -13399,13 +13712,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E97%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4h4qr": {
-          "alternateLabel": [
-            "Late La Tène"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late La Tène"
+            ]
+          },
           "id": "p06v8w4h4qr",
           "label": "Пізньолатенський період",
           "localizedLabel": {
-            "eng-latn": "Late La Tène",
             "ukr-cyrl": "Пізньолатенський період"
           },
           "spatialCoverage": [
@@ -13456,13 +13770,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E68%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4htwc": {
-          "alternateLabel": [
-            "Hellenistic "
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hellenistic "
+            ]
+          },
           "id": "p06v8w4htwc",
           "label": "Елліністичний період",
           "localizedLabel": {
-            "eng-latn": "Hellenistic ",
             "ukr-cyrl": "Елліністичний період"
           },
           "spatialCoverage": [
@@ -13486,14 +13801,15 @@
           "type": "PeriodDefinition"
         },
         "p06v8w4hx4w": {
-          "alternateLabel": [
-            "Republican"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Republican"
+            ]
+          },
           "id": "p06v8w4hx4w",
           "label": "Republikane",
           "localizedLabel": {
-            "als-latn": "Republikane",
-            "eng-latn": "Republican"
+            "als-latn": "Republikane"
           },
           "spatialCoverage": [
             {
@@ -13517,13 +13833,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E15%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4hzqv": {
-          "alternateLabel": [
-            "Early Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Bronze Age"
+            ]
+          },
           "id": "p06v8w4hzqv",
           "label": "Доба ранньої бронзи",
           "localizedLabel": {
-            "eng-latn": "Early Bronze Age",
             "ukr-cyrl": "Доба ранньої бронзи"
           },
           "spatialCoverage": [
@@ -13547,13 +13864,14 @@
           "type": "PeriodDefinition"
         },
         "p06v8w4j58z": {
-          "alternateLabel": [
-            "Modern"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern"
+            ]
+          },
           "id": "p06v8w4j58z",
           "label": "Moderno",
           "localizedLabel": {
-            "eng-latn": "Modern",
             "spa-latn": "Moderno"
           },
           "spatialCoverage": [
@@ -13605,14 +13923,16 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E99%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4j9dh": {
-          "alternateLabel": [
-            "Archaic illyrian",
-            "Protourban illyrian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Archaic illyrian",
+              "Protourban illyrian"
+            ]
+          },
           "id": "p06v8w4j9dh",
           "label": "Archaic/Protourban illyrian",
           "localizedLabel": {
-            "eng-latn": "Archaic illyrian"
+            "eng-latn": "Archaic/Protourban illyrian"
           },
           "spatialCoverage": [
             {
@@ -13636,14 +13956,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E172%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4jhjm": {
-          "alternateLabel": [
-            "Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mesolithic"
+            ]
+          },
           "id": "p06v8w4jhjm",
           "label": "Mezolit",
           "localizedLabel": {
-            "als-latn": "Mezolit",
-            "eng-latn": "Mesolithic"
+            "als-latn": "Mezolit"
           },
           "spatialCoverage": [
             {
@@ -13721,13 +14042,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E22%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4jrfp": {
-          "alternateLabel": [
-            "Final Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Final Bronze Age"
+            ]
+          },
           "id": "p06v8w4jrfp",
           "label": "Доба фінальної бронзи",
           "localizedLabel": {
-            "eng-latn": "Final Bronze Age",
             "ukr-cyrl": "Доба фінальної бронзи"
           },
           "spatialCoverage": [
@@ -13913,14 +14235,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E88%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4kbt3": {
-          "alternateLabel": [
-            "Early Medieval"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Medieval"
+            ]
+          },
           "id": "p06v8w4kbt3",
           "label": "Mesjetë e hershme",
           "localizedLabel": {
-            "als-latn": "Mesjetë e hershme",
-            "eng-latn": "Early Medieval"
+            "als-latn": "Mesjetë e hershme"
           },
           "spatialCoverage": [
             {
@@ -14079,14 +14402,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E141%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4m9zc": {
-          "alternateLabel": [
-            "Late Imperial"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Imperial"
+            ]
+          },
           "id": "p06v8w4m9zc",
           "label": "Perandorake e vonë",
           "localizedLabel": {
-            "als-latn": "Perandorake e vonë",
-            "eng-latn": "Late Imperial"
+            "als-latn": "Perandorake e vonë"
           },
           "spatialCoverage": [
             {
@@ -14137,13 +14461,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E94%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4mc59": {
-          "alternateLabel": [
-            "Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman"
+            ]
+          },
           "id": "p06v8w4mc59",
           "label": "Римський період",
           "localizedLabel": {
-            "eng-latn": "Roman",
             "ukr-cyrl": "Римський період"
           },
           "spatialCoverage": [
@@ -14221,15 +14546,16 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E163%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4mkjq": {
-          "alternateLabel": [
-            "Medieval",
-            "Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Medieval",
+              "Byzantine"
+            ]
+          },
           "id": "p06v8w4mkjq",
           "label": "Mesjetë /Bizantine",
           "localizedLabel": {
-            "als-latn": "Mesjetë /Bizantine",
-            "eng-latn": "Medieval"
+            "als-latn": "Mesjetë /Bizantine"
           },
           "spatialCoverage": [
             {
@@ -14388,13 +14714,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E177%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4n66d": {
-          "alternateLabel": [
-            "Contemporary"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Contemporary"
+            ]
+          },
           "id": "p06v8w4n66d",
           "label": "Contemporaine",
           "localizedLabel": {
-            "eng-latn": "Contemporary",
             "fra-latn": "Contemporaine"
           },
           "spatialCoverage": [
@@ -14419,13 +14746,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E47%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4ncv7": {
-          "alternateLabel": [
-            "Eneolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Eneolithic"
+            ]
+          },
           "id": "p06v8w4ncv7",
           "label": "Енеоліт",
           "localizedLabel": {
-            "eng-latn": "Eneolithic",
             "ukr-cyrl": "Енеоліт"
           },
           "spatialCoverage": [
@@ -14449,14 +14777,15 @@
           "type": "PeriodDefinition"
         },
         "p06v8w4nfqg": {
-          "alternateLabel": [
-            "Contemporary"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Contemporary"
+            ]
+          },
           "id": "p06v8w4nfqg",
           "label": "Bashkëkohore",
           "localizedLabel": {
-            "als-latn": "Bashkëkohore",
-            "eng-latn": "Contemporary"
+            "als-latn": "Bashkëkohore"
           },
           "spatialCoverage": [
             {
@@ -14507,13 +14836,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E61%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4p3qr": {
-          "alternateLabel": [
-            "Lower Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Lower Paleolithic"
+            ]
+          },
           "id": "p06v8w4p3qr",
           "label": "Paléolithique inférieur",
           "localizedLabel": {
-            "eng-latn": "Lower Paleolithic",
             "fra-latn": "Paléolithique inférieur"
           },
           "spatialCoverage": [
@@ -14565,13 +14895,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E140%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4pmpv": {
-          "alternateLabel": [
-            "Eneolothic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Eneolothic"
+            ]
+          },
           "id": "p06v8w4pmpv",
           "label": "Calcolítico",
           "localizedLabel": {
-            "eng-latn": "Eneolothic",
             "spa-latn": "Calcolítico"
           },
           "spatialCoverage": [
@@ -14596,13 +14927,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E120%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4pndh": {
-          "alternateLabel": [
-            "Sarmatian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Sarmatian"
+            ]
+          },
           "id": "p06v8w4pndh",
           "label": "Сармати",
           "localizedLabel": {
-            "eng-latn": "Sarmatian",
             "ukr-cyrl": "Сармати"
           },
           "spatialCoverage": [
@@ -14653,13 +14985,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E19%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4q5mm": {
-          "alternateLabel": [
-            "Bronze age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze age"
+            ]
+          },
           "id": "p06v8w4q5mm",
           "label": "Edad del Bronce",
           "localizedLabel": {
-            "eng-latn": "Bronze age",
             "spa-latn": "Edad del Bronce"
           },
           "spatialCoverage": [
@@ -14711,13 +15044,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E103%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4qf9z": {
-          "alternateLabel": [
-            "Late Antique"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Antique"
+            ]
+          },
           "id": "p06v8w4qf9z",
           "label": "Tard Antiquité",
           "localizedLabel": {
-            "eng-latn": "Late Antique",
             "fra-latn": "Tard Antiquité"
           },
           "spatialCoverage": [
@@ -14769,13 +15103,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E64%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4qp2q": {
-          "alternateLabel": [
-            "Archaic period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Archaic period"
+            ]
+          },
           "id": "p06v8w4qp2q",
           "label": "Архаїчний період",
           "localizedLabel": {
-            "eng-latn": "Archaic period",
             "ukr-cyrl": "Архаїчний період"
           },
           "spatialCoverage": [
@@ -14826,13 +15161,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E148%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4qpm3": {
-          "alternateLabel": [
-            "Lower Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Lower Paleolithic"
+            ]
+          },
           "id": "p06v8w4qpm3",
           "label": "Нижній палеоліт",
           "localizedLabel": {
-            "eng-latn": "Lower Paleolithic",
             "ukr-cyrl": "Нижній палеоліт"
           },
           "spatialCoverage": [
@@ -14883,13 +15219,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E108%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4qsqx": {
-          "alternateLabel": [
-            "Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mesolithic"
+            ]
+          },
           "id": "p06v8w4qsqx",
           "label": "Mesolítico",
           "localizedLabel": {
-            "eng-latn": "Mesolithic",
             "spa-latn": "Mesolítico"
           },
           "spatialCoverage": [
@@ -14914,13 +15251,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E118%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4qswm": {
-          "alternateLabel": [
-            "Middle Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Paleolithic"
+            ]
+          },
           "id": "p06v8w4qswm",
           "label": "Paleolítico medio",
           "localizedLabel": {
-            "eng-latn": "Middle Paleolithic",
             "spa-latn": "Paleolítico medio"
           },
           "spatialCoverage": [
@@ -15026,13 +15364,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E67%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4r785": {
-          "alternateLabel": [
-            "Middle Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Paleolithic"
+            ]
+          },
           "id": "p06v8w4r785",
           "label": "Середній палеоліт",
           "localizedLabel": {
-            "eng-latn": "Middle Paleolithic",
             "ukr-cyrl": "Середній палеоліт"
           },
           "spatialCoverage": [
@@ -15056,14 +15395,15 @@
           "type": "PeriodDefinition"
         },
         "p06v8w4rbc2": {
-          "alternateLabel": [
-            "Hellenistic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hellenistic"
+            ]
+          },
           "id": "p06v8w4rbc2",
           "label": "Helenistike",
           "localizedLabel": {
-            "als-latn": "Helenistike",
-            "eng-latn": "Hellenistic"
+            "als-latn": "Helenistike"
           },
           "spatialCoverage": [
             {
@@ -15087,14 +15427,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E14%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4s3k7": {
-          "alternateLabel": [
-            "Lower Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Lower Paleolithic"
+            ]
+          },
           "id": "p06v8w4s3k7",
           "label": "Paleolit i hershëm",
           "localizedLabel": {
-            "als-latn": "Paleolit i hershëm",
-            "eng-latn": "Lower Paleolithic"
+            "als-latn": "Paleolit i hershëm"
           },
           "spatialCoverage": [
             {
@@ -15118,13 +15459,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E1%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4s5q5": {
-          "alternateLabel": [
-            "Middle Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Paleolithic"
+            ]
+          },
           "id": "p06v8w4s5q5",
           "label": "Paléolithique moyen",
           "localizedLabel": {
-            "eng-latn": "Middle Paleolithic",
             "fra-latn": "Paléolithique moyen"
           },
           "spatialCoverage": [
@@ -15149,13 +15491,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E35%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4s5zg": {
-          "alternateLabel": [
-            "Cimmerian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Cimmerian"
+            ]
+          },
           "id": "p06v8w4s5zg",
           "label": "Кіммерійці",
           "localizedLabel": {
-            "eng-latn": "Cimmerian",
             "ukr-cyrl": "Кіммерійці"
           },
           "spatialCoverage": [
@@ -15179,13 +15522,14 @@
           "type": "PeriodDefinition"
         },
         "p06v8w4s9pz": {
-          "alternateLabel": [
-            "Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age"
+            ]
+          },
           "id": "p06v8w4s9pz",
           "label": "Edad del Hierro",
           "localizedLabel": {
-            "eng-latn": "Iron Age",
             "spa-latn": "Edad del Hierro"
           },
           "spatialCoverage": [
@@ -15237,14 +15581,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E112%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4sm9z": {
-          "alternateLabel": [
-            "Late Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Iron Age"
+            ]
+          },
           "id": "p06v8w4sm9z",
           "label": "Hekur i zhvilluar",
           "localizedLabel": {
-            "als-latn": "Hekur i zhvilluar",
-            "eng-latn": "Late Iron Age"
+            "als-latn": "Hekur i zhvilluar"
           },
           "spatialCoverage": [
             {
@@ -15268,13 +15613,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E11%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4spfw": {
-          "alternateLabel": [
-            "Scythian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Scythian"
+            ]
+          },
           "id": "p06v8w4spfw",
           "label": "Скіфи",
           "localizedLabel": {
-            "eng-latn": "Scythian",
             "ukr-cyrl": "Скіфи"
           },
           "spatialCoverage": [
@@ -15433,13 +15779,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E78%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4t56d": {
-          "alternateLabel": [
-            "Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age"
+            ]
+          },
           "id": "p06v8w4t56d",
           "label": "Залізний вік",
           "localizedLabel": {
-            "eng-latn": "Iron Age",
             "ukr-cyrl": "Залізний вік"
           },
           "spatialCoverage": [
@@ -15490,13 +15837,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E155%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4tcnh": {
-          "alternateLabel": [
-            "Roman Imperial"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman Imperial"
+            ]
+          },
           "id": "p06v8w4tcnh",
           "label": "Romano imperial",
           "localizedLabel": {
-            "eng-latn": "Roman Imperial",
             "spa-latn": "Romano imperial"
           },
           "spatialCoverage": [
@@ -15521,13 +15869,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E124%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4trxf": {
-          "alternateLabel": [
-            "Cossack"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Cossack"
+            ]
+          },
           "id": "p06v8w4trxf",
           "label": "Козаччина",
           "localizedLabel": {
-            "eng-latn": "Cossack",
             "ukr-cyrl": "Козаччина"
           },
           "spatialCoverage": [
@@ -15551,13 +15900,14 @@
           "type": "PeriodDefinition"
         },
         "p06v8w4tswd": {
-          "alternateLabel": [
-            "Modern"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern"
+            ]
+          },
           "id": "p06v8w4tswd",
           "label": "Moderne",
           "localizedLabel": {
-            "eng-latn": "Modern",
             "fra-latn": "Moderne"
           },
           "spatialCoverage": [
@@ -15582,13 +15932,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E46%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4v2r4": {
-          "alternateLabel": [
-            "Late Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age"
+            ]
+          },
           "id": "p06v8w4v2r4",
           "label": "Доба пізньої бронзи",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age",
             "ukr-cyrl": "Доба пізньої бронзи"
           },
           "spatialCoverage": [
@@ -15639,13 +15990,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E31%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4v6xx": {
-          "alternateLabel": [
-            "Upper Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Upper Paleolithic"
+            ]
+          },
           "id": "p06v8w4v6xx",
           "label": "Paleolítico superior",
           "localizedLabel": {
-            "eng-latn": "Upper Paleolithic",
             "spa-latn": "Paleolítico superior"
           },
           "spatialCoverage": [
@@ -15697,13 +16049,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E21%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4v9b6": {
-          "alternateLabel": [
-            "Upper Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Upper Paleolithic"
+            ]
+          },
           "id": "p06v8w4v9b6",
           "label": "Paléolithique supérieur",
           "localizedLabel": {
-            "eng-latn": "Upper Paleolithic",
             "fra-latn": "Paléolithique supérieur"
           },
           "spatialCoverage": [
@@ -15728,14 +16081,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E36%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4vck4": {
-          "alternateLabel": [
-            "Middle Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age"
+            ]
+          },
           "id": "p06v8w4vck4",
           "label": "Bronz i mesëm",
           "localizedLabel": {
-            "als-latn": "Bronz i mesëm",
-            "eng-latn": "Middle Bronze Age"
+            "als-latn": "Bronz i mesëm"
           },
           "spatialCoverage": [
             {
@@ -15894,13 +16248,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E100%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4w2bc": {
-          "alternateLabel": [
-            "Eneolothic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Eneolothic"
+            ]
+          },
           "id": "p06v8w4w2bc",
           "label": "Enéolithique",
           "localizedLabel": {
-            "eng-latn": "Eneolothic",
             "fra-latn": "Enéolithique"
           },
           "spatialCoverage": [
@@ -15952,13 +16307,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E86%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4w68v": {
-          "alternateLabel": [
-            "Late Medieval"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Medieval"
+            ]
+          },
           "id": "p06v8w4w68v",
           "label": "Пізнє Середньовіччя",
           "localizedLabel": {
-            "eng-latn": "Late Medieval",
             "ukr-cyrl": "Пізнє Середньовіччя"
           },
           "spatialCoverage": [
@@ -16036,14 +16392,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E24%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4wpdc": {
-          "alternateLabel": [
-            "Early Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Iron Age"
+            ]
+          },
           "id": "p06v8w4wpdc",
           "label": "Hekuri i hershëm",
           "localizedLabel": {
-            "als-latn": "Hekuri i hershëm",
-            "eng-latn": "Early Iron Age"
+            "als-latn": "Hekuri i hershëm"
           },
           "spatialCoverage": [
             {
@@ -16148,13 +16505,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E70%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4x3fw": {
-          "alternateLabel": [
-            "Lower Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Lower Paleolithic"
+            ]
+          },
           "id": "p06v8w4x3fw",
           "label": "Paleolítico inferior",
           "localizedLabel": {
-            "eng-latn": "Lower Paleolithic",
             "spa-latn": "Paleolítico inferior"
           },
           "spatialCoverage": [
@@ -16179,13 +16537,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E115%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4x4sj": {
-          "alternateLabel": [
-            "Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age"
+            ]
+          },
           "id": "p06v8w4x4sj",
           "label": "Punique",
           "localizedLabel": {
-            "eng-latn": "Iron Age",
             "fra-latn": "Punique"
           },
           "spatialCoverage": [
@@ -16210,14 +16569,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E41%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4x58t": {
-          "alternateLabel": [
-            "Ottoman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ottoman"
+            ]
+          },
           "id": "p06v8w4x58t",
           "label": "Osmane",
           "localizedLabel": {
-            "als-latn": "Osmane",
-            "eng-latn": "Ottoman"
+            "als-latn": "Osmane"
           },
           "spatialCoverage": [
             {
@@ -16295,14 +16655,16 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E178%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4xdt8": {
-          "alternateLabel": [
-            "Medieval",
-            "Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Medieval",
+              "Byzantine"
+            ]
+          },
           "id": "p06v8w4xdt8",
           "label": "Medieval/Byzantine",
           "localizedLabel": {
-            "eng-latn": "Medieval"
+            "eng-latn": "Medieval/Byzantine"
           },
           "spatialCoverage": [
             {
@@ -16326,14 +16688,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E180%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4xtf5": {
-          "alternateLabel": [
-            "Mid Imperial"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mid Imperial"
+            ]
+          },
           "id": "p06v8w4xtf5",
           "label": "Perandorake e mesme",
           "localizedLabel": {
-            "als-latn": "Perandorake e mesme",
-            "eng-latn": "Mid Imperial"
+            "als-latn": "Perandorake e mesme"
           },
           "spatialCoverage": [
             {
@@ -16357,14 +16720,15 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E131%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4xz8n": {
-          "alternateLabel": [
-            "Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neolithic"
+            ]
+          },
           "id": "p06v8w4xz8n",
           "label": "Neolit",
           "localizedLabel": {
-            "als-latn": "Neolit",
-            "eng-latn": "Neolithic"
+            "als-latn": "Neolit"
           },
           "spatialCoverage": [
             {
@@ -16550,13 +16914,14 @@
           "url": "http://www.fastionline.org/cgi-bin/mapserv?map=/var/www/html/fasti-vhost-docroot/config/fasti.map&VERSION=1.0.0&SERVICE=WFS&REQUEST=GetFeature&TYPENAME=periods&FILTER=%3CFilter%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Eark_id%3C/PropertyName%3E%3CLiteral%3E55%3C/Literal%3E%3C/PropertyIsEqualTo%3E%3C/Filter%3E"
         },
         "p06v8w4zbxw": {
-          "alternateLabel": [
-            "Upper Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Upper Paleolithic"
+            ]
+          },
           "id": "p06v8w4zbxw",
           "label": "Верхній палеоліт",
           "localizedLabel": {
-            "eng-latn": "Upper Paleolithic",
             "ukr-cyrl": "Верхній палеоліт"
           },
           "spatialCoverage": [
@@ -16681,13 +17046,15 @@
     "p06xc6m": {
       "definitions": {
         "p06xc6mq829": {
-          "alternateLabel": [
-            "Early Iberian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Iberian"
+            ]
+          },
           "id": "p06xc6mq829",
           "label": "Early Iberian Period",
           "localizedLabel": {
-            "eng-latn": "Early Iberian"
+            "eng-latn": "Early Iberian Period"
           },
           "spatialCoverage": [
             {
@@ -16711,13 +17078,15 @@
           "type": "PeriodDefinition"
         },
         "p06xc6mvjx2": {
-          "alternateLabel": [
-            "Classical Iberian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Classical Iberian"
+            ]
+          },
           "id": "p06xc6mvjx2",
           "label": "Classical Iberian Period",
           "localizedLabel": {
-            "eng-latn": "Classical Iberian"
+            "eng-latn": "Classical Iberian Period"
           },
           "note": "Equivalent to Iberian III (450-350 B.C.) and IV (350-200 B.C.) - cf. M. Diaz-Andreu & S. Keay, 1997. The Archaeology of Iberia; Dominguez in C. Sanchez & G.R. Tsetskhladze, 2001. Greek Pottery from the Iberian Peninsula.",
           "spatialCoverage": [
@@ -16793,9 +17162,11 @@
           "type": "PeriodDefinition"
         },
         "p077fc5wb89": {
-          "alternateLabel": [
-            "Neo-Babylonian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neo-Babylonian"
+            ]
+          },
           "editorialNote": "this date: see also Mazar, 1992",
           "id": "p077fc5wb89",
           "label": "Iron III",
@@ -17395,13 +17766,14 @@
     "p07h9k6": {
       "definitions": {
         "p07h9k62chw": {
-          "alternateLabel": [
-            "Lower Palaeolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Lower Palaeolithic"
+            ]
+          },
           "id": "p07h9k62chw",
           "label": "Paleolítico Inferior",
           "localizedLabel": {
-            "eng-latn": "Lower Palaeolithic",
             "spa-latn": "Paleolítico Inferior"
           },
           "spatialCoverage": [
@@ -17434,13 +17806,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k62pfw": {
-          "alternateLabel": [
-            "Middle Palaeolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Palaeolithic"
+            ]
+          },
           "id": "p07h9k62pfw",
           "label": "Paleolítico Medio",
           "localizedLabel": {
-            "eng-latn": "Middle Palaeolithic",
             "spa-latn": "Paleolítico Medio"
           },
           "spatialCoverage": [
@@ -17473,13 +17846,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k62rq6": {
-          "alternateLabel": [
-            "Epipalaeolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Epipalaeolithic"
+            ]
+          },
           "id": "p07h9k62rq6",
           "label": "Epipaleolítico",
           "localizedLabel": {
-            "eng-latn": "Epipalaeolithic",
             "spa-latn": "Epipaleolítico"
           },
           "spatialCoverage": [
@@ -17512,13 +17886,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k634vf": {
-          "alternateLabel": [
-            "20th and 21st Centuries"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "20th and 21st Centuries"
+            ]
+          },
           "id": "p07h9k634vf",
           "label": "Siglos XX y XXI",
           "localizedLabel": {
-            "eng-latn": "20th and 21st Centuries",
             "spa-latn": "Siglos XX y XXI"
           },
           "spatialCoverage": [
@@ -17551,13 +17926,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k63z2v": {
-          "alternateLabel": [
-            "Modern Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern Period"
+            ]
+          },
           "id": "p07h9k63z2v",
           "label": "Edad Moderna",
           "localizedLabel": {
-            "eng-latn": "Modern Period",
             "spa-latn": "Edad Moderna"
           },
           "spatialCoverage": [
@@ -17590,13 +17966,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k65xxf": {
-          "alternateLabel": [
-            "Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze Age"
+            ]
+          },
           "id": "p07h9k65xxf",
           "label": "Edad del Bronce",
           "localizedLabel": {
-            "eng-latn": "Bronze Age",
             "spa-latn": "Edad del Bronce"
           },
           "spatialCoverage": [
@@ -17629,13 +18006,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k65zqq": {
-          "alternateLabel": [
-            "Late Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Iron Age"
+            ]
+          },
           "id": "p07h9k65zqq",
           "label": "Segunda Edad del Hierro",
           "localizedLabel": {
-            "eng-latn": "Late Iron Age",
             "spa-latn": "Segunda Edad del Hierro"
           },
           "spatialCoverage": [
@@ -17668,13 +18046,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k69b54": {
-          "alternateLabel": [
-            "Palaeolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Palaeolithic"
+            ]
+          },
           "id": "p07h9k69b54",
           "label": "Paleolítico",
           "localizedLabel": {
-            "eng-latn": "Palaeolithic",
             "spa-latn": "Paleolítico"
           },
           "spatialCoverage": [
@@ -17707,13 +18086,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k69cj3": {
-          "alternateLabel": [
-            "Early Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Neolithic"
+            ]
+          },
           "id": "p07h9k69cj3",
           "label": "Neolítico Antiguo",
           "localizedLabel": {
-            "eng-latn": "Early Neolithic",
             "spa-latn": "Neolítico Antiguo"
           },
           "spatialCoverage": [
@@ -17746,13 +18126,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k69qf2": {
-          "alternateLabel": [
-            "Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age"
+            ]
+          },
           "id": "p07h9k69qf2",
           "label": "Edad del Hierro",
           "localizedLabel": {
-            "eng-latn": "Iron Age",
             "spa-latn": "Edad del Hierro"
           },
           "spatialCoverage": [
@@ -17785,13 +18166,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k69vsj": {
-          "alternateLabel": [
-            "Upper Palaeolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Upper Palaeolithic"
+            ]
+          },
           "id": "p07h9k69vsj",
           "label": "Paleolítico Superior",
           "localizedLabel": {
-            "eng-latn": "Upper Palaeolithic",
             "spa-latn": "Paleolítico Superior"
           },
           "spatialCoverage": [
@@ -17824,13 +18206,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6b656": {
-          "alternateLabel": [
-            "Indigenous-Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Indigenous-Roman"
+            ]
+          },
           "id": "p07h9k6b656",
           "label": "Indígena-Romano",
           "localizedLabel": {
-            "eng-latn": "Indigenous-Roman",
             "spa-latn": "Indígena-Romano"
           },
           "note": "The Indigenous-Roman and Early Roman subdivisions of Roman Period have identical dates, but they refer to very different cultural contexts.",
@@ -17864,13 +18247,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6b6dh": {
-          "alternateLabel": [
-            "Early Prehistory"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Prehistory"
+            ]
+          },
           "id": "p07h9k6b6dh",
           "label": "Prehistoria Temprana",
           "localizedLabel": {
-            "eng-latn": "Early Prehistory",
             "spa-latn": "Prehistoria Temprana"
           },
           "spatialCoverage": [
@@ -17903,13 +18287,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6ch24": {
-          "alternateLabel": [
-            "Roman Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman Period"
+            ]
+          },
           "id": "p07h9k6ch24",
           "label": "Época Romana",
           "localizedLabel": {
-            "eng-latn": "Roman Period",
             "spa-latn": "Época Romana"
           },
           "note": "The Indigenous-Roman and Early Roman subdivisions of Roman Period have identical dates, but they refer to very different cultural contexts.",
@@ -17943,13 +18328,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6dpt6": {
-          "alternateLabel": [
-            "18th and 19th Centuries"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "18th and 19th Centuries"
+            ]
+          },
           "id": "p07h9k6dpt6",
           "label": "Siglos XVIII y XIX",
           "localizedLabel": {
-            "eng-latn": "18th and 19th Centuries",
             "spa-latn": "Siglos XVIII y XIX"
           },
           "spatialCoverage": [
@@ -17982,13 +18368,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6f5tz": {
-          "alternateLabel": [
-            "Middle Ages"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Ages"
+            ]
+          },
           "id": "p07h9k6f5tz",
           "label": "Edad Media",
           "localizedLabel": {
-            "eng-latn": "Middle Ages",
             "spa-latn": "Edad Media"
           },
           "spatialCoverage": [
@@ -18021,13 +18408,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6hrk7": {
-          "alternateLabel": [
-            "Late Prehistory"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Prehistory"
+            ]
+          },
           "id": "p07h9k6hrk7",
           "label": "Prehistoria Reciente",
           "localizedLabel": {
-            "eng-latn": "Late Prehistory",
             "spa-latn": "Prehistoria Reciente"
           },
           "spatialCoverage": [
@@ -18060,13 +18448,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6k759": {
-          "alternateLabel": [
-            "Contemporary Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Contemporary Period"
+            ]
+          },
           "id": "p07h9k6k759",
           "label": "Edad Contemporánea",
           "localizedLabel": {
-            "eng-latn": "Contemporary Period",
             "spa-latn": "Edad Contemporánea"
           },
           "spatialCoverage": [
@@ -18099,13 +18488,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6k9vj": {
-          "alternateLabel": [
-            "Late Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Roman"
+            ]
+          },
           "id": "p07h9k6k9vj",
           "label": "Bajo Romano",
           "localizedLabel": {
-            "eng-latn": "Late Roman",
             "spa-latn": "Bajo Romano"
           },
           "spatialCoverage": [
@@ -18138,13 +18528,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6kh4b": {
-          "alternateLabel": [
-            "Early Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Bronze Age"
+            ]
+          },
           "id": "p07h9k6kh4b",
           "label": "Edad del Bronce Inicial",
           "localizedLabel": {
-            "eng-latn": "Early Bronze Age",
             "spa-latn": "Edad del Bronce Inicial"
           },
           "spatialCoverage": [
@@ -18177,13 +18568,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6m88t": {
-          "alternateLabel": [
-            "Central Middle Ages"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Central Middle Ages"
+            ]
+          },
           "id": "p07h9k6m88t",
           "label": "Edad Media central",
           "localizedLabel": {
-            "eng-latn": "Central Middle Ages",
             "spa-latn": "Edad Media central"
           },
           "spatialCoverage": [
@@ -18216,13 +18608,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6n24z": {
-          "alternateLabel": [
-            "Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neolithic"
+            ]
+          },
           "id": "p07h9k6n24z",
           "label": "Neolítico",
           "localizedLabel": {
-            "eng-latn": "Neolithic",
             "spa-latn": "Neolítico"
           },
           "note": "The Neolithic category is split between Early Prehistory and Late Prehistory.",
@@ -18256,13 +18649,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6npwn": {
-          "alternateLabel": [
-            "Early Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Roman"
+            ]
+          },
           "id": "p07h9k6npwn",
           "label": "Alto Romano",
           "localizedLabel": {
-            "eng-latn": "Early Roman",
             "spa-latn": "Alto Romano"
           },
           "spatialCoverage": [
@@ -18295,13 +18689,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6q5bd": {
-          "alternateLabel": [
-            "Middle Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age"
+            ]
+          },
           "id": "p07h9k6q5bd",
           "label": "Edad del Bronce Media",
           "localizedLabel": {
-            "eng-latn": "Middle Bronze Age",
             "spa-latn": "Edad del Bronce Media"
           },
           "spatialCoverage": [
@@ -18334,13 +18729,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6q7dn": {
-          "alternateLabel": [
-            "Late Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Neolithic"
+            ]
+          },
           "id": "p07h9k6q7dn",
           "label": "Neolítico Final",
           "localizedLabel": {
-            "eng-latn": "Late Neolithic",
             "spa-latn": "Neolítico Final"
           },
           "spatialCoverage": [
@@ -18373,13 +18769,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6s57w": {
-          "alternateLabel": [
-            "Late Middle Ages"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Middle Ages"
+            ]
+          },
           "id": "p07h9k6s57w",
           "label": "Baja Edad Media",
           "localizedLabel": {
-            "eng-latn": "Late Middle Ages",
             "spa-latn": "Baja Edad Media"
           },
           "spatialCoverage": [
@@ -18412,13 +18809,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6tmr2": {
-          "alternateLabel": [
-            "Late Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age"
+            ]
+          },
           "id": "p07h9k6tmr2",
           "label": "Edad del Bronce Final",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age",
             "spa-latn": "Edad del Bronce Final"
           },
           "spatialCoverage": [
@@ -18451,13 +18849,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6tz6n": {
-          "alternateLabel": [
-            "16th and 17th Centuries"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "16th and 17th Centuries"
+            ]
+          },
           "id": "p07h9k6tz6n",
           "label": "Siglos XVI y XVII",
           "localizedLabel": {
-            "eng-latn": "16th and 17th Centuries",
             "spa-latn": "Siglos XVI y XVII"
           },
           "spatialCoverage": [
@@ -18490,13 +18889,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6w344": {
-          "alternateLabel": [
-            "Early Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Iron Age"
+            ]
+          },
           "id": "p07h9k6w344",
           "label": "Primera Edad del Hierro",
           "localizedLabel": {
-            "eng-latn": "Early Iron Age",
             "spa-latn": "Primera Edad del Hierro"
           },
           "spatialCoverage": [
@@ -18529,13 +18929,14 @@
           "type": "PeriodDefinition"
         },
         "p07h9k6z49k": {
-          "alternateLabel": [
-            "Early Middle Ages"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Middle Ages"
+            ]
+          },
           "id": "p07h9k6z49k",
           "label": "Alta Edad Media",
           "localizedLabel": {
-            "eng-latn": "Early Middle Ages",
             "spa-latn": "Alta Edad Media"
           },
           "spatialCoverage": [
@@ -18976,15 +19377,17 @@
           "type": "PeriodDefinition"
         },
         "p083p5r8kpg": {
-          "alternateLabel": [
-            "Old Palace",
-            "Protopalatial"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Old Palace",
+              "Protopalatial"
+            ]
+          },
           "editorialNote": "\"(= Middle Minoan IB)\"",
           "id": "p083p5r8kpg",
           "label": "Old Palace (Protopalatial)",
           "localizedLabel": {
-            "eng-latn": "Old Palace"
+            "eng-latn": "Old Palace (Protopalatial)"
           },
           "source": {
             "locator": "page 120",
@@ -19118,14 +19521,16 @@
           "type": "PeriodDefinition"
         },
         "p083p5r9rs7": {
-          "alternateLabel": [
-            "Archaemenid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Archaemenid"
+            ]
+          },
           "editorialNote": "Gates discusses only the Achaemenids in Persia proper in this chapter.",
           "id": "p083p5r9rs7",
           "label": "Achaemenids",
           "localizedLabel": {
-            "eng-latn": "Archaemenid"
+            "eng-latn": "Achaemenids"
           },
           "source": {
             "locator": "page 167",
@@ -19608,13 +20013,15 @@
           "type": "PeriodDefinition"
         },
         "p083p5rdz7f": {
-          "alternateLabel": [
-            "Etruscan"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Etruscan"
+            ]
+          },
           "id": "p083p5rdz7f",
           "label": "Etruscan rule",
           "localizedLabel": {
-            "eng-latn": "Etruscan"
+            "eng-latn": "Etruscan rule"
           },
           "source": {
             "locator": "page 317",
@@ -20067,14 +20474,16 @@
           "type": "PeriodDefinition"
         },
         "p083p5rpb46": {
-          "alternateLabel": [
-            "Late Bronze Age",
-            "Late Cypriot"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age",
+              "Late Cypriot"
+            ]
+          },
           "id": "p083p5rpb46",
           "label": "Late Bronze Age (= Late Cypriot)",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age"
+            "eng-latn": "Late Bronze Age (= Late Cypriot)"
           },
           "source": {
             "locator": "page 154",
@@ -20302,15 +20711,17 @@
           "type": "PeriodDefinition"
         },
         "p083p5rrnpp": {
-          "alternateLabel": [
-            "New Palace",
-            "Neopalatial"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "New Palace",
+              "Neopalatial"
+            ]
+          },
           "editorialNote": "\"(= Middle Minoan III, Late Minoan IA and B)\"",
           "id": "p083p5rrnpp",
           "label": "New Palace (Neopalatial)",
           "localizedLabel": {
-            "eng-latn": "New Palace"
+            "eng-latn": "New Palace (Neopalatial)"
           },
           "source": {
             "locator": "page 120",
@@ -20537,14 +20948,16 @@
           "type": "PeriodDefinition"
         },
         "p083p5rw9rf": {
-          "alternateLabel": [
-            "Protoliterate",
-            "Uruk"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Protoliterate",
+              "Uruk"
+            ]
+          },
           "id": "p083p5rw9rf",
           "label": "Protoliterate (Uruk)",
           "localizedLabel": {
-            "eng-latn": "Protoliterate"
+            "eng-latn": "Protoliterate (Uruk)"
           },
           "source": {
             "locator": "page 29",
@@ -20580,14 +20993,16 @@
           "type": "PeriodDefinition"
         },
         "p083p5rwbk3": {
-          "alternateLabel": [
-            "Early Dynastic",
-            "Archaic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Dynastic",
+              "Archaic"
+            ]
+          },
           "id": "p083p5rwbk3",
           "label": "Early Dynastic (Archaic)",
           "localizedLabel": {
-            "eng-latn": "Early Dynastic"
+            "eng-latn": "Early Dynastic (Archaic)"
           },
           "source": {
             "locator": "page 78",
@@ -20646,15 +21061,17 @@
           "type": "PeriodDefinition"
         },
         "p083p5rwk9g": {
-          "alternateLabel": [
-            "Orientalizing",
-            "Early Archaic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Orientalizing",
+              "Early Archaic"
+            ]
+          },
           "editorialNote": "Gates discusses Greek cities that are now in the territory of Turkey, although he does not refer to Anatolia specifically.",
           "id": "p083p5rwk9g",
           "label": "Orientalizing (Early Archaic)",
           "localizedLabel": {
-            "eng-latn": "Orientalizing"
+            "eng-latn": "Orientalizing (Early Archaic)"
           },
           "source": {
             "locator": "page 193",
@@ -20686,14 +21103,16 @@
           "type": "PeriodDefinition"
         },
         "p083p5rwkfs": {
-          "alternateLabel": [
-            "Harappan"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Harappan"
+            ]
+          },
           "editorialNote": "Indus Valley is defined as \"a region now situated in modern Pakistan and north-west India\"",
           "id": "p083p5rwkfs",
           "label": "Harappan, or Mature",
           "localizedLabel": {
-            "eng-latn": "Harappan"
+            "eng-latn": "Harappan, or Mature"
           },
           "source": {
             "locator": "page 67",
@@ -20835,13 +21254,15 @@
     "p086kj9": {
       "definitions": {
         "p086kj9235v": {
-          "alternateLabel": [
-            "British"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "British"
+            ]
+          },
           "id": "p086kj9235v",
           "label": "British 1763-1783",
           "localizedLabel": {
-            "eng-latn": "British"
+            "eng-latn": "British 1763-1783"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -20866,13 +21287,15 @@
           "url": "http://opencontext.org/types/474648DF-D7C7-4C7D-408F-EFEE98DCCFEB"
         },
         "p086kj924nt": {
-          "alternateLabel": [
-            "18th Century::3rd quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "18th Century::3rd quarter"
+            ]
+          },
           "id": "p086kj924nt",
           "label": "18th Century::3rd quarter (1750 - 1774)",
           "localizedLabel": {
-            "eng-latn": "18th Century::3rd quarter"
+            "eng-latn": "18th Century::3rd quarter (1750 - 1774)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -21065,13 +21488,15 @@
           "url": "http://opencontext.org/types/E2D7C68F-5457-48F3-A8B5-65CED1F6BDF8"
         },
         "p086kj92hb4": {
-          "alternateLabel": [
-            "Glades II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Glades II"
+            ]
+          },
           "id": "p086kj92hb4",
           "label": "Glades II, A.D. 750-1200",
           "localizedLabel": {
-            "eng-latn": "Glades II"
+            "eng-latn": "Glades II, A.D. 750-1200"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -21264,13 +21689,15 @@
           "url": "http://opencontext.org/types/7D0BAB0B-7F90-47DB-D764-95B4D190DB6C"
         },
         "p086kj92szg": {
-          "alternateLabel": [
-            "Glades III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Glades III"
+            ]
+          },
           "id": "p086kj92szg",
           "label": "Glades III, A.D. 1000-1700",
           "localizedLabel": {
-            "eng-latn": "Glades III"
+            "eng-latn": "Glades III, A.D. 1000-1700"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -21435,13 +21862,15 @@
           "url": "http://opencontext.org/types/C3471B8A-2495-490D-6EBC-25028C3ABC5F"
         },
         "p086kj932pt": {
-          "alternateLabel": [
-            "Indian Pond"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Indian Pond"
+            ]
+          },
           "id": "p086kj932pt",
           "label": "Indian Pond A.D. 950-contact",
           "localizedLabel": {
-            "eng-latn": "Indian Pond"
+            "eng-latn": "Indian Pond A.D. 950-contact"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -21634,13 +22063,15 @@
           "url": "http://opencontext.org/types/742FE59A-79A1-4F17-0E9B-69425681AE2B"
         },
         "p086kj93btj": {
-          "alternateLabel": [
-            "18th Century::1st half"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "18th Century::1st half"
+            ]
+          },
           "id": "p086kj93btj",
           "label": "18th Century::1st half (1700 - 1749)",
           "localizedLabel": {
-            "eng-latn": "18th Century::1st half"
+            "eng-latn": "18th Century::1st half (1700 - 1749)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -21665,13 +22096,15 @@
           "url": "http://opencontext.org/types/CF6FA5BC-8769-4356-7F82-5BF8F5CE7FA6"
         },
         "p086kj93gmq": {
-          "alternateLabel": [
-            "Paleoindian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Paleoindian"
+            ]
+          },
           "id": "p086kj93gmq",
           "label": "Paleoindian, 10000 B.C.-8500 B.C.",
           "localizedLabel": {
-            "eng-latn": "Paleoindian"
+            "eng-latn": "Paleoindian, 10000 B.C.-8500 B.C."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -21724,13 +22157,15 @@
           "url": "http://opencontext.org/types/16A1F520-91C5-43C5-21AE-65A2405ABD3E"
         },
         "p086kj93hq2": {
-          "alternateLabel": [
-            "WW I & Aftermath"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "WW I & Aftermath"
+            ]
+          },
           "id": "p086kj93hq2",
           "label": "WW I & Aftermath 1917-1920",
           "localizedLabel": {
-            "eng-latn": "WW I & Aftermath"
+            "eng-latn": "WW I & Aftermath 1917-1920"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -22091,13 +22526,15 @@
           "url": "http://opencontext.org/types/8CE2783D-E3FA-4F4D-9970-21E6BE1E560E"
         },
         "p086kj946k9": {
-          "alternateLabel": [
-            "Antebellum"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Antebellum"
+            ]
+          },
           "id": "p086kj946k9",
           "label": "Antebellum (1821-1861)",
           "localizedLabel": {
-            "eng-latn": "Antebellum"
+            "eng-latn": "Antebellum (1821-1861)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA34",
           "spatialCoverage": [
@@ -22178,13 +22615,15 @@
           "url": "http://opencontext.org/types/178F7FD9-921F-49D5-FB87-DF9B4A1D7F55"
         },
         "p086kj948gv": {
-          "alternateLabel": [
-            "18th Century::2nd quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "18th Century::2nd quarter"
+            ]
+          },
           "id": "p086kj948gv",
           "label": "18th Century::2nd quarter (1725 - 1749)",
           "localizedLabel": {
-            "eng-latn": "18th Century::2nd quarter"
+            "eng-latn": "18th Century::2nd quarter (1725 - 1749)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -22265,13 +22704,15 @@
           "url": "http://opencontext.org/types/2F559B39-505A-4857-B623-7999C1D9B3FE"
         },
         "p086kj94c64": {
-          "alternateLabel": [
-            "19th Century::4th quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "19th Century::4th quarter"
+            ]
+          },
           "id": "p086kj94c64",
           "label": "19th Century::4th quarter (1875 - 1899)",
           "localizedLabel": {
-            "eng-latn": "19th Century::4th quarter"
+            "eng-latn": "19th Century::4th quarter (1875 - 1899)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -22324,13 +22765,15 @@
           "url": "http://opencontext.org/types/A0835291-1BBC-4BD0-0960-1FB93FB0B21E"
         },
         "p086kj94dk3": {
-          "alternateLabel": [
-            "19th Century::1st half"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "19th Century::1st half"
+            ]
+          },
           "id": "p086kj94dk3",
           "label": "19th Century::1st half (1800 - 1849)",
           "localizedLabel": {
-            "eng-latn": "19th Century::1st half"
+            "eng-latn": "19th Century::1st half (1800 - 1849)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -22383,13 +22826,15 @@
           "url": "http://opencontext.org/types/EC6BFE35-73FC-43C7-BBF5-F568779CDD19"
         },
         "p086kj94mbh": {
-          "alternateLabel": [
-            "20th Century::2nd half"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "20th Century::2nd half"
+            ]
+          },
           "id": "p086kj94mbh",
           "label": "20th Century::2nd half (1950 - 1999)",
           "localizedLabel": {
-            "eng-latn": "20th Century::2nd half"
+            "eng-latn": "20th Century::2nd half (1950 - 1999)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -22414,13 +22859,15 @@
           "url": "http://opencontext.org/types/D5F22DF3-7393-4C99-A19D-F21632B181A0"
         },
         "p086kj94nmg": {
-          "alternateLabel": [
-            "20th Century::1st quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "20th Century::1st quarter"
+            ]
+          },
           "id": "p086kj94nmg",
           "label": "20th Century::1st quarter (1900 - 1924)",
           "localizedLabel": {
-            "eng-latn": "20th Century::1st quarter"
+            "eng-latn": "20th Century::1st quarter (1900 - 1924)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -22445,13 +22892,15 @@
           "url": "http://opencontext.org/types/45835294-4799-470D-C99E-EBAAE2820888"
         },
         "p086kj94pwf": {
-          "alternateLabel": [
-            "Post-Reconstruction"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Post-Reconstruction"
+            ]
+          },
           "id": "p086kj94pwf",
           "label": "Post-Reconstruction 1880-1897",
           "localizedLabel": {
-            "eng-latn": "Post-Reconstruction"
+            "eng-latn": "Post-Reconstruction 1880-1897"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -22756,13 +23205,15 @@
           "url": "http://opencontext.org/types/3190E482-744D-4593-266A-240C8652E3C2"
         },
         "p086kj95c6c": {
-          "alternateLabel": [
-            "Statehood & Antebellum"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Statehood & Antebellum"
+            ]
+          },
           "id": "p086kj95c6c",
           "label": "Statehood & Antebellum 1845-1860",
           "localizedLabel": {
-            "eng-latn": "Statehood & Antebellum"
+            "eng-latn": "Statehood & Antebellum 1845-1860"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -22815,13 +23266,15 @@
           "url": "http://opencontext.org/types/06A6670A-782D-464B-78EE-3260AA5963B7"
         },
         "p086kj95kss": {
-          "alternateLabel": [
-            "17th Century::2nd quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "17th Century::2nd quarter"
+            ]
+          },
           "id": "p086kj95kss",
           "label": "17th Century::2nd quarter (1625 - 1649)",
           "localizedLabel": {
-            "eng-latn": "17th Century::2nd quarter"
+            "eng-latn": "17th Century::2nd quarter (1625 - 1649)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -23568,13 +24021,15 @@
           "url": "http://opencontext.org/types/A47D1EA7-20C1-4518-DCF5-46E6E096545E"
         },
         "p086kj96z3n": {
-          "alternateLabel": [
-            "Early Woodland"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Woodland"
+            ]
+          },
           "id": "p086kj96z3n",
           "label": "Early Woodland (1200 B.C. - 299 A.D.)",
           "localizedLabel": {
-            "eng-latn": "Early Woodland"
+            "eng-latn": "Early Woodland (1200 B.C. - 299 A.D.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -23991,13 +24446,15 @@
           "url": "http://opencontext.org/types/C7DF6332-F87A-443F-B319-679EBF7C87BF"
         },
         "p086kj97wnn": {
-          "alternateLabel": [
-            "19th Century::3rd quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "19th Century::3rd quarter"
+            ]
+          },
           "id": "p086kj97wnn",
           "label": "19th Century::3rd quarter (1850 - 1874)",
           "localizedLabel": {
-            "eng-latn": "19th Century::3rd quarter"
+            "eng-latn": "19th Century::3rd quarter (1850 - 1874)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -24106,13 +24563,15 @@
           "url": "http://opencontext.org/types/35F5F056-4182-4331-24D0-6495CD154109"
         },
         "p086kj983gf": {
-          "alternateLabel": [
-            "The New Dominion"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "The New Dominion"
+            ]
+          },
           "id": "p086kj983gf",
           "label": "The New Dominion (1946 - 1988)",
           "localizedLabel": {
-            "eng-latn": "The New Dominion"
+            "eng-latn": "The New Dominion (1946 - 1988)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -24277,13 +24736,15 @@
           "url": "http://opencontext.org/types/8A7AB37F-D71E-4232-698D-63C1630F5A80"
         },
         "p086kj98d84": {
-          "alternateLabel": [
-            "St. Johns"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "St. Johns"
+            ]
+          },
           "id": "p086kj98d84",
           "label": "St. Johns, 700 B.C.-A.D. 1500",
           "localizedLabel": {
-            "eng-latn": "St. Johns"
+            "eng-latn": "St. Johns, 700 B.C.-A.D. 1500"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -24336,13 +24797,15 @@
           "url": "http://opencontext.org/types/AFE77FAF-3C66-4010-FB78-CB2D3B3C2BC6"
         },
         "p086kj98fpd": {
-          "alternateLabel": [
-            "Woodland"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Woodland"
+            ]
+          },
           "id": "p086kj98fpd",
           "label": "Woodland (1200 B.C. - 1606 A.D.)",
           "localizedLabel": {
-            "eng-latn": "Woodland"
+            "eng-latn": "Woodland (1200 B.C. - 1606 A.D.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -24395,13 +24858,15 @@
           "url": "http://opencontext.org/types/186C4457-203C-4001-F08D-A400BCB7ECA6"
         },
         "p086kj98jxm": {
-          "alternateLabel": [
-            "Reconstruction"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Reconstruction"
+            ]
+          },
           "id": "p086kj98jxm",
           "label": "Reconstruction 1866-1879",
           "localizedLabel": {
-            "eng-latn": "Reconstruction"
+            "eng-latn": "Reconstruction 1866-1879"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -24678,13 +25143,15 @@
           "url": "http://opencontext.org/types/495A09EC-3838-4E8B-CFD7-689887430638"
         },
         "p086kj98vgx": {
-          "alternateLabel": [
-            "Territorial"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Territorial"
+            ]
+          },
           "id": "p086kj98vgx",
           "label": "Territorial (1804-1820)",
           "localizedLabel": {
-            "eng-latn": "Territorial"
+            "eng-latn": "Territorial (1804-1820)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA17",
           "spatialCoverage": [
@@ -24709,14 +25176,17 @@
           "url": "http://opencontext.org/types/153C21D9-5CF8-42BD-6089-2E08568BBF03"
         },
         "p086kj98vq9": {
-          "alternateLabel": [
-            "Seminole",
-            " 2nd War to 3rd"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Seminole",
+              " 2nd War to 3rd",
+              "Seminole, 2nd War to 3rd"
+            ]
+          },
           "id": "p086kj98vq9",
           "label": "Seminole, 2nd War to 3rd 1835-1855",
           "localizedLabel": {
-            "eng-latn": "Seminole, 2nd War to 3rd"
+            "eng-latn": "Seminole, 2nd War to 3rd 1835-1855"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -24825,13 +25295,15 @@
           "url": "http://opencontext.org/types/BCAF0CAF-D4A6-42E0-EB7A-5E403C9BDD4F"
         },
         "p086kj9947n": {
-          "alternateLabel": [
-            "17th Century::4th quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "17th Century::4th quarter"
+            ]
+          },
           "id": "p086kj9947n",
           "label": "17th Century::4th quarter (1675 - 1699)",
           "localizedLabel": {
-            "eng-latn": "17th Century::4th quarter"
+            "eng-latn": "17th Century::4th quarter (1675 - 1699)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -24884,13 +25356,15 @@
           "url": "http://opencontext.org/types/9D6D5BD4-4877-4E5F-8C77-8EA6A47C8D7B"
         },
         "p086kj996ck": {
-          "alternateLabel": [
-            "WW II & Aftermath"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "WW II & Aftermath"
+            ]
+          },
           "id": "p086kj996ck",
           "label": "WW II & Aftermath 1941-1950",
           "localizedLabel": {
-            "eng-latn": "WW II & Aftermath"
+            "eng-latn": "WW II & Aftermath 1941-1950"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -24915,13 +25389,15 @@
           "url": "http://opencontext.org/types/304BE504-79BF-471C-3A16-8723B3875371"
         },
         "p086kj997fj": {
-          "alternateLabel": [
-            "Belle Glade"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Belle Glade"
+            ]
+          },
           "id": "p086kj997fj",
           "label": "Belle Glade, 700 B.C.-A.D. 1700",
           "localizedLabel": {
-            "eng-latn": "Belle Glade"
+            "eng-latn": "Belle Glade, 700 B.C.-A.D. 1700"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -24946,13 +25422,15 @@
           "url": "http://opencontext.org/types/EA126D7F-F578-4E5D-D1B8-B4CF84A1F9E9"
         },
         "p086kj997h7": {
-          "alternateLabel": [
-            "17th Century::1st half"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "17th Century::1st half"
+            ]
+          },
           "id": "p086kj997h7",
           "label": "17th Century::1st half (1600 - 1649)",
           "localizedLabel": {
-            "eng-latn": "17th Century::1st half"
+            "eng-latn": "17th Century::1st half (1600 - 1649)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -24977,14 +25455,17 @@
           "url": "http://opencontext.org/types/0C0EC914-A371-44DD-DB16-7E5EA46BA597"
         },
         "p086kj998dh": {
-          "alternateLabel": [
-            "Seminole",
-            " 1st War to 2nd"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Seminole",
+              " 1st War to 2nd",
+              "Seminole, 1st War to 2nd"
+            ]
+          },
           "id": "p086kj998dh",
           "label": "Seminole, 1st War to 2nd 1817-1834",
           "localizedLabel": {
-            "eng-latn": "Seminole, 1st War to 2nd"
+            "eng-latn": "Seminole, 1st War to 2nd 1817-1834"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -25149,13 +25630,15 @@
           "url": "http://opencontext.org/types/2F3170C6-FCF8-409E-1FC0-0811FA363ACB"
         },
         "p086kj99m9g": {
-          "alternateLabel": [
-            "American Acquisition & Development"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "American Acquisition & Development"
+            ]
+          },
           "id": "p086kj99m9g",
           "label": "American Acquisition & Development 1821-45",
           "localizedLabel": {
-            "eng-latn": "American Acquisition & Development"
+            "eng-latn": "American Acquisition & Development 1821-45"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -25348,13 +25831,15 @@
           "url": "http://opencontext.org/types/C87FBFF2-A6E5-405F-2F23-BCE4F6D504AF"
         },
         "p086kj99vs7": {
-          "alternateLabel": [
-            "18th Century::2nd/3rd quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "18th Century::2nd/3rd quarter"
+            ]
+          },
           "id": "p086kj99vs7",
           "label": "18th Century::2nd/3rd quarter (1725 - 1774)",
           "localizedLabel": {
-            "eng-latn": "18th Century::2nd/3rd quarter"
+            "eng-latn": "18th Century::2nd/3rd quarter (1725 - 1774)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -25491,13 +25976,15 @@
           "url": "http://opencontext.org/types/826032F9-3EF8-47DC-6EC3-04B4F290533F"
         },
         "p086kj9b399": {
-          "alternateLabel": [
-            "19th Century::2nd/3rd quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "19th Century::2nd/3rd quarter"
+            ]
+          },
           "id": "p086kj9b399",
           "label": "19th Century::2nd/3rd quarter (1825 - 1874)",
           "localizedLabel": {
-            "eng-latn": "19th Century::2nd/3rd quarter"
+            "eng-latn": "19th Century::2nd/3rd quarter (1825 - 1874)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -25606,13 +26093,15 @@
           "url": "http://opencontext.org/types/2481B6D1-9190-4899-3299-619CB32B0B55"
         },
         "p086kj9b8z4": {
-          "alternateLabel": [
-            "Swift Creek"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Swift Creek"
+            ]
+          },
           "id": "p086kj9b8z4",
           "label": "Swift Creek, 300 B.C.-A.D. 450",
           "localizedLabel": {
-            "eng-latn": "Swift Creek"
+            "eng-latn": "Swift Creek, 300 B.C.-A.D. 450"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -25637,13 +26126,15 @@
           "url": "http://opencontext.org/types/6C6CD1C0-329A-4045-AD06-D2665539FB73"
         },
         "p086kj9b92q": {
-          "alternateLabel": [
-            "20th Century::2nd/3rd quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "20th Century::2nd/3rd quarter"
+            ]
+          },
           "id": "p086kj9b92q",
           "label": "20th Century::2nd/3rd quarter (1925 - 1974)",
           "localizedLabel": {
-            "eng-latn": "20th Century::2nd/3rd quarter"
+            "eng-latn": "20th Century::2nd/3rd quarter (1925 - 1974)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -25696,13 +26187,15 @@
           "url": "http://opencontext.org/types/6B333A6B-3393-4859-51E2-A1C43606F243"
         },
         "p086kj9bcrz": {
-          "alternateLabel": [
-            "Cades Pond"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Cades Pond"
+            ]
+          },
           "id": "p086kj9bcrz",
           "label": "Cades Pond 300 B.C.-A.D. 800",
           "localizedLabel": {
-            "eng-latn": "Cades Pond"
+            "eng-latn": "Cades Pond 300 B.C.-A.D. 800"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -25783,13 +26276,15 @@
           "url": "http://opencontext.org/types/ADE27363-666D-402C-1DC8-B935DDF13E88"
         },
         "p086kj9bj2s": {
-          "alternateLabel": [
-            "Manasota"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Manasota"
+            ]
+          },
           "id": "p086kj9bj2s",
           "label": "Manasota, 700 B.C.-A.D. 700",
           "localizedLabel": {
-            "eng-latn": "Manasota"
+            "eng-latn": "Manasota, 700 B.C.-A.D. 700"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -26094,13 +26589,15 @@
           "url": "http://opencontext.org/types/A72E7B70-BA05-42C3-AC92-2201028080DE"
         },
         "p086kj9bzz2": {
-          "alternateLabel": [
-            "18th Century::1st quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "18th Century::1st quarter"
+            ]
+          },
           "id": "p086kj9bzz2",
           "label": "18th Century::1st quarter (1700 - 1724)",
           "localizedLabel": {
-            "eng-latn": "18th Century::1st quarter"
+            "eng-latn": "18th Century::1st quarter (1700 - 1724)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -26125,13 +26622,15 @@
           "url": "http://opencontext.org/types/ECA39B77-B04F-44D2-3FA7-62238AF14478"
         },
         "p086kj9c327": {
-          "alternateLabel": [
-            "Seminole"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Seminole"
+            ]
+          },
           "id": "p086kj9c327",
           "label": "Seminole 1716-present",
           "localizedLabel": {
-            "eng-latn": "Seminole"
+            "eng-latn": "Seminole 1716-present"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -26268,13 +26767,15 @@
           "url": "http://opencontext.org/types/8A27AE27-ADDC-4837-4564-DE132531ACEA"
         },
         "p086kj9c9vn": {
-          "alternateLabel": [
-            "Spanish-American War"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Spanish-American War"
+            ]
+          },
           "id": "p086kj9c9vn",
           "label": "Spanish-American War 1898-1916",
           "localizedLabel": {
-            "eng-latn": "Spanish-American War"
+            "eng-latn": "Spanish-American War 1898-1916"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -26355,14 +26856,17 @@
           "url": "http://opencontext.org/types/19DEB4FD-C5DD-4CF1-A03C-2209AD59B8F7"
         },
         "p086kj9ccn8": {
-          "alternateLabel": [
-            "Seminole",
-            " 3rd War onward"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Seminole",
+              " 3rd War onward",
+              "Seminole, 3rd War onward"
+            ]
+          },
           "id": "p086kj9ccn8",
           "label": "Seminole, 3rd War onward, 1856-",
           "localizedLabel": {
-            "eng-latn": "Seminole, 3rd War onward"
+            "eng-latn": "Seminole, 3rd War onward, 1856-"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -26555,13 +27059,15 @@
           "url": "http://opencontext.org/types/ABDA2799-98F2-4D5A-9964-2832B8B00FC6"
         },
         "p086kj9cm7b": {
-          "alternateLabel": [
-            "World War I to World War II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "World War I to World War II"
+            ]
+          },
           "id": "p086kj9cm7b",
           "label": "World War I to World War II (1917 - 1945)",
           "localizedLabel": {
-            "eng-latn": "World War I to World War II"
+            "eng-latn": "World War I to World War II (1917 - 1945)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -26754,13 +27260,15 @@
           "url": "http://opencontext.org/types/BBACCE72-7B51-4E9B-9A69-0FF3CEC63EA5"
         },
         "p086kj9ctdr": {
-          "alternateLabel": [
-            "Contact Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Contact Period"
+            ]
+          },
           "id": "p086kj9ctdr",
           "label": "Contact Period (1607 - 1750)",
           "localizedLabel": {
-            "eng-latn": "Contact Period"
+            "eng-latn": "Contact Period (1607 - 1750)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -27065,13 +27573,15 @@
           "url": "http://opencontext.org/types/BE05B0E8-E27A-47FD-3E19-80794EDAA05E"
         },
         "p086kj9d84m": {
-          "alternateLabel": [
-            "20th Century"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "20th Century"
+            ]
+          },
           "id": "p086kj9d84m",
           "label": "20th Century (1900 - 1999)",
           "localizedLabel": {
-            "eng-latn": "20th Century"
+            "eng-latn": "20th Century (1900 - 1999)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -27264,13 +27774,15 @@
           "url": "http://opencontext.org/types/61D1FBB3-87DD-4D88-537C-30479877769E"
         },
         "p086kj9dfv4": {
-          "alternateLabel": [
-            "Safety Harbor"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Safety Harbor"
+            ]
+          },
           "id": "p086kj9dfv4",
           "label": "Safety Harbor, A.D. 1000-1500",
           "localizedLabel": {
-            "eng-latn": "Safety Harbor"
+            "eng-latn": "Safety Harbor, A.D. 1000-1500"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -27687,13 +28199,15 @@
           "url": "http://opencontext.org/types/BD4E4AEE-BF8B-4B3A-32F0-CF6C6B7547CC"
         },
         "p086kj9fcmf": {
-          "alternateLabel": [
-            "Middle Archaic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Archaic"
+            ]
+          },
           "id": "p086kj9fcmf",
           "label": "Middle Archaic (6500 - 3001 B.C.)",
           "localizedLabel": {
-            "eng-latn": "Middle Archaic"
+            "eng-latn": "Middle Archaic (6500 - 3001 B.C.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -27830,13 +28344,15 @@
           "url": "http://opencontext.org/types/AAAAFEBC-0FF6-4081-C80C-3AB706B4ECCA"
         },
         "p086kj9fnds": {
-          "alternateLabel": [
-            "17th Century::1st quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "17th Century::1st quarter"
+            ]
+          },
           "id": "p086kj9fnds",
           "label": "17th Century::1st quarter (1600 - 1624)",
           "localizedLabel": {
-            "eng-latn": "17th Century::1st quarter"
+            "eng-latn": "17th Century::1st quarter (1600 - 1624)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -27861,13 +28377,15 @@
           "url": "http://opencontext.org/types/97AA1EDD-B08F-4D27-DDC5-7C2196ABAA65"
         },
         "p086kj9frv2": {
-          "alternateLabel": [
-            "17th Century::2nd half"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "17th Century::2nd half"
+            ]
+          },
           "id": "p086kj9frv2",
           "label": "17th Century::2nd half (1650 - 1699)",
           "localizedLabel": {
-            "eng-latn": "17th Century::2nd half"
+            "eng-latn": "17th Century::2nd half (1650 - 1699)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -28032,13 +28550,15 @@
           "url": "http://opencontext.org/types/6DEDCFE7-5584-4E96-9795-204B7705069A"
         },
         "p086kj9g4c9": {
-          "alternateLabel": [
-            "Colonial"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Colonial"
+            ]
+          },
           "id": "p086kj9g4c9",
           "label": "Colonial (1700-1803)",
           "localizedLabel": {
-            "eng-latn": "Colonial"
+            "eng-latn": "Colonial (1700-1803)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA8",
           "spatialCoverage": [
@@ -28203,13 +28723,15 @@
           "url": "http://opencontext.org/types/C83686E7-C5DA-4BC9-DB3A-E187C1D99D62"
         },
         "p086kj9gbmd": {
-          "alternateLabel": [
-            "18th Century"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "18th Century"
+            ]
+          },
           "id": "p086kj9gbmd",
           "label": "18th Century (1700 - 1799)",
           "localizedLabel": {
-            "eng-latn": "18th Century"
+            "eng-latn": "18th Century (1700 - 1799)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -28710,13 +29232,15 @@
           "url": "http://opencontext.org/types/AAC8775A-472C-483E-F044-D7574E94EE94"
         },
         "p086kj9h55t": {
-          "alternateLabel": [
-            "19th c. American"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "19th c. American"
+            ]
+          },
           "id": "p086kj9h55t",
           "label": "Nineteenth C. American 1821-1899",
           "localizedLabel": {
-            "eng-latn": "19th c. American"
+            "eng-latn": "Nineteenth C. American 1821-1899"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -28825,13 +29349,15 @@
           "url": "http://opencontext.org/types/2D4B092C-EA60-487E-A2FA-CECD20A5E034"
         },
         "p086kj9hk3q": {
-          "alternateLabel": [
-            "17th Century"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "17th Century"
+            ]
+          },
           "id": "p086kj9hk3q",
           "label": "17th Century (1600 - 1699)",
           "localizedLabel": {
-            "eng-latn": "17th Century"
+            "eng-latn": "17th Century (1600 - 1699)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -28912,13 +29438,15 @@
           "url": "http://opencontext.org/types/12F99E4F-47F1-4701-DDD5-DF0D60AAF80C"
         },
         "p086kj9hqsk": {
-          "alternateLabel": [
-            "Post Cold War"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Post Cold War"
+            ]
+          },
           "id": "p086kj9hqsk",
           "label": "Post Cold War (1989 - Present)",
           "localizedLabel": {
-            "eng-latn": "Post Cold War"
+            "eng-latn": "Post Cold War (1989 - Present)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -29083,14 +29611,16 @@
           "url": "http://opencontext.org/types/ECC9AE2D-3548-40CD-9E4A-6D4AF9350DC8"
         },
         "p086kj9j3tt": {
-          "alternateLabel": [
-            "Terminal Late Woodland",
-            "Emergent Miss."
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Terminal Late Woodland",
+              "Emergent Miss."
+            ]
+          },
           "id": "p086kj9j3tt",
           "label": "Terminal Late Woodland (Emergent Miss.)",
           "localizedLabel": {
-            "eng-latn": "Terminal Late Woodland"
+            "eng-latn": "Terminal Late Woodland (Emergent Miss.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA16",
           "spatialCoverage": [
@@ -29171,13 +29701,15 @@
           "url": "http://opencontext.org/types/34D19695-ECF1-4436-0C1F-B68261CAC9E9"
         },
         "p086kj9j8fn": {
-          "alternateLabel": [
-            "Antebellum Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Antebellum Period"
+            ]
+          },
           "id": "p086kj9j8fn",
           "label": "Antebellum Period (1830 - 1860)",
           "localizedLabel": {
-            "eng-latn": "Antebellum Period"
+            "eng-latn": "Antebellum Period (1830 - 1860)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -29202,13 +29734,15 @@
           "url": "http://opencontext.org/types/93B43E77-43B2-4E00-94F2-DF62D35E7164"
         },
         "p086kj9j8wz": {
-          "alternateLabel": [
-            "20th c. American"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "20th c. American"
+            ]
+          },
           "id": "p086kj9j8wz",
           "label": "Twentieth C American",
           "localizedLabel": {
-            "eng-latn": "20th c. American"
+            "eng-latn": "Twentieth C American"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -29457,13 +29991,15 @@
           "url": "http://opencontext.org/types/3B9FFCD2-0BDF-4384-7187-5333708D9BC7"
         },
         "p086kj9jkgn": {
-          "alternateLabel": [
-            "Late Archaic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Archaic"
+            ]
+          },
           "id": "p086kj9jkgn",
           "label": "Late Archaic (3000 - 1201 B.C.)",
           "localizedLabel": {
-            "eng-latn": "Late Archaic"
+            "eng-latn": "Late Archaic (3000 - 1201 B.C.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -29516,13 +30052,15 @@
           "url": "http://opencontext.org/types/41B622F5-E47F-4DF2-CEEA-D9720CF7A05E"
         },
         "p086kj9jn9k": {
-          "alternateLabel": [
-            "Civil War"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Civil War"
+            ]
+          },
           "id": "p086kj9jn9k",
           "label": "Civil War (1861 - 1865)",
           "localizedLabel": {
-            "eng-latn": "Civil War"
+            "eng-latn": "Civil War (1861 - 1865)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -29547,13 +30085,15 @@
           "url": "http://opencontext.org/types/634ADFB8-84A0-4D35-002E-44E50B1C3842"
         },
         "p086kj9jndk": {
-          "alternateLabel": [
-            "Seminole-Colonization Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Seminole-Colonization Period"
+            ]
+          },
           "id": "p086kj9jndk",
           "label": "Seminole-Colonization Period 1750-1816",
           "localizedLabel": {
-            "eng-latn": "Seminole-Colonization Period"
+            "eng-latn": "Seminole-Colonization Period 1750-1816"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -29606,13 +30146,15 @@
           "url": "http://opencontext.org/types/D48E49CE-3B30-498D-C75B-C55B083FCBBC"
         },
         "p086kj9jqnh": {
-          "alternateLabel": [
-            "Early National Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early National Period"
+            ]
+          },
           "id": "p086kj9jqnh",
           "label": "Early National Period (1790 - 1829)",
           "localizedLabel": {
-            "eng-latn": "Early National Period"
+            "eng-latn": "Early National Period (1790 - 1829)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -29721,13 +30263,15 @@
           "url": "http://opencontext.org/types/952994BE-DD31-462E-B548-ACBBDE2EE436"
         },
         "p086kj9jvw2": {
-          "alternateLabel": [
-            "Late Woodland"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Woodland"
+            ]
+          },
           "id": "p086kj9jvw2",
           "label": "Late Woodland (1000 - 1606)",
           "localizedLabel": {
-            "eng-latn": "Late Woodland"
+            "eng-latn": "Late Woodland (1000 - 1606)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -29836,13 +30380,15 @@
           "url": "http://opencontext.org/types/E83D8362-AFAD-4644-8685-A34CC1436B6C"
         },
         "p086kj9kft3": {
-          "alternateLabel": [
-            "17th Century::3rd quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "17th Century::3rd quarter"
+            ]
+          },
           "id": "p086kj9kft3",
           "label": "17th Century::3rd quarter (1650 - 1674)",
           "localizedLabel": {
-            "eng-latn": "17th Century::3rd quarter"
+            "eng-latn": "17th Century::3rd quarter (1650 - 1674)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -29895,13 +30441,15 @@
           "url": "http://opencontext.org/types/09C441EC-2991-4D7B-C494-76643EB520A0"
         },
         "p086kj9kh9n": {
-          "alternateLabel": [
-            "Glades I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Glades I"
+            ]
+          },
           "id": "p086kj9kh9n",
           "label": "Glades I, 1000 B.C.-A.D. 750",
           "localizedLabel": {
-            "eng-latn": "Glades I"
+            "eng-latn": "Glades I, 1000 B.C.-A.D. 750"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -29954,13 +30502,15 @@
           "url": "http://opencontext.org/types/27EA910B-9622-4C41-CAC2-B673F3AB7CAB"
         },
         "p086kj9kkzk": {
-          "alternateLabel": [
-            "Transitional"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Transitional"
+            ]
+          },
           "id": "p086kj9kkzk",
           "label": "Transitional, 1000 B.C.-700 B.C.",
           "localizedLabel": {
-            "eng-latn": "Transitional"
+            "eng-latn": "Transitional, 1000 B.C.-700 B.C."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -30125,13 +30675,15 @@
           "url": "http://opencontext.org/types/132C6182-5039-4D87-3068-3AAD6470F1BF"
         },
         "p086kj9kvs9": {
-          "alternateLabel": [
-            "Colony to Nation"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Colony to Nation"
+            ]
+          },
           "id": "p086kj9kvs9",
           "label": "Colony to Nation (1751 - 1789)",
           "localizedLabel": {
-            "eng-latn": "Colony to Nation"
+            "eng-latn": "Colony to Nation (1751 - 1789)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -30156,13 +30708,15 @@
           "url": "http://opencontext.org/types/2CD70C87-E741-46A3-35F4-9AFD75DF5CCF"
         },
         "p086kj9kwkk": {
-          "alternateLabel": [
-            "Ft. Walton"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ft. Walton"
+            ]
+          },
           "id": "p086kj9kwkk",
           "label": "Ft. Walton A.D. 1000-1500",
           "localizedLabel": {
-            "eng-latn": "Ft. Walton"
+            "eng-latn": "Ft. Walton A.D. 1000-1500"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -30243,13 +30797,15 @@
           "url": "http://opencontext.org/types/D70B05BB-E9A1-4C2A-E20E-3879E5F0278B"
         },
         "p086kj9kxzj": {
-          "alternateLabel": [
-            "20th Century::1st half"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "20th Century::1st half"
+            ]
+          },
           "id": "p086kj9kxzj",
           "label": "20th Century::1st half (1900 - 1949)",
           "localizedLabel": {
-            "eng-latn": "20th Century::1st half"
+            "eng-latn": "20th Century::1st half (1900 - 1949)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -30330,13 +30886,15 @@
           "url": "http://opencontext.org/types/E286D32C-6267-4F92-E9AA-4DE71E84CDD3"
         },
         "p086kj9m2fd": {
-          "alternateLabel": [
-            "Urban/Industrial"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Urban/Industrial"
+            ]
+          },
           "id": "p086kj9m2fd",
           "label": "Urban / Industrial (1900-1960)",
           "localizedLabel": {
-            "eng-latn": "Urban/Industrial"
+            "eng-latn": "Urban / Industrial (1900-1960)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA18",
           "spatialCoverage": [
@@ -30417,13 +30975,15 @@
           "url": "http://opencontext.org/types/FBB65406-C10C-4D1A-C453-B9FD2616B610"
         },
         "p086kj9m6nk": {
-          "alternateLabel": [
-            "18th Century::2nd half"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "18th Century::2nd half"
+            ]
+          },
           "id": "p086kj9m6nk",
           "label": "18th Century::2nd half (1750 - 1799)",
           "localizedLabel": {
-            "eng-latn": "18th Century::2nd half"
+            "eng-latn": "18th Century::2nd half (1750 - 1799)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -30756,13 +31316,15 @@
           "url": "http://opencontext.org/types/561EBF02-B8F1-4A9F-0A0E-9AF7FC8E8FD9"
         },
         "p086kj9n5x7": {
-          "alternateLabel": [
-            "Boom Times"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Boom Times"
+            ]
+          },
           "id": "p086kj9n5x7",
           "label": "Boom Times 1921-1929",
           "localizedLabel": {
-            "eng-latn": "Boom Times"
+            "eng-latn": "Boom Times 1921-1929"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -30955,13 +31517,15 @@
           "url": "http://opencontext.org/types/D415A671-F1AE-412A-8E73-D333D7B306B9"
         },
         "p086kj9np4z": {
-          "alternateLabel": [
-            "1870-1930"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "1870-1930"
+            ]
+          },
           "id": "p086kj9np4z",
           "label": "1870 - 1930",
           "localizedLabel": {
-            "eng-latn": "1870-1930"
+            "eng-latn": "1870 - 1930"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR95",
           "spatialCoverage": [
@@ -31630,13 +32194,15 @@
           "url": "http://opencontext.org/types/63339B73-F076-4ACD-B897-60E75DC66A73"
         },
         "p086kj9pr6h": {
-          "alternateLabel": [
-            "Modern"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern"
+            ]
+          },
           "id": "p086kj9pr6h",
           "label": "Modern (Post 1950)",
           "localizedLabel": {
-            "eng-latn": "Modern"
+            "eng-latn": "Modern (Post 1950)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -31745,13 +32311,15 @@
           "url": "http://opencontext.org/types/F4CE6AB4-42A5-4169-A162-A089206A9B6E"
         },
         "p086kj9pv4q": {
-          "alternateLabel": [
-            "19th Century::1st quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "19th Century::1st quarter"
+            ]
+          },
           "id": "p086kj9pv4q",
           "label": "19th Century::1st quarter (1800 - 1825)",
           "localizedLabel": {
-            "eng-latn": "19th Century::1st quarter"
+            "eng-latn": "19th Century::1st quarter (1800 - 1825)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -31776,13 +32344,15 @@
           "url": "http://opencontext.org/types/4FDB5251-8ED3-497B-FD41-110A0365F6DF"
         },
         "p086kj9pxcn": {
-          "alternateLabel": [
-            "19th Century::2nd half"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "19th Century::2nd half"
+            ]
+          },
           "id": "p086kj9pxcn",
           "label": "19th Century::2nd half (1850 - 1899)",
           "localizedLabel": {
-            "eng-latn": "19th Century::2nd half"
+            "eng-latn": "19th Century::2nd half (1850 - 1899)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -31807,13 +32377,15 @@
           "url": "http://opencontext.org/types/AFE1EF29-FA17-4AD2-FE11-63E5C9083F0E"
         },
         "p086kj9q8fx": {
-          "alternateLabel": [
-            "St. Johns II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "St. Johns II"
+            ]
+          },
           "id": "p086kj9q8fx",
           "label": "St. Johns II, A.D. 800-1500",
           "localizedLabel": {
-            "eng-latn": "St. Johns II"
+            "eng-latn": "St. Johns II, A.D. 800-1500"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -32006,13 +32578,15 @@
           "url": "http://opencontext.org/types/33953028-54F0-4AE9-8555-0867AE7D2FDF"
         },
         "p086kj9qq6g": {
-          "alternateLabel": [
-            "Spanish-Second Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Spanish-Second Period"
+            ]
+          },
           "id": "p086kj9qq6g",
           "label": "Spanish-Second Period 1783-1821",
           "localizedLabel": {
-            "eng-latn": "Spanish-Second Period"
+            "eng-latn": "Spanish-Second Period 1783-1821"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -32121,13 +32695,15 @@
           "url": "http://opencontext.org/types/4FF94278-0012-4946-65AB-BE641ECB84C7"
         },
         "p086kj9qtfp": {
-          "alternateLabel": [
-            "Spanish-First Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Spanish-First Period"
+            ]
+          },
           "id": "p086kj9qtfp",
           "label": "Spanish-First Period 1513-1763",
           "localizedLabel": {
-            "eng-latn": "Spanish-First Period"
+            "eng-latn": "Spanish-First Period 1513-1763"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -32180,13 +32756,15 @@
           "url": "http://opencontext.org/types/AB3BD9D1-2F3C-4B7D-1685-4AE5ACA9AB0A"
         },
         "p086kj9qztj": {
-          "alternateLabel": [
-            "Prehistoric/Unknown"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Prehistoric/Unknown"
+            ]
+          },
           "id": "p086kj9qztj",
           "label": "Prehistoric/Unknown (15000 B.C. - 1606 A.D.)",
           "localizedLabel": {
-            "eng-latn": "Prehistoric/Unknown"
+            "eng-latn": "Prehistoric/Unknown (15000 B.C. - 1606 A.D.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -32435,13 +33013,15 @@
           "url": "http://opencontext.org/types/1970AC12-0CCD-47D6-EE48-DB810A849560"
         },
         "p086kj9rn4g": {
-          "alternateLabel": [
-            "American"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "American"
+            ]
+          },
           "id": "p086kj9rn4g",
           "label": "American 1821-present",
           "localizedLabel": {
-            "eng-latn": "American"
+            "eng-latn": "American 1821-present"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -32550,13 +33130,15 @@
           "url": "http://opencontext.org/types/7CDAA5F8-BB7A-4D9A-ACEC-1ECBD6883680"
         },
         "p086kj9rxqh": {
-          "alternateLabel": [
-            "Civil War"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Civil War"
+            ]
+          },
           "id": "p086kj9rxqh",
           "label": "Civil War 1861-1865",
           "localizedLabel": {
-            "eng-latn": "Civil War"
+            "eng-latn": "Civil War 1861-1865"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -32805,13 +33387,15 @@
           "url": "http://opencontext.org/types/0610FD9A-F341-417B-C07B-6D82664C8796"
         },
         "p086kj9sf59": {
-          "alternateLabel": [
-            "18th Century::4th quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "18th Century::4th quarter"
+            ]
+          },
           "id": "p086kj9sf59",
           "label": "18th Century::4th quarter (1775 - 1799)",
           "localizedLabel": {
-            "eng-latn": "18th Century::4th quarter"
+            "eng-latn": "18th Century::4th quarter (1775 - 1799)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -32836,13 +33420,15 @@
           "url": "http://opencontext.org/types/CC1E3F6C-ED07-470F-21B3-983554047069"
         },
         "p086kj9sfdm": {
-          "alternateLabel": [
-            "20th Century::4th quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "20th Century::4th quarter"
+            ]
+          },
           "id": "p086kj9sfdm",
           "label": "20th Century::4th quarter (1975 - 1999)",
           "localizedLabel": {
-            "eng-latn": "20th Century::4th quarter"
+            "eng-latn": "20th Century::4th quarter (1975 - 1999)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -32979,13 +33565,15 @@
           "url": "http://opencontext.org/types/D3771A53-EEE3-4862-B600-14A5F7EB9776"
         },
         "p086kj9srkx": {
-          "alternateLabel": [
-            "Glades"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Glades"
+            ]
+          },
           "id": "p086kj9srkx",
           "label": "Glades, 1000 B.C.-A.D. 1700",
           "localizedLabel": {
-            "eng-latn": "Glades"
+            "eng-latn": "Glades, 1000 B.C.-A.D. 1700"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -33010,13 +33598,15 @@
           "url": "http://opencontext.org/types/D5D8804B-605F-4ACA-FB36-E09CFEFE1289"
         },
         "p086kj9srm9": {
-          "alternateLabel": [
-            "Paleo-Indian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Paleo-Indian"
+            ]
+          },
           "id": "p086kj9srm9",
           "label": "Paleo-Indian (15000 - 8501 B.C.)",
           "localizedLabel": {
-            "eng-latn": "Paleo-Indian"
+            "eng-latn": "Paleo-Indian (15000 - 8501 B.C.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -33181,13 +33771,15 @@
           "url": "http://opencontext.org/types/51781134-C327-460D-AD96-602454CE0678"
         },
         "p086kj9sxn4": {
-          "alternateLabel": [
-            "Early Industrial"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Industrial"
+            ]
+          },
           "id": "p086kj9sxn4",
           "label": "Early Industrial (1866-1899)",
           "localizedLabel": {
-            "eng-latn": "Early Industrial"
+            "eng-latn": "Early Industrial (1866-1899)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA32",
           "spatialCoverage": [
@@ -33408,13 +34000,15 @@
           "url": "http://opencontext.org/types/1FE7801E-6419-4C75-9BAB-277490ABED03"
         },
         "p086kj9t9hp": {
-          "alternateLabel": [
-            "Early Archaic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Archaic"
+            ]
+          },
           "id": "p086kj9t9hp",
           "label": "Early Archaic (8500 - 6501 B.C.)",
           "localizedLabel": {
-            "eng-latn": "Early Archaic"
+            "eng-latn": "Early Archaic (8500 - 6501 B.C.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -33551,13 +34145,15 @@
           "url": "http://opencontext.org/types/083A84F3-E0A0-4BAB-82F4-FF0554FF93B4"
         },
         "p086kj9tj9r": {
-          "alternateLabel": [
-            "Archaic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Archaic"
+            ]
+          },
           "id": "p086kj9tj9r",
           "label": "Archaic (8500 - 1201 B.C.)",
           "localizedLabel": {
-            "eng-latn": "Archaic"
+            "eng-latn": "Archaic (8500 - 1201 B.C.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -33694,13 +34290,15 @@
           "url": "http://opencontext.org/types/0F928470-4C21-423A-4AC6-0DC26D92A5CE"
         },
         "p086kj9tr4v": {
-          "alternateLabel": [
-            "Civil War"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Civil War"
+            ]
+          },
           "id": "p086kj9tr4v",
           "label": "Civil War (1861-1865)",
           "localizedLabel": {
-            "eng-latn": "Civil War"
+            "eng-latn": "Civil War (1861-1865)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA33",
           "spatialCoverage": [
@@ -33753,13 +34351,15 @@
           "url": "http://opencontext.org/types/72F92326-E950-4075-21EC-7288AF2845C7"
         },
         "p086kj9ttng": {
-          "alternateLabel": [
-            "Early/Middle Woodland"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early/Middle Woodland"
+            ]
+          },
           "id": "p086kj9ttng",
           "label": "Early/Middle Woodland (1200 B.C. - 999 A.D.)",
           "localizedLabel": {
-            "eng-latn": "Early/Middle Woodland"
+            "eng-latn": "Early/Middle Woodland (1200 B.C. - 999 A.D.)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -33784,13 +34384,15 @@
           "url": "http://opencontext.org/types/EEABA899-74E4-4299-B960-79752EE8FCB2"
         },
         "p086kj9twsd": {
-          "alternateLabel": [
-            "Depression/New Deal"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Depression/New Deal"
+            ]
+          },
           "id": "p086kj9twsd",
           "label": "Depression/New Deal 1930-1940",
           "localizedLabel": {
-            "eng-latn": "Depression/New Deal"
+            "eng-latn": "Depression/New Deal 1930-1940"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -33815,13 +34417,15 @@
           "url": "http://opencontext.org/types/943655DD-15E8-4F29-932B-46DAF670FDA4"
         },
         "p086kj9v37h": {
-          "alternateLabel": [
-            "Caloosahatchee"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Caloosahatchee"
+            ]
+          },
           "id": "p086kj9v37h",
           "label": "Caloosahatchee 500 B.C.-1700 A.D.",
           "localizedLabel": {
-            "eng-latn": "Caloosahatchee"
+            "eng-latn": "Caloosahatchee 500 B.C.-1700 A.D."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -33846,13 +34450,15 @@
           "url": "http://opencontext.org/types/5AC649C4-E169-49E5-09B0-C2F501D4F225"
         },
         "p086kj9v6zd": {
-          "alternateLabel": [
-            "Hickory Pond"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hickory Pond"
+            ]
+          },
           "id": "p086kj9v6zd",
           "label": "Hickory Pond, A.D. 800-1250",
           "localizedLabel": {
-            "eng-latn": "Hickory Pond"
+            "eng-latn": "Hickory Pond, A.D. 800-1250"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -33877,13 +34483,15 @@
           "url": "http://opencontext.org/types/D18910CF-4712-41CB-E697-6CA2AD4957EA"
         },
         "p086kj9v8jz": {
-          "alternateLabel": [
-            "Deptford"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Deptford"
+            ]
+          },
           "id": "p086kj9v8jz",
           "label": "Deptford 700 B.C.-300 B.C.",
           "localizedLabel": {
-            "eng-latn": "Deptford"
+            "eng-latn": "Deptford 700 B.C.-300 B.C."
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -34160,13 +34768,15 @@
           "url": "http://opencontext.org/types/30C0C06A-EF20-48F4-F6B8-011CAA015EBE"
         },
         "p086kj9vzjw": {
-          "alternateLabel": [
-            "Weeden Island"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Weeden Island"
+            ]
+          },
           "id": "p086kj9vzjw",
           "label": "Weeden Island A.D. 450-1000",
           "localizedLabel": {
-            "eng-latn": "Weeden Island"
+            "eng-latn": "Weeden Island A.D. 450-1000"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -34303,13 +34913,15 @@
           "url": "http://opencontext.org/types/C458ADC4-7082-4548-35E0-E6B4B03420B6"
         },
         "p086kj9w9vj": {
-          "alternateLabel": [
-            "Reconstruction and Growth"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Reconstruction and Growth"
+            ]
+          },
           "id": "p086kj9w9vj",
           "label": "Reconstruction and Growth (1866 - 1916)",
           "localizedLabel": {
-            "eng-latn": "Reconstruction and Growth"
+            "eng-latn": "Reconstruction and Growth (1866 - 1916)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -34362,13 +34974,15 @@
           "url": "http://opencontext.org/types/0E8CF331-A58E-4D7E-05BC-8A579A230958"
         },
         "p086kj9wbvt": {
-          "alternateLabel": [
-            "19th Century"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "19th Century"
+            ]
+          },
           "id": "p086kj9wbvt",
           "label": "19th Century (1800 - 1899)",
           "localizedLabel": {
-            "eng-latn": "19th Century"
+            "eng-latn": "19th Century (1800 - 1899)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -34533,13 +35147,15 @@
           "url": "http://opencontext.org/types/B0B00D35-F34E-4A8D-C709-9181A9D4882D"
         },
         "p086kj9wzb6": {
-          "alternateLabel": [
-            "20th Century::2nd quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "20th Century::2nd quarter"
+            ]
+          },
           "id": "p086kj9wzb6",
           "label": "20th Century::2nd quarter (1925 - 1949)",
           "localizedLabel": {
-            "eng-latn": "20th Century::2nd quarter"
+            "eng-latn": "20th Century::2nd quarter (1925 - 1949)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -34564,13 +35180,15 @@
           "url": "http://opencontext.org/types/1636C51B-97D0-42B5-BA12-F2BF7660D0C8"
         },
         "p086kj9x24q": {
-          "alternateLabel": [
-            "17th Century::2nd/3rd quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "17th Century::2nd/3rd quarter"
+            ]
+          },
           "id": "p086kj9x24q",
           "label": "17th Century::2nd/3rd quarter (1625 - 1674)",
           "localizedLabel": {
-            "eng-latn": "17th Century::2nd/3rd quarter"
+            "eng-latn": "17th Century::2nd/3rd quarter (1625 - 1674)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -34707,13 +35325,15 @@
           "url": "http://opencontext.org/types/541B8388-BCFF-4C49-E0D9-3198776CC5AE"
         },
         "p086kj9xd3c": {
-          "alternateLabel": [
-            "20th Century::3rd quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "20th Century::3rd quarter"
+            ]
+          },
           "id": "p086kj9xd3c",
           "label": "20th Century::3rd quarter (1950 - 1974)",
           "localizedLabel": {
-            "eng-latn": "20th Century::3rd quarter"
+            "eng-latn": "20th Century::3rd quarter (1950 - 1974)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -34962,13 +35582,15 @@
           "url": "http://opencontext.org/types/211B1300-9E8D-4783-9047-002CA1571A32"
         },
         "p086kj9xtn8": {
-          "alternateLabel": [
-            "First Spanish Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "First Spanish Period"
+            ]
+          },
           "id": "p086kj9xtn8",
           "label": "First Spanish Period 1513-1599",
           "localizedLabel": {
-            "eng-latn": "First Spanish Period"
+            "eng-latn": "First Spanish Period 1513-1599"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
@@ -35609,13 +36231,15 @@
           "url": "http://opencontext.org/types/7EC753E6-EC7F-41DF-67A9-EC7F5073330F"
         },
         "p086kj9zswj": {
-          "alternateLabel": [
-            "19th Century::2nd quarter"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "19th Century::2nd quarter"
+            ]
+          },
           "id": "p086kj9zswj",
           "label": "19th Century::2nd quarter (1825 - 1849)",
           "localizedLabel": {
-            "eng-latn": "19th Century::2nd quarter"
+            "eng-latn": "19th Century::2nd quarter (1825 - 1849)"
           },
           "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
@@ -36233,13 +36857,15 @@
           "type": "PeriodDefinition"
         },
         "p08tf6p9dvg": {
-          "alternateLabel": [
-            "Neo-Assyrian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neo-Assyrian"
+            ]
+          },
           "id": "p08tf6p9dvg",
           "label": "Neo Assyrian",
           "localizedLabel": {
-            "eng-latn": "Neo-Assyrian"
+            "eng-latn": "Neo Assyrian"
           },
           "source": {
             "locator": "page 341",
@@ -36948,13 +37574,15 @@
           "type": "PeriodDefinition"
         },
         "p0bd66427t9": {
-          "alternateLabel": [
-            "Third Intermediate Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Third Intermediate Period"
+            ]
+          },
           "id": "p0bd66427t9",
           "label": "Third Intermediate period",
           "localizedLabel": {
-            "eng-latn": "Third Intermediate Period"
+            "eng-latn": "Third Intermediate period"
           },
           "source": {
             "locator": "page 586",
@@ -36981,9 +37609,11 @@
           "type": "PeriodDefinition"
         },
         "p0bd6642r9q": {
-          "alternateLabel": [
-            "Hyksos rule"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hyksos rule"
+            ]
+          },
           "editorialNote": "GeoDia had 1795-1550 B.C., and Hyksos from 1650-1550 B.C.",
           "id": "p0bd6642r9q",
           "label": "Second Intermediate Period",
@@ -37860,9 +38490,11 @@
           "type": "PeriodDefinition"
         },
         "p0ccnvbpfm3": {
-          "alternateLabel": [
-            "Proto-Classical"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Proto-Classical"
+            ]
+          },
           "editorialNote": "Brendel also calls this period \"Proto-Classical\" (e.g. 283ff).",
           "id": "p0ccnvbpfm3",
           "label": "Transitional",
@@ -38126,13 +38758,15 @@
           "type": "PeriodDefinition"
         },
         "p0cfv7g66d8": {
-          "alternateLabel": [
-            "Old Syrian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Old Syrian"
+            ]
+          },
           "id": "p0cfv7g66d8",
           "label": "Old Syrian Period",
           "localizedLabel": {
-            "eng-latn": "Old Syrian"
+            "eng-latn": "Old Syrian Period"
           },
           "source": {
             "locator": "page 367",
@@ -38435,13 +39069,15 @@
           "type": "PeriodDefinition"
         },
         "p0cfv7gpdxn": {
-          "alternateLabel": [
-            "New Syrian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "New Syrian"
+            ]
+          },
           "id": "p0cfv7gpdxn",
           "label": "New Syrian Period",
           "localizedLabel": {
-            "eng-latn": "New Syrian"
+            "eng-latn": "New Syrian Period"
           },
           "source": {
             "locator": "page 367",
@@ -38540,13 +39176,15 @@
           "type": "PeriodDefinition"
         },
         "p0cfv7gqtzs": {
-          "alternateLabel": [
-            "Monarchic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Monarchic"
+            ]
+          },
           "id": "p0cfv7gqtzs",
           "label": "monarchic period",
           "localizedLabel": {
-            "eng-latn": "Monarchic"
+            "eng-latn": "monarchic period"
           },
           "source": {
             "locator": "page 393",
@@ -38645,14 +39283,16 @@
           "type": "PeriodDefinition"
         },
         "p0cfv7gxhs2": {
-          "alternateLabel": [
-            "Early Canaanite"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Canaanite"
+            ]
+          },
           "editorialNote": "see also Mazar, 1992",
           "id": "p0cfv7gxhs2",
           "label": "Early Canaanite Period",
           "localizedLabel": {
-            "eng-latn": "Early Canaanite"
+            "eng-latn": "Early Canaanite Period"
           },
           "source": {
             "locator": "page 366-367",
@@ -38717,9 +39357,11 @@
     "p0cmdf9": {
       "definitions": {
         "p0cmdf94cnf": {
-          "alternateLabel": [
-            "Achaemenid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Achaemenid"
+            ]
+          },
           "id": "p0cmdf94cnf",
           "label": "Late Lydian",
           "localizedLabel": {
@@ -38748,9 +39390,11 @@
           "type": "PeriodDefinition"
         },
         "p0cmdf9kmfv": {
-          "alternateLabel": [
-            "Mermnad"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mermnad"
+            ]
+          },
           "id": "p0cmdf9kmfv",
           "label": "Middle Lydian",
           "localizedLabel": {
@@ -38779,9 +39423,11 @@
           "type": "PeriodDefinition"
         },
         "p0cmdf9ntkh": {
-          "alternateLabel": [
-            "Early Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Iron Age"
+            ]
+          },
           "id": "p0cmdf9ntkh",
           "label": "Early Lydian",
           "localizedLabel": {
@@ -39734,13 +40380,14 @@
     "p0dntkb": {
       "definitions": {
         "p0dntkb67vz": {
-          "alternateLabel": [
-            "Phase III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Phase III"
+            ]
+          },
           "id": "p0dntkb67vz",
           "label": "Fase III",
           "localizedLabel": {
-            "eng-latn": "Phase III",
             "ita-latn": "Fase III"
           },
           "note": "This period only applies to the indigenous necropolis of Monte Casasia in Sicily. The end date is provided by the assumption that the site was destroyed by the Carthaginians in 405 B.C.",
@@ -39769,13 +40416,14 @@
           "type": "PeriodDefinition"
         },
         "p0dntkbc6tn": {
-          "alternateLabel": [
-            "Phase II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Phase II"
+            ]
+          },
           "id": "p0dntkbc6tn",
           "label": "Fase II",
           "localizedLabel": {
-            "eng-latn": "Phase II",
             "ita-latn": "Fase II"
           },
           "note": "This period only applies to the indigenous necropolis of Monte Casasia in Sicily.",
@@ -39806,13 +40454,14 @@
           "type": "PeriodDefinition"
         },
         "p0dntkbcv4m": {
-          "alternateLabel": [
-            "Phase I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Phase I"
+            ]
+          },
           "id": "p0dntkbcv4m",
           "label": "Fase I",
           "localizedLabel": {
-            "eng-latn": "Phase I",
             "ita-latn": "Fase I"
           },
           "note": "This periodization only applies to the indigenous necropolis at Monte Casasia in Sicily.",
@@ -40462,14 +41111,16 @@
           "type": "PeriodDefinition"
         },
         "p0ff3dt3t2p": {
-          "alternateLabel": [
-            "Early Christian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Christian"
+            ]
+          },
           "editorialNote": "Maps pages 116, 119.",
           "id": "p0ff3dt3t2p",
           "label": "Early Christian (Britain, Ireland)",
           "localizedLabel": {
-            "eng-latn": "Early Christian"
+            "eng-latn": "Early Christian (Britain, Ireland)"
           },
           "source": {
             "locator": "page 211",
@@ -40596,14 +41247,16 @@
           "type": "PeriodDefinition"
         },
         "p0ff3dt8j6x": {
-          "alternateLabel": [
-            "Anglo-Saxon"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Anglo-Saxon"
+            ]
+          },
           "editorialNote": "Maps pages 110-111.",
           "id": "p0ff3dt8j6x",
           "label": "Anglo-Saxon (East Britain)",
           "localizedLabel": {
-            "eng-latn": "Anglo-Saxon"
+            "eng-latn": "Anglo-Saxon (East Britain)"
           },
           "source": {
             "locator": "page 211",
@@ -40682,9 +41335,11 @@
           "type": "PeriodDefinition"
         },
         "p0ff3dtmpwd": {
-          "alternateLabel": [
-            "Urnfield period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Urnfield period"
+            ]
+          },
           "id": "p0ff3dtmpwd",
           "label": "Hallstatt B",
           "localizedLabel": {
@@ -40883,9 +41538,11 @@
           "type": "PeriodDefinition"
         },
         "p0ff3dtxpjd": {
-          "alternateLabel": [
-            "Urnfield period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Urnfield period"
+            ]
+          },
           "id": "p0ff3dtxpjd",
           "label": "Hallstatt A",
           "localizedLabel": {
@@ -41679,14 +42336,16 @@
           "url": "http://finds.org.uk/database/terminology/period/id/66"
         },
         "p0gjgrsn5zn": {
-          "alternateLabel": [
-            "Lower Palaeolithic",
-            "Early Palaeolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Lower Palaeolithic",
+              "Early Palaeolithic"
+            ]
+          },
           "id": "p0gjgrsn5zn",
           "label": "Lower (Early) Palaeolithic",
           "localizedLabel": {
-            "eng-latn": "Lower Palaeolithic"
+            "eng-latn": "Lower (Early) Palaeolithic"
           },
           "spatialCoverage": [
             {
@@ -41872,14 +42531,16 @@
           "url": "http://finds.org.uk/database/terminology/period/id/6"
         },
         "p0gjgrswcr8": {
-          "alternateLabel": [
-            "Upper Palaeolithic",
-            "Late Palaeolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Upper Palaeolithic",
+              "Late Palaeolithic"
+            ]
+          },
           "id": "p0gjgrswcr8",
           "label": "Upper (Late) Palaeolithic",
           "localizedLabel": {
-            "eng-latn": "Upper Palaeolithic"
+            "eng-latn": "Upper (Late) Palaeolithic"
           },
           "spatialCoverage": [
             {
@@ -41975,14 +42636,15 @@
     "p0hrtx5": {
       "definitions": {
         "p0hrtx5dm4p": {
-          "alternateLabel": [
-            "Hallstatt-culture"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hallstatt-culture"
+            ]
+          },
           "editorialNote": "Come back later to this source to mine / match to formal p.175-222 & Celtic art periods p.431-450 (SB scanned) though the latter is mainly references to other writers.",
           "id": "p0hrtx5dm4p",
           "label": "Cultura de Hallstatt",
           "localizedLabel": {
-            "eng-latn": "Hallstatt-culture",
             "spa-latn": "Cultura de Hallstatt"
           },
           "spatialCoverage": [
@@ -42156,14 +42818,16 @@
           "type": "PeriodDefinition"
         },
         "p0j5frxvrwg": {
-          "alternateLabel": [
-            "Early Dynastic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Dynastic"
+            ]
+          },
           "editorialNote": "Removed due to inferences in GeoDia: al-'Ubaid (5500-4000 B.C.), Uruk (4000-3250 B.C.), Jamdat Nasr periods (3250-3000 B.C.), and Ur of the Chaldees (1150-800 B.C.). Note this quote p.15: \"At an archaeological congress of excavators held at Baghdad in 1929 it was agreed that the early stages of human settlement in south Mesopotamia could be classified n successive phases which should be called, after the places where the evidence for each was first discovered, the al-'Ubaid period, the Uruk period, the Jamdat Nasr period, and then the Early Dynastic period, towards the end of which (in IIIb) comes the First Dynasty of Ur.\" p.16: \"Archaeological excavation ... does not of itself offer an absolute chronology in years B.C./A.D.\"",
           "id": "p0j5frxvrwg",
           "label": "Early Dynastic period",
           "localizedLabel": {
-            "eng-latn": "Early Dynastic"
+            "eng-latn": "Early Dynastic period"
           },
           "note": "These are approximate dates.",
           "source": {
@@ -42254,14 +42918,16 @@
     "p0jtbzw": {
       "definitions": {
         "p0jtbzw33x8": {
-          "alternateLabel": [
-            "Late Bronze Age IB",
-            "Late Cypriot IB"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age IB",
+              "Late Cypriot IB"
+            ]
+          },
           "id": "p0jtbzw33x8",
           "label": "Late Bronze Age (Late Cypriot) IB",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age IB"
+            "eng-latn": "Late Bronze Age (Late Cypriot) IB"
           },
           "spatialCoverage": [
             {
@@ -42284,14 +42950,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzw3p99": {
-          "alternateLabel": [
-            "Middle Bronze Age I",
-            "Middle Cypriot I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age I",
+              "Middle Cypriot I"
+            ]
+          },
           "id": "p0jtbzw3p99",
           "label": "Middle Bronze Age (Middle Cypriot) I",
           "localizedLabel": {
-            "eng-latn": "Middle Bronze Age I"
+            "eng-latn": "Middle Bronze Age (Middle Cypriot) I"
           },
           "spatialCoverage": [
             {
@@ -42314,14 +42982,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzw6f7b": {
-          "alternateLabel": [
-            "Late Bronze Age IIA",
-            "Late Cypriot IIA"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age IIA",
+              "Late Cypriot IIA"
+            ]
+          },
           "id": "p0jtbzw6f7b",
           "label": "Late Bronze Age (Late Cypriot) IIA",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age IIA"
+            "eng-latn": "Late Bronze Age (Late Cypriot) IIA"
           },
           "spatialCoverage": [
             {
@@ -42344,14 +43014,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzw727b": {
-          "alternateLabel": [
-            "Middle Bronze Age III",
-            "Middle Cypriot III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age III",
+              "Middle Cypriot III"
+            ]
+          },
           "id": "p0jtbzw727b",
           "label": "Middle Bronze Age (Middle Cypriot) III",
           "localizedLabel": {
-            "eng-latn": "Middle Bronze Age III"
+            "eng-latn": "Middle Bronze Age (Middle Cypriot) III"
           },
           "spatialCoverage": [
             {
@@ -42374,14 +43046,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzw8gr5": {
-          "alternateLabel": [
-            "Geometric I",
-            "Cypro-Geometric I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Geometric I",
+              "Cypro-Geometric I"
+            ]
+          },
           "id": "p0jtbzw8gr5",
           "label": "Geometric (Cypro-Geometric) I",
           "localizedLabel": {
-            "eng-latn": "Geometric I"
+            "eng-latn": "Geometric (Cypro-Geometric) I"
           },
           "spatialCoverage": [
             {
@@ -42404,14 +43078,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzw8xcb": {
-          "alternateLabel": [
-            "Archaic II",
-            "Cypro-Archaic II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Archaic II",
+              "Cypro-Archaic II"
+            ]
+          },
           "id": "p0jtbzw8xcb",
           "label": "Archaic (Cypro-Archaic) II",
           "localizedLabel": {
-            "eng-latn": "Archaic II"
+            "eng-latn": "Archaic (Cypro-Archaic) II"
           },
           "spatialCoverage": [
             {
@@ -42434,14 +43110,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzw932g": {
-          "alternateLabel": [
-            "Geometric III",
-            "Cypro-Geometric III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Geometric III",
+              "Cypro-Geometric III"
+            ]
+          },
           "id": "p0jtbzw932g",
           "label": "Geometric (Cypro-Geometric) III",
           "localizedLabel": {
-            "eng-latn": "Geometric III"
+            "eng-latn": "Geometric (Cypro-Geometric) III"
           },
           "spatialCoverage": [
             {
@@ -42490,14 +43168,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwcs2w": {
-          "alternateLabel": [
-            "Middle Bronze Age II",
-            "Middle Cypriot II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age II",
+              "Middle Cypriot II"
+            ]
+          },
           "id": "p0jtbzwcs2w",
           "label": "Middle Bronze Age (Middle Cypriot) II",
           "localizedLabel": {
-            "eng-latn": "Middle Bronze Age II"
+            "eng-latn": "Middle Bronze Age (Middle Cypriot) II"
           },
           "spatialCoverage": [
             {
@@ -42546,14 +43226,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwfmq9": {
-          "alternateLabel": [
-            "Late Bronze Age IIB",
-            "Late Cypriot IIB"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age IIB",
+              "Late Cypriot IIB"
+            ]
+          },
           "id": "p0jtbzwfmq9",
           "label": "Late Bronze Age (Late Cypriot) IIB",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age IIB"
+            "eng-latn": "Late Bronze Age (Late Cypriot) IIB"
           },
           "spatialCoverage": [
             {
@@ -42576,14 +43258,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwfv22": {
-          "alternateLabel": [
-            "Late Bronze Age IIIB",
-            "Late Cypriot IIIB"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age IIIB",
+              "Late Cypriot IIIB"
+            ]
+          },
           "id": "p0jtbzwfv22",
           "label": "Late Bronze Age (Late Cypriot) IIIB",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age IIIB"
+            "eng-latn": "Late Bronze Age (Late Cypriot) IIIB"
           },
           "spatialCoverage": [
             {
@@ -42606,14 +43290,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwg63z": {
-          "alternateLabel": [
-            "Archaic I",
-            "Cypro-Archaic I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Archaic I",
+              "Cypro-Archaic I"
+            ]
+          },
           "id": "p0jtbzwg63z",
           "label": "Archaic (Cypro-Archaic) I",
           "localizedLabel": {
-            "eng-latn": "Archaic I"
+            "eng-latn": "Archaic (Cypro-Archaic) I"
           },
           "spatialCoverage": [
             {
@@ -42636,14 +43322,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwgxd7": {
-          "alternateLabel": [
-            "Classical I",
-            "Cypro-Classical I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Classical I",
+              "Cypro-Classical I"
+            ]
+          },
           "id": "p0jtbzwgxd7",
           "label": "Classical (Cypro-Classical) I",
           "localizedLabel": {
-            "eng-latn": "Classical I"
+            "eng-latn": "Classical (Cypro-Classical) I"
           },
           "spatialCoverage": [
             {
@@ -42666,14 +43354,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwhwbh": {
-          "alternateLabel": [
-            "Transitional",
-            "Philia Culture"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Transitional",
+              "Philia Culture"
+            ]
+          },
           "id": "p0jtbzwhwbh",
           "label": "Transitional (Philia Culture)",
           "localizedLabel": {
-            "eng-latn": "Transitional"
+            "eng-latn": "Transitional (Philia Culture)"
           },
           "spatialCoverage": [
             {
@@ -42723,14 +43413,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwkp48": {
-          "alternateLabel": [
-            "Late Bronze Age IA",
-            "Late Cypriot IA"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age IA",
+              "Late Cypriot IA"
+            ]
+          },
           "id": "p0jtbzwkp48",
           "label": "Late Bronze Age (Late Cypriot) IA",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age IA"
+            "eng-latn": "Late Bronze Age (Late Cypriot) IA"
           },
           "spatialCoverage": [
             {
@@ -42779,14 +43471,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwnc5f": {
-          "alternateLabel": [
-            "Early Bronze Age III",
-            "Early Cypriot III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Bronze Age III",
+              "Early Cypriot III"
+            ]
+          },
           "id": "p0jtbzwnc5f",
           "label": "Early Bronze Age (Early Cypriot) III",
           "localizedLabel": {
-            "eng-latn": "Early Bronze Age III"
+            "eng-latn": "Early Bronze Age (Early Cypriot) III"
           },
           "spatialCoverage": [
             {
@@ -42809,14 +43503,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwp3dn": {
-          "alternateLabel": [
-            "Geometric II",
-            "Cypro-Geometric II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Geometric II",
+              "Cypro-Geometric II"
+            ]
+          },
           "id": "p0jtbzwp3dn",
           "label": "Geometric (Cypro-Geometric) II",
           "localizedLabel": {
-            "eng-latn": "Geometric II"
+            "eng-latn": "Geometric (Cypro-Geometric) II"
           },
           "spatialCoverage": [
             {
@@ -42839,14 +43535,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwr3rh": {
-          "alternateLabel": [
-            "Classical II",
-            "Cypro-Classical II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Classical II",
+              "Cypro-Classical II"
+            ]
+          },
           "id": "p0jtbzwr3rh",
           "label": "Classical (Cypro-Classical) II",
           "localizedLabel": {
-            "eng-latn": "Classical II"
+            "eng-latn": "Classical (Cypro-Classical) II"
           },
           "spatialCoverage": [
             {
@@ -42869,14 +43567,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwr5gf": {
-          "alternateLabel": [
-            "Early Bronze Age I",
-            "Early Cypriot I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Bronze Age I",
+              "Early Cypriot I"
+            ]
+          },
           "id": "p0jtbzwr5gf",
           "label": "Early Bronze Age (Early Cypriot) I",
           "localizedLabel": {
-            "eng-latn": "Early Bronze Age I"
+            "eng-latn": "Early Bronze Age (Early Cypriot) I"
           },
           "spatialCoverage": [
             {
@@ -42979,14 +43679,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwt8d6": {
-          "alternateLabel": [
-            "Early Bronze Age II",
-            "Early Cypriot II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Bronze Age II",
+              "Early Cypriot II"
+            ]
+          },
           "id": "p0jtbzwt8d6",
           "label": "Early Bronze Age (Early Cypriot) II",
           "localizedLabel": {
-            "eng-latn": "Early Bronze Age II"
+            "eng-latn": "Early Bronze Age (Early Cypriot) II"
           },
           "spatialCoverage": [
             {
@@ -43009,14 +43711,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwtk9t": {
-          "alternateLabel": [
-            "Late Bronze Age IIIC",
-            "Late Cypriot IIIC"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age IIIC",
+              "Late Cypriot IIIC"
+            ]
+          },
           "id": "p0jtbzwtk9t",
           "label": "Late Bronze Age (Late Cypriot) IIIC",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age IIIC"
+            "eng-latn": "Late Bronze Age (Late Cypriot) IIIC"
           },
           "spatialCoverage": [
             {
@@ -43065,14 +43769,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzww7hd": {
-          "alternateLabel": [
-            "Late Bronze Age IIIA",
-            "Late Cypriot IIIA"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age IIIA",
+              "Late Cypriot IIIA"
+            ]
+          },
           "id": "p0jtbzww7hd",
           "label": "Late Bronze Age (Late Cypriot) IIIA",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age IIIA"
+            "eng-latn": "Late Bronze Age (Late Cypriot) IIIA"
           },
           "spatialCoverage": [
             {
@@ -43095,14 +43801,16 @@
           "type": "PeriodDefinition"
         },
         "p0jtbzwwmnz": {
-          "alternateLabel": [
-            "Late Bronze Age IIC",
-            "Late Cypriot IIC"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age IIC",
+              "Late Cypriot IIC"
+            ]
+          },
           "id": "p0jtbzwwmnz",
           "label": "Late Bronze Age (Late Cypriot) IIC",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age IIC"
+            "eng-latn": "Late Bronze Age (Late Cypriot) IIC"
           },
           "spatialCoverage": [
             {
@@ -43407,14 +44115,16 @@
           "type": "PeriodDefinition"
         },
         "p0kc8t6g2xc": {
-          "alternateLabel": [
-            "Uruk Period",
-            "Warka Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Uruk Period",
+              "Warka Period"
+            ]
+          },
           "id": "p0kc8t6g2xc",
           "label": "Uruk (Warka) Period",
           "localizedLabel": {
-            "eng-latn": "Uruk Period"
+            "eng-latn": "Uruk (Warka) Period"
           },
           "spatialCoverage": [
             {
@@ -43546,9 +44256,11 @@
     "p0kgptq": {
       "definitions": {
         "p0kgptq9qvc": {
-          "alternateLabel": [
-            "Middle Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"",
           "id": "p0kgptq9qvc",
           "label": "Middle Canaanite Age",
@@ -43597,9 +44309,11 @@
           "type": "PeriodDefinition"
         },
         "p0kgptqfs5b": {
-          "alternateLabel": [
-            "Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age"
+            ]
+          },
           "editorialNote": "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"",
           "id": "p0kgptqfs5b",
           "label": "Israelite Age",
@@ -43648,9 +44362,11 @@
           "type": "PeriodDefinition"
         },
         "p0kgptqgcs2": {
-          "alternateLabel": [
-            "Early Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"",
           "id": "p0kgptqgcs2",
           "label": "Early Canaanite Age",
@@ -43699,9 +44415,11 @@
           "type": "PeriodDefinition"
         },
         "p0kgptqv6b3": {
-          "alternateLabel": [
-            "pre-Israelite"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "pre-Israelite"
+            ]
+          },
           "editorialNote": "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"",
           "id": "p0kgptqv6b3",
           "label": "Canaanite Age",
@@ -45018,9 +45736,11 @@
     "p0kj6dj": {
       "definitions": {
         "p0kj6dj4bzp": {
-          "alternateLabel": [
-            "Fourth Armenian Monarchy of the Bagratids"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Fourth Armenian Monarchy of the Bagratids"
+            ]
+          },
           "id": "p0kj6dj4bzp",
           "label": "Fourth Armenian Monarchy",
           "localizedLabel": {
@@ -45131,13 +45851,15 @@
           "type": "PeriodDefinition"
         },
         "p0kj6dj68rm": {
-          "alternateLabel": [
-            "Arsacid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Arsacid"
+            ]
+          },
           "id": "p0kj6dj68rm",
           "label": "Arsacid period",
           "localizedLabel": {
-            "eng-latn": "Arsacid"
+            "eng-latn": "Arsacid period"
           },
           "source": {
             "locator": "pages 76, 83, 153",
@@ -45189,9 +45911,11 @@
           "type": "PeriodDefinition"
         },
         "p0kj6dj7pzf": {
-          "alternateLabel": [
-            "Median Monarchy"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Median Monarchy"
+            ]
+          },
           "editorialNote": "Deleted Kingdom of Commagene (163 B.C.-72 A.D.) on 10/20/14 due to problem with this end-date. Found these from the index entry for Armenia.",
           "id": "p0kj6dj7pzf",
           "label": "proto-Armenian Satrapy of Greater Armenia",
@@ -45359,13 +46083,15 @@
           "type": "PeriodDefinition"
         },
         "p0kj6djj5cn": {
-          "alternateLabel": [
-            "post-Arsacid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "post-Arsacid"
+            ]
+          },
           "id": "p0kj6djj5cn",
           "label": "post-Arsacid period",
           "localizedLabel": {
-            "eng-latn": "post-Arsacid"
+            "eng-latn": "post-Arsacid period"
           },
           "source": {
             "locator": "pages 152-153",
@@ -45472,9 +46198,11 @@
           "type": "PeriodDefinition"
         },
         "p0kj6djr5rv": {
-          "alternateLabel": [
-            "Second Monarchy of Great Armenia"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Second Monarchy of Great Armenia"
+            ]
+          },
           "id": "p0kj6djr5rv",
           "label": "Artaxiad Monarchy",
           "localizedLabel": {
@@ -45530,9 +46258,11 @@
           "type": "PeriodDefinition"
         },
         "p0kj6djwt67": {
-          "alternateLabel": [
-            "First Armenian Monarchy of the Orontids; Monarchy of Greater Armenia"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "First Armenian Monarchy of the Orontids; Monarchy of Greater Armenia"
+            ]
+          },
           "id": "p0kj6djwt67",
           "label": "Orontid First Monarchy",
           "localizedLabel": {
@@ -45605,9 +46335,11 @@
     "p0m63nj": {
       "definitions": {
         "p0m63nj24nd": {
-          "alternateLabel": [
-            "IA I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "IA I"
+            ]
+          },
           "id": "p0m63nj24nd",
           "label": "Iron Age I",
           "localizedLabel": {
@@ -45772,9 +46504,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj3kjh": {
-          "alternateLabel": [
-            "IA III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "IA III"
+            ]
+          },
           "id": "p0m63nj3kjh",
           "label": "Iron Age III",
           "localizedLabel": {
@@ -45803,13 +46537,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj3pm3": {
-          "alternateLabel": [
-            "Late Hellenistic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Hellenistic"
+            ]
+          },
           "id": "p0m63nj3pm3",
           "label": "Late Hellenistic Period",
           "localizedLabel": {
-            "eng-latn": "Late Hellenistic"
+            "eng-latn": "Late Hellenistic Period"
           },
           "spatialCoverage": [
             {
@@ -45862,9 +46598,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj4dkm": {
-          "alternateLabel": [
-            "MK"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "MK"
+            ]
+          },
           "id": "p0m63nj4dkm",
           "label": "Middle Kingdom",
           "localizedLabel": {
@@ -45921,9 +46659,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj4skv": {
-          "alternateLabel": [
-            "CG I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "CG I"
+            ]
+          },
           "id": "p0m63nj4skv",
           "label": "Cypro Geometric I",
           "localizedLabel": {
@@ -45952,13 +46692,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj575d": {
-          "alternateLabel": [
-            "Late Hellenistic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Hellenistic"
+            ]
+          },
           "id": "p0m63nj575d",
           "label": "Late Hellenistic Period",
           "localizedLabel": {
-            "eng-latn": "Late Hellenistic"
+            "eng-latn": "Late Hellenistic Period"
           },
           "spatialCoverage": [
             {
@@ -45987,13 +46729,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj57xq": {
-          "alternateLabel": [
-            "Neo Babylonian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neo Babylonian"
+            ]
+          },
           "id": "p0m63nj57xq",
           "label": "Neo Babylonian Period",
           "localizedLabel": {
-            "eng-latn": "Neo Babylonian"
+            "eng-latn": "Neo Babylonian Period"
           },
           "spatialCoverage": [
             {
@@ -46030,9 +46774,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj5pzw": {
-          "alternateLabel": [
-            "IB"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "IB"
+            ]
+          },
           "id": "p0m63nj5pzw",
           "label": "Intermediate Bronze Age",
           "localizedLabel": {
@@ -46061,13 +46807,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj633s": {
-          "alternateLabel": [
-            "Early Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Roman"
+            ]
+          },
           "id": "p0m63nj633s",
           "label": "Early Roman Period",
           "localizedLabel": {
-            "eng-latn": "Early Roman"
+            "eng-latn": "Early Roman Period"
           },
           "spatialCoverage": [
             {
@@ -46092,13 +46840,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj65bq": {
-          "alternateLabel": [
-            "Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Byzantine"
+            ]
+          },
           "id": "p0m63nj65bq",
           "label": "Byzantine Period",
           "localizedLabel": {
-            "eng-latn": "Byzantine"
+            "eng-latn": "Byzantine Period"
           },
           "spatialCoverage": [
             {
@@ -46123,13 +46873,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj66cc": {
-          "alternateLabel": [
-            "Ottoman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ottoman"
+            ]
+          },
           "id": "p0m63nj66cc",
           "label": "Ottoman Period",
           "localizedLabel": {
-            "eng-latn": "Ottoman"
+            "eng-latn": "Ottoman Period"
           },
           "spatialCoverage": [
             {
@@ -46166,13 +46918,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj699k": {
-          "alternateLabel": [
-            "Early Islamic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Islamic"
+            ]
+          },
           "id": "p0m63nj699k",
           "label": "Early Islamic Period",
           "localizedLabel": {
-            "eng-latn": "Early Islamic"
+            "eng-latn": "Early Islamic Period"
           },
           "spatialCoverage": [
             {
@@ -46209,9 +46963,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj6qws": {
-          "alternateLabel": [
-            "LC IIA-B"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "LC IIA-B"
+            ]
+          },
           "id": "p0m63nj6qws",
           "label": "Late Cypriot II A-B",
           "localizedLabel": {
@@ -46268,9 +47024,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj78xj": {
-          "alternateLabel": [
-            "IA I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "IA I"
+            ]
+          },
           "id": "p0m63nj78xj",
           "label": "Iron Age I",
           "localizedLabel": {
@@ -46311,13 +47069,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj7tfm": {
-          "alternateLabel": [
-            "Early Hellenistic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Hellenistic"
+            ]
+          },
           "id": "p0m63nj7tfm",
           "label": "Early Hellenistic Period",
           "localizedLabel": {
-            "eng-latn": "Early Hellenistic"
+            "eng-latn": "Early Hellenistic Period"
           },
           "spatialCoverage": [
             {
@@ -46342,13 +47102,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj7v3k": {
-          "alternateLabel": [
-            "Fatimid/Mameluke"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Fatimid/Mameluke"
+            ]
+          },
           "id": "p0m63nj7v3k",
           "label": "Fatimid/Mameluke Periods",
           "localizedLabel": {
-            "eng-latn": "Fatimid/Mameluke"
+            "eng-latn": "Fatimid/Mameluke Periods"
           },
           "spatialCoverage": [
             {
@@ -46385,9 +47147,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj7zfs": {
-          "alternateLabel": [
-            "IA IIC"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "IA IIC"
+            ]
+          },
           "id": "p0m63nj7zfs",
           "label": "Iron Age IIC",
           "localizedLabel": {
@@ -46428,13 +47192,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj833b": {
-          "alternateLabel": [
-            "Middle Hellenistic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Hellenistic"
+            ]
+          },
           "id": "p0m63nj833b",
           "label": "Middle Hellenistic Period",
           "localizedLabel": {
-            "eng-latn": "Middle Hellenistic"
+            "eng-latn": "Middle Hellenistic Period"
           },
           "spatialCoverage": [
             {
@@ -46459,9 +47225,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj83wz": {
-          "alternateLabel": [
-            "EB IV"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "EB IV"
+            ]
+          },
           "id": "p0m63nj83wz",
           "label": "Early Bronze Age IV",
           "localizedLabel": {
@@ -46502,9 +47270,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63nj8jfh": {
-          "alternateLabel": [
-            "MB II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "MB II"
+            ]
+          },
           "id": "p0m63nj8jfh",
           "label": "Middle Bronze Age II",
           "localizedLabel": {
@@ -46641,9 +47411,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njb86b": {
-          "alternateLabel": [
-            "LB I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "LB I"
+            ]
+          },
           "id": "p0m63njb86b",
           "label": "Late Bronze Age I",
           "localizedLabel": {
@@ -46684,9 +47456,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njbvnp": {
-          "alternateLabel": [
-            "EB I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "EB I"
+            ]
+          },
           "id": "p0m63njbvnp",
           "label": "Early Bronze Age I",
           "localizedLabel": {
@@ -46727,13 +47501,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njbxb9": {
-          "alternateLabel": [
-            "Early Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Roman"
+            ]
+          },
           "id": "p0m63njbxb9",
           "label": "Early Roman Period",
           "localizedLabel": {
-            "eng-latn": "Early Roman"
+            "eng-latn": "Early Roman Period"
           },
           "spatialCoverage": [
             {
@@ -46790,13 +47566,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njc4hd": {
-          "alternateLabel": [
-            "Early Hellenistic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Hellenistic"
+            ]
+          },
           "id": "p0m63njc4hd",
           "label": "Early Hellenistic Period",
           "localizedLabel": {
-            "eng-latn": "Early Hellenistic"
+            "eng-latn": "Early Hellenistic Period"
           },
           "spatialCoverage": [
             {
@@ -46825,9 +47603,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njc6qz": {
-          "alternateLabel": [
-            "LC IIC"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "LC IIC"
+            ]
+          },
           "id": "p0m63njc6qz",
           "label": "Late Cypriot II C",
           "localizedLabel": {
@@ -46856,9 +47636,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njcrhq": {
-          "alternateLabel": [
-            "EC"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "EC"
+            ]
+          },
           "id": "p0m63njcrhq",
           "label": "Early Cypriot",
           "localizedLabel": {
@@ -46943,13 +47725,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njdf2z": {
-          "alternateLabel": [
-            "Hellenistic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hellenistic"
+            ]
+          },
           "id": "p0m63njdf2z",
           "label": "Hellenistic Period",
           "localizedLabel": {
-            "eng-latn": "Hellenistic"
+            "eng-latn": "Hellenistic Period"
           },
           "spatialCoverage": [
             {
@@ -47002,13 +47786,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njdrpn": {
-          "alternateLabel": [
-            "Late Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Roman"
+            ]
+          },
           "id": "p0m63njdrpn",
           "label": "Late Roman Period",
           "localizedLabel": {
-            "eng-latn": "Late Roman"
+            "eng-latn": "Late Roman Period"
           },
           "spatialCoverage": [
             {
@@ -47041,13 +47827,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njdz8f": {
-          "alternateLabel": [
-            "Ottoman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ottoman"
+            ]
+          },
           "id": "p0m63njdz8f",
           "label": "Ottoman Period",
           "localizedLabel": {
-            "eng-latn": "Ottoman"
+            "eng-latn": "Ottoman Period"
           },
           "spatialCoverage": [
             {
@@ -47156,13 +47944,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njfbsc": {
-          "alternateLabel": [
-            "Early Islamic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Islamic"
+            ]
+          },
           "id": "p0m63njfbsc",
           "label": "Early Islamic Period",
           "localizedLabel": {
-            "eng-latn": "Early Islamic"
+            "eng-latn": "Early Islamic Period"
           },
           "spatialCoverage": [
             {
@@ -47187,9 +47977,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njfd2x": {
-          "alternateLabel": [
-            "MB III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "MB III"
+            ]
+          },
           "id": "p0m63njfd2x",
           "label": "Middle Bronze Age III",
           "localizedLabel": {
@@ -47230,9 +48022,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njfkpf": {
-          "alternateLabel": [
-            "CG III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "CG III"
+            ]
+          },
           "id": "p0m63njfkpf",
           "label": "Cypro Geometric III",
           "localizedLabel": {
@@ -47261,13 +48055,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njfmrd": {
-          "alternateLabel": [
-            "Middle Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Roman"
+            ]
+          },
           "id": "p0m63njfmrd",
           "label": "Middle Roman Period",
           "localizedLabel": {
-            "eng-latn": "Middle Roman"
+            "eng-latn": "Middle Roman Period"
           },
           "spatialCoverage": [
             {
@@ -47296,13 +48092,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njfppb": {
-          "alternateLabel": [
-            "Later Islamic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Later Islamic"
+            ]
+          },
           "id": "p0m63njfppb",
           "label": "Later Islamic Period",
           "localizedLabel": {
-            "eng-latn": "Later Islamic"
+            "eng-latn": "Later Islamic Period"
           },
           "spatialCoverage": [
             {
@@ -47339,13 +48137,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njfs4v": {
-          "alternateLabel": [
-            "Early Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Roman"
+            ]
+          },
           "id": "p0m63njfs4v",
           "label": "Early Roman Period",
           "localizedLabel": {
-            "eng-latn": "Early Roman"
+            "eng-latn": "Early Roman Period"
           },
           "spatialCoverage": [
             {
@@ -47370,13 +48170,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njfv4g": {
-          "alternateLabel": [
-            "Frankish/Ayyubid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Frankish/Ayyubid"
+            ]
+          },
           "id": "p0m63njfv4g",
           "label": "Frankish/Ayyubid Periods",
           "localizedLabel": {
-            "eng-latn": "Frankish/Ayyubid"
+            "eng-latn": "Frankish/Ayyubid Periods"
           },
           "spatialCoverage": [
             {
@@ -47413,13 +48215,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njgvtd": {
-          "alternateLabel": [
-            "Late Hellenistic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Hellenistic"
+            ]
+          },
           "id": "p0m63njgvtd",
           "label": "Late Hellenistic Period",
           "localizedLabel": {
-            "eng-latn": "Late Hellenistic"
+            "eng-latn": "Late Hellenistic Period"
           },
           "spatialCoverage": [
             {
@@ -47476,9 +48280,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njh7tb": {
-          "alternateLabel": [
-            "LP"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "LP"
+            ]
+          },
           "id": "p0m63njh7tb",
           "label": "Late Period",
           "localizedLabel": {
@@ -47563,13 +48369,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njjcn4": {
-          "alternateLabel": [
-            "Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Byzantine"
+            ]
+          },
           "id": "p0m63njjcn4",
           "label": "Byzantine Period",
           "localizedLabel": {
-            "eng-latn": "Byzantine"
+            "eng-latn": "Byzantine Period"
           },
           "spatialCoverage": [
             {
@@ -47662,13 +48470,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njk6fv": {
-          "alternateLabel": [
-            "Early Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Roman"
+            ]
+          },
           "id": "p0m63njk6fv",
           "label": "Early Roman Period",
           "localizedLabel": {
-            "eng-latn": "Early Roman"
+            "eng-latn": "Early Roman Period"
           },
           "spatialCoverage": [
             {
@@ -47697,13 +48507,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njm6n5": {
-          "alternateLabel": [
-            "Middle Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Roman"
+            ]
+          },
           "id": "p0m63njm6n5",
           "label": "Middle Roman Period",
           "localizedLabel": {
-            "eng-latn": "Middle Roman"
+            "eng-latn": "Middle Roman Period"
           },
           "spatialCoverage": [
             {
@@ -47784,9 +48596,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njmx32": {
-          "alternateLabel": [
-            "NK"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "NK"
+            ]
+          },
           "id": "p0m63njmx32",
           "label": "New Kingdom",
           "localizedLabel": {
@@ -47843,9 +48657,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njncbv": {
-          "alternateLabel": [
-            "EB"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "EB"
+            ]
+          },
           "id": "p0m63njncbv",
           "label": "Early Bronze Age",
           "localizedLabel": {
@@ -47874,9 +48690,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njnd5h": {
-          "alternateLabel": [
-            "CG II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "CG II"
+            ]
+          },
           "id": "p0m63njnd5h",
           "label": "Cypro Geometric II",
           "localizedLabel": {
@@ -47905,9 +48723,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njngrr": {
-          "alternateLabel": [
-            "MB"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "MB"
+            ]
+          },
           "id": "p0m63njngrr",
           "label": "Middle Bronze Age",
           "localizedLabel": {
@@ -47992,13 +48812,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njpjkx": {
-          "alternateLabel": [
-            "Hasmonean"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hasmonean"
+            ]
+          },
           "id": "p0m63njpjkx",
           "label": "Hasmonean Period",
           "localizedLabel": {
-            "eng-latn": "Hasmonean"
+            "eng-latn": "Hasmonean Period"
           },
           "spatialCoverage": [
             {
@@ -48095,9 +48917,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njq9qg": {
-          "alternateLabel": [
-            "LB II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "LB II"
+            ]
+          },
           "id": "p0m63njq9qg",
           "label": "Late Bronze Age II",
           "localizedLabel": {
@@ -48138,9 +48962,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njqgqx": {
-          "alternateLabel": [
-            "OK"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "OK"
+            ]
+          },
           "id": "p0m63njqgqx",
           "label": "Old Kingdom",
           "localizedLabel": {
@@ -48169,9 +48995,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njqrdb": {
-          "alternateLabel": [
-            "EB II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "EB II"
+            ]
+          },
           "id": "p0m63njqrdb",
           "label": "Early Bronze Age II",
           "localizedLabel": {
@@ -48240,9 +49068,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njrgjj": {
-          "alternateLabel": [
-            "IB"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "IB"
+            ]
+          },
           "id": "p0m63njrgjj",
           "label": "Intermediate Bronze Age",
           "localizedLabel": {
@@ -48283,9 +49113,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njrhc6": {
-          "alternateLabel": [
-            "MC I-II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "MC I-II"
+            ]
+          },
           "id": "p0m63njrhc6",
           "label": "Middle Cypriot I and II",
           "localizedLabel": {
@@ -48342,13 +49174,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njrpgn": {
-          "alternateLabel": [
-            "Late Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Roman"
+            ]
+          },
           "id": "p0m63njrpgn",
           "label": "Late Roman Period",
           "localizedLabel": {
-            "eng-latn": "Late Roman"
+            "eng-latn": "Late Roman Period"
           },
           "spatialCoverage": [
             {
@@ -48373,13 +49207,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njrpxz": {
-          "alternateLabel": [
-            "Ummayyad/Abbasid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ummayyad/Abbasid"
+            ]
+          },
           "id": "p0m63njrpxz",
           "label": "Ummayyad/Abbasid Periods",
           "localizedLabel": {
-            "eng-latn": "Ummayyad/Abbasid"
+            "eng-latn": "Ummayyad/Abbasid Periods"
           },
           "spatialCoverage": [
             {
@@ -48472,9 +49308,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njsg85": {
-          "alternateLabel": [
-            "IA IIB"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "IA IIB"
+            ]
+          },
           "id": "p0m63njsg85",
           "label": "Iron Age IIB",
           "localizedLabel": {
@@ -48515,13 +49353,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njsqs7": {
-          "alternateLabel": [
-            "Middle Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Roman"
+            ]
+          },
           "id": "p0m63njsqs7",
           "label": "Middle Roman Period",
           "localizedLabel": {
-            "eng-latn": "Middle Roman"
+            "eng-latn": "Middle Roman Period"
           },
           "spatialCoverage": [
             {
@@ -48554,9 +49394,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njt6zp": {
-          "alternateLabel": [
-            "IA IIA"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "IA IIA"
+            ]
+          },
           "id": "p0m63njt6zp",
           "label": "Iron Age IIA",
           "localizedLabel": {
@@ -48625,13 +49467,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njtm6w": {
-          "alternateLabel": [
-            "Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Byzantine"
+            ]
+          },
           "id": "p0m63njtm6w",
           "label": "Byzantine Period",
           "localizedLabel": {
-            "eng-latn": "Byzantine"
+            "eng-latn": "Byzantine Period"
           },
           "spatialCoverage": [
             {
@@ -48656,13 +49500,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njtmv8": {
-          "alternateLabel": [
-            "Late Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Roman"
+            ]
+          },
           "id": "p0m63njtmv8",
           "label": "Late Roman Period",
           "localizedLabel": {
-            "eng-latn": "Late Roman"
+            "eng-latn": "Late Roman Period"
           },
           "spatialCoverage": [
             {
@@ -48691,9 +49537,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njtn97": {
-          "alternateLabel": [
-            "EB III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "EB III"
+            ]
+          },
           "id": "p0m63njtn97",
           "label": "Early Bronze Age III",
           "localizedLabel": {
@@ -48762,9 +49610,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njtr7f": {
-          "alternateLabel": [
-            "MB I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "MB I"
+            ]
+          },
           "id": "p0m63njtr7f",
           "label": "Middle Bronze Age I",
           "localizedLabel": {
@@ -48861,13 +49711,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njw2xp": {
-          "alternateLabel": [
-            "Herodian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Herodian"
+            ]
+          },
           "id": "p0m63njw2xp",
           "label": "Herodian Period",
           "localizedLabel": {
-            "eng-latn": "Herodian"
+            "eng-latn": "Herodian Period"
           },
           "spatialCoverage": [
             {
@@ -48896,9 +49748,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njw3sn": {
-          "alternateLabel": [
-            "IB"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "IB"
+            ]
+          },
           "id": "p0m63njw3sn",
           "label": "Intermediate Bronze Age",
           "localizedLabel": {
@@ -48927,13 +49781,15 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njw6r7": {
-          "alternateLabel": [
-            "Early Hellenistic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Hellenistic"
+            ]
+          },
           "id": "p0m63njw6r7",
           "label": "Early Hellenistic Period",
           "localizedLabel": {
-            "eng-latn": "Early Hellenistic"
+            "eng-latn": "Early Hellenistic Period"
           },
           "spatialCoverage": [
             {
@@ -48990,9 +49846,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njwrjx": {
-          "alternateLabel": [
-            "LB"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "LB"
+            ]
+          },
           "id": "p0m63njwrjx",
           "label": "Late Bronze Age",
           "localizedLabel": {
@@ -49021,9 +49879,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njwxjf": {
-          "alternateLabel": [
-            "IB"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "IB"
+            ]
+          },
           "id": "p0m63njwxjf",
           "label": "Intermediate Bronze Age",
           "localizedLabel": {
@@ -49052,9 +49912,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njx89q": {
-          "alternateLabel": [
-            "IA II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "IA II"
+            ]
+          },
           "id": "p0m63njx89q",
           "label": "Iron Age II",
           "localizedLabel": {
@@ -49083,9 +49945,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njxhf5": {
-          "alternateLabel": [
-            "MC III-LC I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "MC III-LC I"
+            ]
+          },
           "id": "p0m63njxhf5",
           "label": "Middle Cypriot III/Late Cypriot I",
           "localizedLabel": {
@@ -49114,9 +49978,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njzbxk": {
-          "alternateLabel": [
-            "ED"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "ED"
+            ]
+          },
           "id": "p0m63njzbxk",
           "label": "Early Dynastic",
           "localizedLabel": {
@@ -49145,9 +50011,11 @@
           "url": "http://www.levantineceramics.org/periods"
         },
         "p0m63njzdfh": {
-          "alternateLabel": [
-            "LC III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "LC III"
+            ]
+          },
           "id": "p0m63njzdfh",
           "label": "Late Cypriot III",
           "localizedLabel": {
@@ -49221,9 +50089,11 @@
     "p0ms2ch": {
       "definitions": {
         "p0ms2ch58wg": {
-          "alternateLabel": [
-            "Dark Age III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Dark Age III"
+            ]
+          },
           "id": "p0ms2ch58wg",
           "label": "DAIII",
           "localizedLabel": {
@@ -49251,9 +50121,11 @@
           "type": "PeriodDefinition"
         },
         "p0ms2ch6k6q": {
-          "alternateLabel": [
-            "Dark Age I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Dark Age I"
+            ]
+          },
           "id": "p0ms2ch6k6q",
           "label": "DAI",
           "localizedLabel": {
@@ -49281,9 +50153,11 @@
           "type": "PeriodDefinition"
         },
         "p0ms2chfwkv": {
-          "alternateLabel": [
-            "Dark Age II/III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Dark Age II/III"
+            ]
+          },
           "id": "p0ms2chfwkv",
           "label": "DAII/III",
           "localizedLabel": {
@@ -49337,9 +50211,11 @@
           "type": "PeriodDefinition"
         },
         "p0ms2chvhsq": {
-          "alternateLabel": [
-            "Dark Age II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Dark Age II"
+            ]
+          },
           "id": "p0ms2chvhsq",
           "label": "DAII",
           "localizedLabel": {
@@ -49441,13 +50317,15 @@
           "type": "PeriodDefinition"
         },
         "p0njrb45vw3": {
-          "alternateLabel": [
-            "Old Babylonian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Old Babylonian"
+            ]
+          },
           "id": "p0njrb45vw3",
           "label": "Old Babylonian period",
           "localizedLabel": {
-            "eng-latn": "Old Babylonian"
+            "eng-latn": "Old Babylonian period"
           },
           "source": {
             "locator": "page 352",
@@ -49479,13 +50357,15 @@
           "type": "PeriodDefinition"
         },
         "p0njrb4hmpk": {
-          "alternateLabel": [
-            "Jemder Nasr"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Jemder Nasr"
+            ]
+          },
           "id": "p0njrb4hmpk",
           "label": "Jemdet Nasr period",
           "localizedLabel": {
-            "eng-latn": "Jemder Nasr"
+            "eng-latn": "Jemdet Nasr period"
           },
           "source": {
             "locator": "page 350",
@@ -49622,13 +50502,15 @@
           "type": "PeriodDefinition"
         },
         "p0njrb4pv8x": {
-          "alternateLabel": [
-            "Early Uruk"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Uruk"
+            ]
+          },
           "id": "p0njrb4pv8x",
           "label": "Early Uruk period",
           "localizedLabel": {
-            "eng-latn": "Early Uruk"
+            "eng-latn": "Early Uruk period"
           },
           "source": {
             "locator": "page 349",
@@ -49660,13 +50542,15 @@
           "type": "PeriodDefinition"
         },
         "p0njrb4t3cg": {
-          "alternateLabel": [
-            "Later Uruk"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Later Uruk"
+            ]
+          },
           "id": "p0njrb4t3cg",
           "label": "Later Uruk period",
           "localizedLabel": {
-            "eng-latn": "Later Uruk"
+            "eng-latn": "Later Uruk period"
           },
           "source": {
             "locator": "page 350",
@@ -49698,13 +50582,15 @@
           "type": "PeriodDefinition"
         },
         "p0njrb4w994": {
-          "alternateLabel": [
-            "Neo-Assyrian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neo-Assyrian"
+            ]
+          },
           "id": "p0njrb4w994",
           "label": "Neo-Assyrian period",
           "localizedLabel": {
-            "eng-latn": "Neo-Assyrian"
+            "eng-latn": "Neo-Assyrian period"
           },
           "source": {
             "locator": "page 358",
@@ -49837,13 +50723,14 @@
     "p0pqptc": {
       "definitions": {
         "p0pqptc2r8x": {
-          "alternateLabel": [
-            "Early Roman Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Roman Period"
+            ]
+          },
           "id": "p0pqptc2r8x",
           "label": "Romeinse tijd vroeg",
           "localizedLabel": {
-            "eng-latn": "Early Roman Period",
             "nld-latn": "Romeinse tijd vroeg"
           },
           "spatialCoverage": [
@@ -49867,13 +50754,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc2sdk": {
-          "alternateLabel": [
-            "Early Middle Ages"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Middle Ages"
+            ]
+          },
           "id": "p0pqptc2sdk",
           "label": "Middeleeuwen vroeg",
           "localizedLabel": {
-            "eng-latn": "Early Middle Ages",
             "nld-latn": "Middeleeuwen vroeg"
           },
           "spatialCoverage": [
@@ -49897,13 +50785,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc2ww5": {
-          "alternateLabel": [
-            "Middle Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Mesolithic"
+            ]
+          },
           "id": "p0pqptc2ww5",
           "label": "Mesolithicum midden",
           "localizedLabel": {
-            "eng-latn": "Middle Mesolithic",
             "nld-latn": "Mesolithicum midden"
           },
           "spatialCoverage": [
@@ -49927,13 +50816,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc49xx": {
-          "alternateLabel": [
-            "Early Neolithic B"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Neolithic B"
+            ]
+          },
           "id": "p0pqptc49xx",
           "label": "Neolithicum vroeg B",
           "localizedLabel": {
-            "eng-latn": "Early Neolithic B",
             "nld-latn": "Neolithicum vroeg B"
           },
           "spatialCoverage": [
@@ -49957,13 +50847,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc4xpx": {
-          "alternateLabel": [
-            "Late Middle Ages B"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Middle Ages B"
+            ]
+          },
           "id": "p0pqptc4xpx",
           "label": "Middeleeuwen laat B",
           "localizedLabel": {
-            "eng-latn": "Late Middle Ages B",
             "nld-latn": "Middeleeuwen laat B"
           },
           "spatialCoverage": [
@@ -49987,13 +50878,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc533f": {
-          "alternateLabel": [
-            "Late Neolithic A"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Neolithic A"
+            ]
+          },
           "id": "p0pqptc533f",
           "label": "Neolithicum laat A",
           "localizedLabel": {
-            "eng-latn": "Late Neolithic A",
             "nld-latn": "Neolithicum laat A"
           },
           "spatialCoverage": [
@@ -50017,13 +50909,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc5cn5": {
-          "alternateLabel": [
-            "Modern Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern Period"
+            ]
+          },
           "id": "p0pqptc5cn5",
           "label": "Nieuwe tijd",
           "localizedLabel": {
-            "eng-latn": "Modern Period",
             "nld-latn": "Nieuwe tijd"
           },
           "spatialCoverage": [
@@ -50047,13 +50940,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc5rvd": {
-          "alternateLabel": [
-            "Modern Period B"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern Period B"
+            ]
+          },
           "id": "p0pqptc5rvd",
           "label": "Nieuwe tijd B",
           "localizedLabel": {
-            "eng-latn": "Modern Period B",
             "nld-latn": "Nieuwe tijd B"
           },
           "spatialCoverage": [
@@ -50077,13 +50971,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc6vm7": {
-          "alternateLabel": [
-            "Early Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Bronze Age"
+            ]
+          },
           "id": "p0pqptc6vm7",
           "label": "Bronstijd vroeg",
           "localizedLabel": {
-            "eng-latn": "Early Bronze Age",
             "nld-latn": "Bronstijd vroeg"
           },
           "spatialCoverage": [
@@ -50107,13 +51002,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc7s5j": {
-          "alternateLabel": [
-            "Late Middle Ages"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Middle Ages"
+            ]
+          },
           "id": "p0pqptc7s5j",
           "label": "Middeleeuwen laat",
           "localizedLabel": {
-            "eng-latn": "Late Middle Ages",
             "nld-latn": "Middeleeuwen laat"
           },
           "spatialCoverage": [
@@ -50137,13 +51033,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc7tx6": {
-          "alternateLabel": [
-            "Late Middle Ages A"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Middle Ages A"
+            ]
+          },
           "id": "p0pqptc7tx6",
           "label": "Middeleeuwen laat A",
           "localizedLabel": {
-            "eng-latn": "Late Middle Ages A",
             "nld-latn": "Middeleeuwen laat A"
           },
           "spatialCoverage": [
@@ -50167,13 +51064,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc8dj7": {
-          "alternateLabel": [
-            "Early Middle Ages D"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Middle Ages D"
+            ]
+          },
           "id": "p0pqptc8dj7",
           "label": "Middeleeuwen vroeg D",
           "localizedLabel": {
-            "eng-latn": "Early Middle Ages D",
             "nld-latn": "Middeleeuwen vroeg D"
           },
           "spatialCoverage": [
@@ -50197,13 +51095,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc96jp": {
-          "alternateLabel": [
-            "Middle Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Paleolithic"
+            ]
+          },
           "id": "p0pqptc96jp",
           "label": "Paleolithicum midden",
           "localizedLabel": {
-            "eng-latn": "Middle Paleolithic",
             "nld-latn": "Paleolithicum midden"
           },
           "spatialCoverage": [
@@ -50227,13 +51126,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptc976n": {
-          "alternateLabel": [
-            "Middle Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age"
+            ]
+          },
           "id": "p0pqptc976n",
           "label": "Bronstijd midden",
           "localizedLabel": {
-            "eng-latn": "Middle Bronze Age",
             "nld-latn": "Bronstijd midden"
           },
           "spatialCoverage": [
@@ -50257,13 +51157,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcctbj": {
-          "alternateLabel": [
-            "Late Roman Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Roman Period"
+            ]
+          },
           "id": "p0pqptcctbj",
           "label": "Romeinse tijd laat",
           "localizedLabel": {
-            "eng-latn": "Late Roman Period",
             "nld-latn": "Romeinse tijd laat"
           },
           "spatialCoverage": [
@@ -50287,13 +51188,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcdcrx": {
-          "alternateLabel": [
-            "Early Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Iron Age"
+            ]
+          },
           "id": "p0pqptcdcrx",
           "label": "IJzertijd vroeg",
           "localizedLabel": {
-            "eng-latn": "Early Iron Age",
             "nld-latn": "IJzertijd vroeg"
           },
           "spatialCoverage": [
@@ -50317,13 +51219,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcdgk6": {
-          "alternateLabel": [
-            "Modern Period A"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern Period A"
+            ]
+          },
           "id": "p0pqptcdgk6",
           "label": "Nieuwe tijd A",
           "localizedLabel": {
-            "eng-latn": "Modern Period A",
             "nld-latn": "Nieuwe tijd A"
           },
           "spatialCoverage": [
@@ -50347,13 +51250,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcdxp2": {
-          "alternateLabel": [
-            "Roman Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman Period"
+            ]
+          },
           "id": "p0pqptcdxp2",
           "label": "Romeinse tijd",
           "localizedLabel": {
-            "eng-latn": "Roman Period",
             "nld-latn": "Romeinse tijd"
           },
           "spatialCoverage": [
@@ -50377,13 +51281,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcfq9t": {
-          "alternateLabel": [
-            "Middle Ages"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Ages"
+            ]
+          },
           "id": "p0pqptcfq9t",
           "label": "Middeleeuwen",
           "localizedLabel": {
-            "eng-latn": "Middle Ages",
             "nld-latn": "Middeleeuwen"
           },
           "spatialCoverage": [
@@ -50407,13 +51312,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcgfpd": {
-          "alternateLabel": [
-            "Early Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Neolithic"
+            ]
+          },
           "id": "p0pqptcgfpd",
           "label": "Neolithicum vroeg",
           "localizedLabel": {
-            "eng-latn": "Early Neolithic",
             "nld-latn": "Neolithicum vroeg"
           },
           "spatialCoverage": [
@@ -50437,13 +51343,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptch5g9": {
-          "alternateLabel": [
-            "Middle Bronze Age A"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age A"
+            ]
+          },
           "id": "p0pqptch5g9",
           "label": "Bronstijd midden A",
           "localizedLabel": {
-            "eng-latn": "Middle Bronze Age A",
             "nld-latn": "Bronstijd midden A"
           },
           "spatialCoverage": [
@@ -50467,13 +51374,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptch797": {
-          "alternateLabel": [
-            "Early Middle Ages A"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Middle Ages A"
+            ]
+          },
           "id": "p0pqptch797",
           "label": "Middeleeuwen vroeg A",
           "localizedLabel": {
-            "eng-latn": "Early Middle Ages A",
             "nld-latn": "Middeleeuwen vroeg A"
           },
           "spatialCoverage": [
@@ -50497,13 +51405,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptchhqk": {
-          "alternateLabel": [
-            "Middle Roman Period A"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Roman Period A"
+            ]
+          },
           "id": "p0pqptchhqk",
           "label": "Romeinse tijd midden A",
           "localizedLabel": {
-            "eng-latn": "Middle Roman Period A",
             "nld-latn": "Romeinse tijd midden A"
           },
           "spatialCoverage": [
@@ -50527,13 +51436,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptchk66": {
-          "alternateLabel": [
-            "Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze Age"
+            ]
+          },
           "id": "p0pqptchk66",
           "label": "Bronstijd",
           "localizedLabel": {
-            "eng-latn": "Bronze Age",
             "nld-latn": "Bronstijd"
           },
           "spatialCoverage": [
@@ -50557,13 +51467,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptchpfd": {
-          "alternateLabel": [
-            "Early Roman Period A"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Roman Period A"
+            ]
+          },
           "id": "p0pqptchpfd",
           "label": "Romeinse tijd vroeg A",
           "localizedLabel": {
-            "eng-latn": "Early Roman Period A",
             "nld-latn": "Romeinse tijd vroeg A"
           },
           "spatialCoverage": [
@@ -50587,14 +51498,15 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcjxw3": {
-          "alternateLabel": [
-            "Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Paleolithic"
+            ]
+          },
           "editorialNote": "no start date provided: noted only as \"before 8800 B.C.\"",
           "id": "p0pqptcjxw3",
           "label": "Paleolithicum",
           "localizedLabel": {
-            "eng-latn": "Paleolithic",
             "nld-latn": "Paleolithicum"
           },
           "spatialCoverage": [
@@ -50612,13 +51524,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptck7qq": {
-          "alternateLabel": [
-            "Late Neolithic B"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Neolithic B"
+            ]
+          },
           "id": "p0pqptck7qq",
           "label": "Neolithicum laat B",
           "localizedLabel": {
-            "eng-latn": "Late Neolithic B",
             "nld-latn": "Neolithicum laat B"
           },
           "spatialCoverage": [
@@ -50642,13 +51555,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptckbqm": {
-          "alternateLabel": [
-            "Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age"
+            ]
+          },
           "id": "p0pqptckbqm",
           "label": "IJzertijd",
           "localizedLabel": {
-            "eng-latn": "Iron Age",
             "nld-latn": "IJzertijd"
           },
           "spatialCoverage": [
@@ -50672,13 +51586,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptckfbt": {
-          "alternateLabel": [
-            "Early Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Mesolithic"
+            ]
+          },
           "id": "p0pqptckfbt",
           "label": "Mesolithicum vroeg",
           "localizedLabel": {
-            "eng-latn": "Early Mesolithic",
             "nld-latn": "Mesolithicum vroeg"
           },
           "spatialCoverage": [
@@ -50702,13 +51617,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcmc4h": {
-          "alternateLabel": [
-            "Modern Period C"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern Period C"
+            ]
+          },
           "id": "p0pqptcmc4h",
           "label": "Nieuwe tijd C",
           "localizedLabel": {
-            "eng-latn": "Modern Period C",
             "nld-latn": "Nieuwe tijd C"
           },
           "spatialCoverage": [
@@ -50732,13 +51648,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcmfqr": {
-          "alternateLabel": [
-            "Early Neolithic A"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Neolithic A"
+            ]
+          },
           "id": "p0pqptcmfqr",
           "label": "Neolithicum vroeg A",
           "localizedLabel": {
-            "eng-latn": "Early Neolithic A",
             "nld-latn": "Neolithicum vroeg A"
           },
           "spatialCoverage": [
@@ -50762,13 +51679,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcn452": {
-          "alternateLabel": [
-            "Late Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Iron Age"
+            ]
+          },
           "id": "p0pqptcn452",
           "label": "IJzertijd laat",
           "localizedLabel": {
-            "eng-latn": "Late Iron Age",
             "nld-latn": "IJzertijd laat"
           },
           "spatialCoverage": [
@@ -50792,13 +51710,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcnbbg": {
-          "alternateLabel": [
-            "Middle Roman Period B"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Roman Period B"
+            ]
+          },
           "id": "p0pqptcnbbg",
           "label": "Romeinse tijd midden B",
           "localizedLabel": {
-            "eng-latn": "Middle Roman Period B",
             "nld-latn": "Romeinse tijd midden B"
           },
           "spatialCoverage": [
@@ -50822,13 +51741,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcnhrx": {
-          "alternateLabel": [
-            "Middle Roman Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Roman Period"
+            ]
+          },
           "id": "p0pqptcnhrx",
           "label": "Romeinse tijd midden",
           "localizedLabel": {
-            "eng-latn": "Middle Roman Period",
             "nld-latn": "Romeinse tijd midden"
           },
           "spatialCoverage": [
@@ -50852,13 +51772,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcnpgr": {
-          "alternateLabel": [
-            "Early Roman Period B"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Roman Period B"
+            ]
+          },
           "id": "p0pqptcnpgr",
           "label": "Romeinse tijd vroeg B",
           "localizedLabel": {
-            "eng-latn": "Early Roman Period B",
             "nld-latn": "Romeinse tijd vroeg B"
           },
           "spatialCoverage": [
@@ -50882,13 +51803,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcnxt6": {
-          "alternateLabel": [
-            "Late Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Neolithic"
+            ]
+          },
           "id": "p0pqptcnxt6",
           "label": "Neolithicum laat",
           "localizedLabel": {
-            "eng-latn": "Late Neolithic",
             "nld-latn": "Neolithicum laat"
           },
           "spatialCoverage": [
@@ -50912,13 +51834,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcp92r": {
-          "alternateLabel": [
-            "Middle Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Iron Age"
+            ]
+          },
           "id": "p0pqptcp92r",
           "label": "IJzertijd midden",
           "localizedLabel": {
-            "eng-latn": "Middle Iron Age",
             "nld-latn": "IJzertijd midden"
           },
           "spatialCoverage": [
@@ -50942,13 +51865,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcpcb2": {
-          "alternateLabel": [
-            "Early Middle Ages B"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Middle Ages B"
+            ]
+          },
           "id": "p0pqptcpcb2",
           "label": "Middeleeuwen vroeg B",
           "localizedLabel": {
-            "eng-latn": "Early Middle Ages B",
             "nld-latn": "Middeleeuwen vroeg B"
           },
           "spatialCoverage": [
@@ -50972,13 +51896,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcppjp": {
-          "alternateLabel": [
-            "Late Paleolithic A"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Paleolithic A"
+            ]
+          },
           "id": "p0pqptcppjp",
           "label": "Paleolithicum laat A",
           "localizedLabel": {
-            "eng-latn": "Late Paleolithic A",
             "nld-latn": "Paleolithicum laat A"
           },
           "spatialCoverage": [
@@ -51002,13 +51927,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcprsm": {
-          "alternateLabel": [
-            "Late Roman Period B"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Roman Period B"
+            ]
+          },
           "id": "p0pqptcprsm",
           "label": "Romeinse tijd laat B",
           "localizedLabel": {
-            "eng-latn": "Late Roman Period B",
             "nld-latn": "Romeinse tijd laat B"
           },
           "spatialCoverage": [
@@ -51032,13 +51958,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcq3hk": {
-          "alternateLabel": [
-            "Late Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age"
+            ]
+          },
           "id": "p0pqptcq3hk",
           "label": "Bronstijd laat",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age",
             "nld-latn": "Bronstijd laat"
           },
           "spatialCoverage": [
@@ -51062,14 +51989,15 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcqkgd": {
-          "alternateLabel": [
-            "Early Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Paleolithic"
+            ]
+          },
           "editorialNote": "no start date provided: noted only as \"before 300000 BP\"",
           "id": "p0pqptcqkgd",
           "label": "Paleolithicum vroeg",
           "localizedLabel": {
-            "eng-latn": "Early Paleolithic",
             "nld-latn": "Paleolithicum vroeg"
           },
           "spatialCoverage": [
@@ -51087,13 +52015,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcqq2k": {
-          "alternateLabel": [
-            "Middle Bronze Age B"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age B"
+            ]
+          },
           "id": "p0pqptcqq2k",
           "label": "Bronstijd midden B",
           "localizedLabel": {
-            "eng-latn": "Middle Bronze Age B",
             "nld-latn": "Bronstijd midden B"
           },
           "spatialCoverage": [
@@ -51117,13 +52046,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcrcx7": {
-          "alternateLabel": [
-            "Middle Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Neolithic"
+            ]
+          },
           "id": "p0pqptcrcx7",
           "label": "Neolithicum midden",
           "localizedLabel": {
-            "eng-latn": "Middle Neolithic",
             "nld-latn": "Neolithicum midden"
           },
           "spatialCoverage": [
@@ -51147,13 +52077,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcs32r": {
-          "alternateLabel": [
-            "Middle Neolithic A"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Neolithic A"
+            ]
+          },
           "id": "p0pqptcs32r",
           "label": "Neolithicum midden A",
           "localizedLabel": {
-            "eng-latn": "Middle Neolithic A",
             "nld-latn": "Neolithicum midden A"
           },
           "spatialCoverage": [
@@ -51177,13 +52108,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcsn5h": {
-          "alternateLabel": [
-            "Late Roman Period A"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Roman Period A"
+            ]
+          },
           "id": "p0pqptcsn5h",
           "label": "Romeinse tijd laat A",
           "localizedLabel": {
-            "eng-latn": "Late Roman Period A",
             "nld-latn": "Romeinse tijd laat A"
           },
           "spatialCoverage": [
@@ -51207,13 +52139,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptct727": {
-          "alternateLabel": [
-            "Early Middle Ages C"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Middle Ages C"
+            ]
+          },
           "id": "p0pqptct727",
           "label": "Middeleeuwen vroeg C",
           "localizedLabel": {
-            "eng-latn": "Early Middle Ages C",
             "nld-latn": "Middeleeuwen vroeg C"
           },
           "spatialCoverage": [
@@ -51237,13 +52170,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptctdsp": {
-          "alternateLabel": [
-            "Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Mesolithic"
+            ]
+          },
           "id": "p0pqptctdsp",
           "label": "Mesolithicum",
           "localizedLabel": {
-            "eng-latn": "Mesolithic",
             "nld-latn": "Mesolithicum"
           },
           "spatialCoverage": [
@@ -51267,13 +52201,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcvm8q": {
-          "alternateLabel": [
-            "Late Paleolithic B"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Paleolithic B"
+            ]
+          },
           "id": "p0pqptcvm8q",
           "label": "Paleolithicum laat B",
           "localizedLabel": {
-            "eng-latn": "Late Paleolithic B",
             "nld-latn": "Paleolithicum laat B"
           },
           "spatialCoverage": [
@@ -51297,13 +52232,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcvsg7": {
-          "alternateLabel": [
-            "Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neolithic"
+            ]
+          },
           "id": "p0pqptcvsg7",
           "label": "Neolithicum",
           "localizedLabel": {
-            "eng-latn": "Neolithic",
             "nld-latn": "Neolithicum"
           },
           "spatialCoverage": [
@@ -51327,13 +52263,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptcw5mg": {
-          "alternateLabel": [
-            "Middle Neolithic B"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Neolithic B"
+            ]
+          },
           "id": "p0pqptcw5mg",
           "label": "Neolithicum midden B",
           "localizedLabel": {
-            "eng-latn": "Middle Neolithic B",
             "nld-latn": "Neolithicum midden B"
           },
           "spatialCoverage": [
@@ -51357,13 +52294,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptczcmr": {
-          "alternateLabel": [
-            "Late Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Mesolithic"
+            ]
+          },
           "id": "p0pqptczcmr",
           "label": "Mesolithicum laat",
           "localizedLabel": {
-            "eng-latn": "Late Mesolithic",
             "nld-latn": "Mesolithicum laat"
           },
           "spatialCoverage": [
@@ -51387,13 +52325,14 @@
           "type": "PeriodDefinition"
         },
         "p0pqptczm5h": {
-          "alternateLabel": [
-            "Late Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Paleolithic"
+            ]
+          },
           "id": "p0pqptczm5h",
           "label": "Paleolithicum laat",
           "localizedLabel": {
-            "eng-latn": "Late Paleolithic",
             "nld-latn": "Paleolithicum laat"
           },
           "spatialCoverage": [
@@ -51692,14 +52631,16 @@
           "url": "http://uee.ucla.edu/chronology/"
         },
         "p0qk76z85jw": {
-          "alternateLabel": [
-            "Badarian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Badarian"
+            ]
+          },
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76z85jw",
           "label": "Badarian (Middle Egypt)",
           "localizedLabel": {
-            "eng-latn": "Badarian"
+            "eng-latn": "Badarian (Middle Egypt)"
           },
           "spatialCoverage": [
             {
@@ -52040,15 +52981,17 @@
           "url": "http://uee.ucla.edu/chronology/"
         },
         "p0qk76zjnwg": {
-          "alternateLabel": [
-            "Maadi",
-            "Buto I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Maadi",
+              "Buto I"
+            ]
+          },
           "editorialNote": "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of.",
           "id": "p0qk76zjnwg",
           "label": "Maadi/Buto I",
           "localizedLabel": {
-            "eng-latn": "Maadi"
+            "eng-latn": "Maadi/Buto I"
           },
           "spatialCoverage": [
             {
@@ -54488,9 +55431,11 @@
     "p0qwcp6": {
       "definitions": {
         "p0qwcp63xkk": {
-          "alternateLabel": [
-            "Persian (Achaemenid) Empire"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Persian (Achaemenid) Empire"
+            ]
+          },
           "editorialNote": "see also Mazar, 1992",
           "id": "p0qwcp63xkk",
           "label": "Persian",
@@ -54570,10 +55515,12 @@
           "type": "PeriodDefinition"
         },
         "p0qwcp6cg65": {
-          "alternateLabel": [
-            "Neo-Assyrian",
-            " Neo-Babylonian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Neo-Assyrian",
+              " Neo-Babylonian"
+            ]
+          },
           "id": "p0qwcp6cg65",
           "label": "Iron I-II",
           "localizedLabel": {
@@ -54652,15 +55599,17 @@
           "type": "PeriodDefinition"
         },
         "p0qwcp6pkdc": {
-          "alternateLabel": [
-            "Middle Bronze I-II",
-            "Old Babylonian",
-            " Old Assyrian"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze I-II",
+              "Old Babylonian",
+              " Old Assyrian"
+            ]
+          },
           "id": "p0qwcp6pkdc",
           "label": "MB I-II",
           "localizedLabel": {
-            "eng-latn": "Middle Bronze I-II"
+            "eng-latn": "MB I-II"
           },
           "spatialCoverage": [
             {
@@ -54829,14 +55778,15 @@
     "p0rqpwq": {
       "definitions": {
         "p0rqpwq4prr": {
-          "alternateLabel": [
-            "Second era"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Second era"
+            ]
+          },
           "editorialNote": "no date type shown, but context indicates BC",
           "id": "p0rqpwq4prr",
           "label": "Deuxième époque",
           "localizedLabel": {
-            "eng-latn": "Second era",
             "fra-latn": "Deuxième époque"
           },
           "note": "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)",
@@ -54864,14 +55814,15 @@
           "type": "PeriodDefinition"
         },
         "p0rqpwqb48w": {
-          "alternateLabel": [
-            "First era"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "First era"
+            ]
+          },
           "editorialNote": "no date type shown, but context indicates BC",
           "id": "p0rqpwqb48w",
           "label": "Première époque",
           "localizedLabel": {
-            "eng-latn": "First era",
             "fra-latn": "Première époque"
           },
           "note": "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)",
@@ -54898,14 +55849,15 @@
           "type": "PeriodDefinition"
         },
         "p0rqpwqbq39": {
-          "alternateLabel": [
-            "Fourth era"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Fourth era"
+            ]
+          },
           "editorialNote": "no designation present (BCE, etc.)",
           "id": "p0rqpwqbq39",
           "label": "Quatrième époque",
           "localizedLabel": {
-            "eng-latn": "Fourth era",
             "fra-latn": "Quatrième époque"
           },
           "spatialCoverage": [
@@ -54932,14 +55884,15 @@
           "type": "PeriodDefinition"
         },
         "p0rqpwqwxnj": {
-          "alternateLabel": [
-            "Third era"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Third era"
+            ]
+          },
           "editorialNote": "no date type shown, but context indicates BC",
           "id": "p0rqpwqwxnj",
           "label": "Troisième époque",
           "localizedLabel": {
-            "eng-latn": "Third era",
             "fra-latn": "Troisième époque"
           },
           "note": "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)",
@@ -55188,14 +56141,16 @@
           "type": "PeriodDefinition"
         },
         "p0tns5v4kdf": {
-          "alternateLabel": [
-            "Iron Age II",
-            "Middle Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age II",
+              "Middle Iron Age"
+            ]
+          },
           "id": "p0tns5v4kdf",
           "label": "Iron Age II (Middle Iron Age)",
           "localizedLabel": {
-            "eng-latn": "Iron Age II"
+            "eng-latn": "Iron Age II (Middle Iron Age)"
           },
           "note": "This period is used to designate the moment of Phoenician colonization in the West before the development of a distinctive Punic identity.",
           "source": {
@@ -55369,14 +56324,16 @@
           "type": "PeriodDefinition"
         },
         "p0tns5vkwc5": {
-          "alternateLabel": [
-            "Iron Age I",
-            "Early Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age I",
+              "Early Iron Age"
+            ]
+          },
           "id": "p0tns5vkwc5",
           "label": "Iron Age I (Early Iron Age)",
           "localizedLabel": {
-            "eng-latn": "Iron Age I"
+            "eng-latn": "Iron Age I (Early Iron Age)"
           },
           "source": {
             "locator": "page 25",
@@ -55975,13 +56932,15 @@
           "type": "PeriodDefinition"
         },
         "p0vm8tztmtk": {
-          "alternateLabel": [
-            "Early Migrations"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Migrations"
+            ]
+          },
           "id": "p0vm8tztmtk",
           "label": "Early Migrations Period",
           "localizedLabel": {
-            "eng-latn": "Early Migrations"
+            "eng-latn": "Early Migrations Period"
           },
           "spatialCoverage": [
             {
@@ -56022,13 +56981,14 @@
     "p0vn2fr": {
       "definitions": {
         "p0vn2fr2ft3": {
-          "alternateLabel": [
-            "Late Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Mesolithic"
+            ]
+          },
           "id": "p0vn2fr2ft3",
           "label": "Yngre mesolitikum",
           "localizedLabel": {
-            "eng-latn": "Late Mesolithic",
             "swe-latn": "Yngre mesolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p114",
@@ -56054,13 +57014,14 @@
           "url": "http://mis.historiska.se/rdf/period#p114"
         },
         "p0vn2fr33s2": {
-          "alternateLabel": [
-            "Paleolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Paleolithic"
+            ]
+          },
           "id": "p0vn2fr33s2",
           "label": "Paleolitikum",
           "localizedLabel": {
-            "eng-latn": "Paleolithic",
             "swe-latn": "Paleolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p111",
@@ -56086,13 +57047,14 @@
           "url": "http://mis.historiska.se/rdf/period#p111"
         },
         "p0vn2fr45nj": {
-          "alternateLabel": [
-            "Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age"
+            ]
+          },
           "id": "p0vn2fr45nj",
           "label": "Järnålder",
           "localizedLabel": {
-            "eng-latn": "Iron Age",
             "swe-latn": "Järnålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p300",
@@ -56118,13 +57080,14 @@
           "url": "http://mis.historiska.se/rdf/period#p300"
         },
         "p0vn2fr5tcr": {
-          "alternateLabel": [
-            "High Medieval Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "High Medieval Period"
+            ]
+          },
           "id": "p0vn2fr5tcr",
           "label": "Högmedeltid",
           "localizedLabel": {
-            "eng-latn": "High Medieval Period",
             "swe-latn": "Högmedeltid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p420",
@@ -56150,13 +57113,14 @@
           "url": "http://mis.historiska.se/rdf/period#p420"
         },
         "p0vn2fr68nx": {
-          "alternateLabel": [
-            "Bronze Age III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze Age III"
+            ]
+          },
           "id": "p0vn2fr68nx",
           "label": "Bronsålder period iii",
           "localizedLabel": {
-            "eng-latn": "Bronze Age III",
             "swe-latn": "Bronsålder period iii"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p213",
@@ -56182,13 +57146,14 @@
           "url": "http://mis.historiska.se/rdf/period#p213"
         },
         "p0vn2fr8fmm": {
-          "alternateLabel": [
-            "Late Medieval Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Medieval Period"
+            ]
+          },
           "id": "p0vn2fr8fmm",
           "label": "Senmedeltid",
           "localizedLabel": {
-            "eng-latn": "Late Medieval Period",
             "swe-latn": "Senmedeltid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p430",
@@ -56214,13 +57179,14 @@
           "url": "http://mis.historiska.se/rdf/period#p430"
         },
         "p0vn2fr8n53": {
-          "alternateLabel": [
-            "Viking Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Viking Period"
+            ]
+          },
           "id": "p0vn2fr8n53",
           "label": "Vikingatid",
           "localizedLabel": {
-            "eng-latn": "Viking Period",
             "swe-latn": "Vikingatid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p323",
@@ -56246,13 +57212,14 @@
           "url": "http://mis.historiska.se/rdf/period#p323"
         },
         "p0vn2fr9whq": {
-          "alternateLabel": [
-            "Vendel Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Vendel Period"
+            ]
+          },
           "id": "p0vn2fr9whq",
           "label": "Vendeltid",
           "localizedLabel": {
-            "eng-latn": "Vendel Period",
             "swe-latn": "Vendeltid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p322",
@@ -56278,14 +57245,15 @@
           "url": "http://mis.historiska.se/rdf/period#p322"
         },
         "p0vn2frbn8k": {
-          "alternateLabel": [
-            "Roman Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman Iron Age"
+            ]
+          },
           "editorialNote": "The original entries just had \"Kr. f.\", which I assume means \"birth of Christ\", but I don't know if their system is using year 0 or year -1/year 1 ",
           "id": "p0vn2frbn8k",
           "label": "Romersk järnålder",
           "localizedLabel": {
-            "eng-latn": "Roman Iron Age",
             "swe-latn": "Romersk järnålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p312",
@@ -56311,13 +57279,14 @@
           "url": "http://mis.historiska.se/rdf/period#p312"
         },
         "p0vn2frbvn2": {
-          "alternateLabel": [
-            "Bronze Age I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze Age I"
+            ]
+          },
           "id": "p0vn2frbvn2",
           "label": "Bronsålder period i",
           "localizedLabel": {
-            "eng-latn": "Bronze Age I",
             "swe-latn": "Bronsålder period i"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p211",
@@ -56343,13 +57312,14 @@
           "url": "http://mis.historiska.se/rdf/period#p211"
         },
         "p0vn2frc8n8": {
-          "alternateLabel": [
-            "Early Medieval Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Medieval Period"
+            ]
+          },
           "id": "p0vn2frc8n8",
           "label": "Tidig medeltid",
           "localizedLabel": {
-            "eng-latn": "Early Medieval Period",
             "swe-latn": "Tidig medeltid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p410",
@@ -56375,13 +57345,14 @@
           "url": "http://mis.historiska.se/rdf/period#p410"
         },
         "p0vn2frcrrd": {
-          "alternateLabel": [
-            "Early Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Neolithic"
+            ]
+          },
           "id": "p0vn2frcrrd",
           "label": "Tidigneolitikum",
           "localizedLabel": {
-            "eng-latn": "Early Neolithic",
             "swe-latn": "Tidigneolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p121",
@@ -56407,13 +57378,14 @@
           "url": "http://mis.historiska.se/rdf/period#p121"
         },
         "p0vn2frcz8h": {
-          "alternateLabel": [
-            "Stone Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Stone Age"
+            ]
+          },
           "id": "p0vn2frcz8h",
           "label": "Stenålder",
           "localizedLabel": {
-            "eng-latn": "Stone Age",
             "swe-latn": "Stenålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p100",
@@ -56439,13 +57411,14 @@
           "url": "http://mis.historiska.se/rdf/period#p100"
         },
         "p0vn2frdds2": {
-          "alternateLabel": [
-            "Early Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Mesolithic"
+            ]
+          },
           "id": "p0vn2frdds2",
           "label": "Äldre mesolitikum",
           "localizedLabel": {
-            "eng-latn": "Early Mesolithic",
             "swe-latn": "Äldre mesolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p112",
@@ -56471,13 +57444,14 @@
           "url": "http://mis.historiska.se/rdf/period#p112"
         },
         "p0vn2frdpb3": {
-          "alternateLabel": [
-            "Bronze Age VI"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze Age VI"
+            ]
+          },
           "id": "p0vn2frdpb3",
           "label": "Bronsålder period vi",
           "localizedLabel": {
-            "eng-latn": "Bronze Age VI",
             "swe-latn": "Bronsålder period vi"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p223",
@@ -56503,13 +57477,14 @@
           "url": "http://mis.historiska.se/rdf/period#p223"
         },
         "p0vn2frfrzw": {
-          "alternateLabel": [
-            "Late Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Neolithic"
+            ]
+          },
           "id": "p0vn2frfrzw",
           "label": "Senneolitikum",
           "localizedLabel": {
-            "eng-latn": "Late Neolithic",
             "swe-latn": "Senneolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p123",
@@ -56535,13 +57510,14 @@
           "url": "http://mis.historiska.se/rdf/period#p123"
         },
         "p0vn2frhrrf": {
-          "alternateLabel": [
-            "Migration Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Migration Period"
+            ]
+          },
           "id": "p0vn2frhrrf",
           "label": "Folkvandringstid",
           "localizedLabel": {
-            "eng-latn": "Migration Period",
             "swe-latn": "Folkvandringstid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p321",
@@ -56567,13 +57543,14 @@
           "url": "http://mis.historiska.se/rdf/period#p321"
         },
         "p0vn2frkqvn": {
-          "alternateLabel": [
-            "Late Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age"
+            ]
+          },
           "id": "p0vn2frkqvn",
           "label": "Yngre bronsålder",
           "localizedLabel": {
-            "eng-latn": "Late Bronze Age",
             "swe-latn": "Yngre bronsålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p220",
@@ -56599,13 +57576,14 @@
           "url": "http://mis.historiska.se/rdf/period#p220"
         },
         "p0vn2frn6dd": {
-          "alternateLabel": [
-            "Early Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Bronze Age"
+            ]
+          },
           "id": "p0vn2frn6dd",
           "label": "Äldre bronsålder",
           "localizedLabel": {
-            "eng-latn": "Early Bronze Age",
             "swe-latn": "Äldre bronsålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p210",
@@ -56631,13 +57609,14 @@
           "url": "http://mis.historiska.se/rdf/period#p210"
         },
         "p0vn2frnbfw": {
-          "alternateLabel": [
-            "Early Stone Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Stone Age"
+            ]
+          },
           "id": "p0vn2frnbfw",
           "label": "Äldre stenålder",
           "localizedLabel": {
-            "eng-latn": "Early Stone Age",
             "swe-latn": "Äldre stenålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p110",
@@ -56663,14 +57642,15 @@
           "url": "http://mis.historiska.se/rdf/period#p110"
         },
         "p0vn2frnrrg": {
-          "alternateLabel": [
-            "Pre-Roman Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Pre-Roman Iron Age"
+            ]
+          },
           "editorialNote": "The original entries just had \"Kr. f.\", which I assume means \"birth of Christ\", but I don't know if their system is using year 0 or year -1/year 1 ",
           "id": "p0vn2frnrrg",
           "label": "Förromersk järnålder",
           "localizedLabel": {
-            "eng-latn": "Pre-Roman Iron Age",
             "swe-latn": "Förromersk järnålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p311",
@@ -56696,13 +57676,14 @@
           "url": "http://mis.historiska.se/rdf/period#p311"
         },
         "p0vn2frpf43": {
-          "alternateLabel": [
-            "Medieval Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Medieval Period"
+            ]
+          },
           "id": "p0vn2frpf43",
           "label": "Medeltid",
           "localizedLabel": {
-            "eng-latn": "Medieval Period",
             "swe-latn": "Medeltid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p400",
@@ -56728,13 +57709,14 @@
           "url": "http://mis.historiska.se/rdf/period#p400"
         },
         "p0vn2frpqm4": {
-          "alternateLabel": [
-            "Middle Mesolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Mesolithic"
+            ]
+          },
           "id": "p0vn2frpqm4",
           "label": "Mellanmesolitikum",
           "localizedLabel": {
-            "eng-latn": "Middle Mesolithic",
             "swe-latn": "Mellanmesolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p113",
@@ -56760,13 +57742,14 @@
           "url": "http://mis.historiska.se/rdf/period#p113"
         },
         "p0vn2frrq4x": {
-          "alternateLabel": [
-            "Bronze Age V"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze Age V"
+            ]
+          },
           "id": "p0vn2frrq4x",
           "label": "Bronsålder period v",
           "localizedLabel": {
-            "eng-latn": "Bronze Age V",
             "swe-latn": "Bronsålder period v"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p222",
@@ -56792,13 +57775,14 @@
           "url": "http://mis.historiska.se/rdf/period#p222"
         },
         "p0vn2frrx4q": {
-          "alternateLabel": [
-            "Bronze Age IV"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze Age IV"
+            ]
+          },
           "id": "p0vn2frrx4q",
           "label": "Bronsålder period iv",
           "localizedLabel": {
-            "eng-latn": "Bronze Age IV",
             "swe-latn": "Bronsålder period iv"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p221",
@@ -56824,13 +57808,14 @@
           "url": "http://mis.historiska.se/rdf/period#p221"
         },
         "p0vn2frs9vn": {
-          "alternateLabel": [
-            "Early Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Iron Age"
+            ]
+          },
           "id": "p0vn2frs9vn",
           "label": "Äldre järnålder",
           "localizedLabel": {
-            "eng-latn": "Early Iron Age",
             "swe-latn": "Äldre järnålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p310",
@@ -56856,13 +57841,14 @@
           "url": "http://mis.historiska.se/rdf/period#p310"
         },
         "p0vn2frt3sg": {
-          "alternateLabel": [
-            "Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze Age"
+            ]
+          },
           "id": "p0vn2frt3sg",
           "label": "Bronsålder",
           "localizedLabel": {
-            "eng-latn": "Bronze Age",
             "swe-latn": "Bronsålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p200",
@@ -56888,13 +57874,14 @@
           "url": "http://mis.historiska.se/rdf/period#p200"
         },
         "p0vn2frvjj8": {
-          "alternateLabel": [
-            "Middle Neolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Neolithic"
+            ]
+          },
           "id": "p0vn2frvjj8",
           "label": "Mellanneolitikum",
           "localizedLabel": {
-            "eng-latn": "Middle Neolithic",
             "swe-latn": "Mellanneolitikum"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p122",
@@ -56920,13 +57907,14 @@
           "url": "http://mis.historiska.se/rdf/period#p122"
         },
         "p0vn2frw2cp": {
-          "alternateLabel": [
-            "Late Stone Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Stone Age"
+            ]
+          },
           "id": "p0vn2frw2cp",
           "label": "Yngre stenålder",
           "localizedLabel": {
-            "eng-latn": "Late Stone Age",
             "swe-latn": "Yngre stenålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p120",
@@ -56952,13 +57940,14 @@
           "url": "http://mis.historiska.se/rdf/period#p120"
         },
         "p0vn2frwpp2": {
-          "alternateLabel": [
-            "Modern Period"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Modern Period"
+            ]
+          },
           "id": "p0vn2frwpp2",
           "label": "Nyare tid",
           "localizedLabel": {
-            "eng-latn": "Modern Period",
             "swe-latn": "Nyare tid"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p500",
@@ -56984,13 +57973,14 @@
           "url": "http://mis.historiska.se/rdf/period#p500"
         },
         "p0vn2frz2mj": {
-          "alternateLabel": [
-            "Late Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Iron Age"
+            ]
+          },
           "id": "p0vn2frz2mj",
           "label": "Yngre järnålder",
           "localizedLabel": {
-            "eng-latn": "Late Iron Age",
             "swe-latn": "Yngre järnålder"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p320",
@@ -57016,13 +58006,14 @@
           "url": "http://mis.historiska.se/rdf/period#p320"
         },
         "p0vn2frzrfs": {
-          "alternateLabel": [
-            "Bronze Age II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze Age II"
+            ]
+          },
           "id": "p0vn2frzrfs",
           "label": "Bronsålder period ii",
           "localizedLabel": {
-            "eng-latn": "Bronze Age II",
             "swe-latn": "Bronsålder period ii"
           },
           "sameAs": "http://mis.historiska.se/rdf/period#p212",
@@ -57246,14 +58237,16 @@
           "type": "PeriodDefinition"
         },
         "p0vpm8v82h2": {
-          "alternateLabel": [
-            "Early Iron Age",
-            "Iron Age I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Iron Age",
+              "Iron Age I"
+            ]
+          },
           "id": "p0vpm8v82h2",
           "label": "Early Iron Age (I)",
           "localizedLabel": {
-            "eng-latn": "Early Iron Age"
+            "eng-latn": "Early Iron Age (I)"
           },
           "source": {
             "locator": "page 269",
@@ -57529,9 +58522,11 @@
     "p0wf3wd": {
       "definitions": {
         "p0wf3wd4vsk": {
-          "alternateLabel": [
-            "Phoenician"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Phoenician"
+            ]
+          },
           "editorialNote": "added",
           "id": "p0wf3wd4vsk",
           "label": "Orientalizing",
@@ -57559,9 +58554,11 @@
           "type": "PeriodDefinition"
         },
         "p0wf3wd6p49": {
-          "alternateLabel": [
-            "Bonnanaro B/Nuragic I"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bonnanaro B/Nuragic I"
+            ]
+          },
           "editorialNote": "added",
           "id": "p0wf3wd6p49",
           "label": "Middle Bronze Age",
@@ -57589,9 +58586,11 @@
           "type": "PeriodDefinition"
         },
         "p0wf3wd88kk": {
-          "alternateLabel": [
-            "Nuragic II"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Nuragic II"
+            ]
+          },
           "editorialNote": "added",
           "id": "p0wf3wd88kk",
           "label": "Late Bronze Age",
@@ -57619,9 +58618,11 @@
           "type": "PeriodDefinition"
         },
         "p0wf3wd8m8j": {
-          "alternateLabel": [
-            "Early Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Iron Age"
+            ]
+          },
           "id": "p0wf3wd8m8j",
           "label": "Phoenician",
           "localizedLabel": {
@@ -57649,9 +58650,11 @@
           "type": "PeriodDefinition"
         },
         "p0wf3wd9ww6": {
-          "alternateLabel": [
-            "Phoenician"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Phoenician"
+            ]
+          },
           "editorialNote": "added",
           "id": "p0wf3wd9ww6",
           "label": "Geometric",
@@ -57706,9 +58709,11 @@
           "type": "PeriodDefinition"
         },
         "p0wf3wdkdzr": {
-          "alternateLabel": [
-            "Nuragic III"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Nuragic III"
+            ]
+          },
           "editorialNote": "added",
           "id": "p0wf3wdkdzr",
           "label": "Final Bronze Age",
@@ -57736,15 +58741,17 @@
           "type": "PeriodDefinition"
         },
         "p0wf3wdm797": {
-          "alternateLabel": [
-            "Eneolithic",
-            "Copper Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Eneolithic",
+              "Copper Age"
+            ]
+          },
           "editorialNote": "added",
           "id": "p0wf3wdm797",
           "label": "Eneolithic (Copper Age)",
           "localizedLabel": {
-            "eng-latn": "Eneolithic"
+            "eng-latn": "Eneolithic (Copper Age)"
           },
           "spatialCoverage": [
             {
@@ -57794,9 +58801,11 @@
           "type": "PeriodDefinition"
         },
         "p0wf3wdp4xt": {
-          "alternateLabel": [
-            "Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman"
+            ]
+          },
           "editorialNote": "added",
           "id": "p0wf3wdp4xt",
           "label": "Imperial",
@@ -57824,9 +58833,11 @@
           "type": "PeriodDefinition"
         },
         "p0wf3wdpr8t": {
-          "alternateLabel": [
-            "Bonnanaro A"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bonnanaro A"
+            ]
+          },
           "editorialNote": "added",
           "id": "p0wf3wdpr8t",
           "label": "Early Bronze Age",
@@ -57854,9 +58865,11 @@
           "type": "PeriodDefinition"
         },
         "p0wf3wdq7bb": {
-          "alternateLabel": [
-            "Phoenician"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Phoenician"
+            ]
+          },
           "editorialNote": "added",
           "id": "p0wf3wdq7bb",
           "label": "Archaic",
@@ -57884,9 +58897,11 @@
           "type": "PeriodDefinition"
         },
         "p0wf3wdv7pp": {
-          "alternateLabel": [
-            "Roman"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Roman"
+            ]
+          },
           "editorialNote": "added",
           "id": "p0wf3wdv7pp",
           "label": "Republican",
@@ -58240,9 +59255,11 @@
           "type": "PeriodDefinition"
         },
         "p0z3skm5c7p": {
-          "alternateLabel": [
-            "Middle Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skm5c7p",
           "label": "Middle Bronze",
@@ -58279,14 +59296,16 @@
           "type": "PeriodDefinition"
         },
         "p0z3skm7q76": {
-          "alternateLabel": [
-            "Phoenician"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Phoenician"
+            ]
+          },
           "editorialNote": "removed Neo-Assyrian (722-586 B.C.) and Neo-Babylonian (586-539 B.C.) since not explicit, and added new sources Amitai, Barton, Savage, King/Stager, and Richard. ",
           "id": "p0z3skm7q76",
           "label": "Phoenician culture",
           "localizedLabel": {
-            "eng-latn": "Phoenician"
+            "eng-latn": "Phoenician culture"
           },
           "source": {
             "locator": "page 356-357",
@@ -58442,9 +59461,11 @@
           "type": "PeriodDefinition"
         },
         "p0z3skmgf99": {
-          "alternateLabel": [
-            "Iron Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Iron Age"
+            ]
+          },
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skmgf99",
           "label": "Iron",
@@ -58517,9 +59538,11 @@
           "type": "PeriodDefinition"
         },
         "p0z3skmhvm4": {
-          "alternateLabel": [
-            "Late Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skmhvm4",
           "label": "Late Bronze",
@@ -58556,9 +59579,11 @@
           "type": "PeriodDefinition"
         },
         "p0z3skmkqhf": {
-          "alternateLabel": [
-            "Early Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Bronze Age"
+            ]
+          },
           "editorialNote": "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"",
           "id": "p0z3skmkqhf",
           "label": "Early Bronze",
@@ -58667,9 +59692,11 @@
           "type": "PeriodDefinition"
         },
         "p0z3skmnss7": {
-          "alternateLabel": [
-            "Bronze Age"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Bronze Age"
+            ]
+          },
           "editorialNote": "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30.",
           "id": "p0z3skmnss7",
           "label": "Bronze",
@@ -58887,14 +59914,16 @@
           "type": "PeriodDefinition"
         },
         "p0z3skmvv5c": {
-          "alternateLabel": [
-            "Canaanite"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Canaanite"
+            ]
+          },
           "editorialNote": "removed Neo-Assyrian (722-586 B.C.) and Neo-Babylonian (586-539 B.C.) since not explicit, and added new sources Amitai, Barton, Savage, King/Stager, and Richard. ",
           "id": "p0z3skmvv5c",
           "label": "Canaanite culture",
           "localizedLabel": {
-            "eng-latn": "Canaanite"
+            "eng-latn": "Canaanite culture"
           },
           "source": {
             "locator": "page 174",
@@ -59175,14 +60204,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvh2k9p": {
-          "alternateLabel": [
-            "High Classical"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "High Classical"
+            ]
+          },
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvh2k9p",
           "label": "High Classical Period",
           "localizedLabel": {
-            "eng-latn": "High Classical"
+            "eng-latn": "High Classical Period"
           },
           "source": {
             "locator": "page 113",
@@ -59213,14 +60244,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvh3htc": {
-          "alternateLabel": [
-            "Early Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Byzantine"
+            ]
+          },
           "editorialNote": "For spatial coverage label, please see map on page 235.",
           "id": "p0z5nvh3htc",
           "label": "Early Byzantine Period",
           "localizedLabel": {
-            "eng-latn": "Early Byzantine"
+            "eng-latn": "Early Byzantine Period"
           },
           "source": {
             "locator": "page 262",
@@ -59307,13 +60340,15 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvh48dj": {
-          "alternateLabel": [
-            "Gupta"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Gupta"
+            ]
+          },
           "id": "p0z5nvh48dj",
           "label": "Gupta Period",
           "localizedLabel": {
-            "eng-latn": "Gupta"
+            "eng-latn": "Gupta Period"
           },
           "source": {
             "locator": "pages 319, 312",
@@ -59479,14 +60514,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvh5rr9": {
-          "alternateLabel": [
-            "Late Classical"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Classical"
+            ]
+          },
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvh5rr9",
           "label": "Late Classical Period",
           "localizedLabel": {
-            "eng-latn": "Late Classical"
+            "eng-latn": "Late Classical Period"
           },
           "source": {
             "locator": "page 113",
@@ -59646,14 +60683,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvh9s8x": {
-          "alternateLabel": [
-            "Hellenistic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Hellenistic"
+            ]
+          },
           "editorialNote": "See also map on page 85.",
           "id": "p0z5nvh9s8x",
           "label": "Hellenistic Period",
           "localizedLabel": {
-            "eng-latn": "Hellenistic"
+            "eng-latn": "Hellenistic Period"
           },
           "source": {
             "locator": "page 113",
@@ -59686,14 +60725,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhbkf4": {
-          "alternateLabel": [
-            "Romanesque"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Romanesque"
+            ]
+          },
           "editorialNote": "For spatial coverage label, please see map on page 475.",
           "id": "p0z5nvhbkf4",
           "label": "Romanesque period",
           "localizedLabel": {
-            "eng-latn": "Romanesque"
+            "eng-latn": "Romanesque period"
           },
           "source": {
             "locator": "pages 511, 474",
@@ -59736,14 +60777,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhbsjv": {
-          "alternateLabel": [
-            "Proto-Geometric"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Proto-Geometric"
+            ]
+          },
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvhbsjv",
           "label": "Proto-Geometric Period",
           "localizedLabel": {
-            "eng-latn": "Proto-Geometric"
+            "eng-latn": "Proto-Geometric Period"
           },
           "source": {
             "locator": "page 113",
@@ -59825,14 +60868,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhcxgn": {
-          "alternateLabel": [
-            "Orientalizing"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Orientalizing"
+            ]
+          },
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvhcxgn",
           "label": "Orientalizing Period",
           "localizedLabel": {
-            "eng-latn": "Orientalizing"
+            "eng-latn": "Orientalizing Period"
           },
           "source": {
             "locator": "page 113",
@@ -59863,14 +60908,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhd9kk": {
-          "alternateLabel": [
-            "Geometric"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Geometric"
+            ]
+          },
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvhd9kk",
           "label": "Geometric Period",
           "localizedLabel": {
-            "eng-latn": "Geometric"
+            "eng-latn": "Geometric Period"
           },
           "source": {
             "locator": "page 113",
@@ -59944,13 +60991,15 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhjb4k": {
-          "alternateLabel": [
-            "Minoan New Palace"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Minoan New Palace"
+            ]
+          },
           "id": "p0z5nvhjb4k",
           "label": "Minoan New Palace period",
           "localizedLabel": {
-            "eng-latn": "Minoan New Palace"
+            "eng-latn": "Minoan New Palace period"
           },
           "source": {
             "locator": "page 105",
@@ -59978,14 +61027,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhk4b3": {
-          "alternateLabel": [
-            "Middle Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Middle Byzantine"
+            ]
+          },
           "editorialNote": "For spatial coverage label, please see map on page 235.",
           "id": "p0z5nvhk4b3",
           "label": "Middle Byzantine Period",
           "localizedLabel": {
-            "eng-latn": "Middle Byzantine"
+            "eng-latn": "Middle Byzantine Period"
           },
           "source": {
             "locator": "page 262",
@@ -60099,14 +61150,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhmjhj": {
-          "alternateLabel": [
-            "Helladic",
-            "Mycenaean culture"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Helladic",
+              "Mycenaean culture"
+            ]
+          },
           "id": "p0z5nvhmjhj",
           "label": "Helladic period",
           "localizedLabel": {
-            "eng-latn": "Helladic"
+            "eng-latn": "Helladic period"
           },
           "source": {
             "locator": "pages 95, 105",
@@ -60263,13 +61316,15 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhpjd3": {
-          "alternateLabel": [
-            "Kushan and Later Andhra"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Kushan and Later Andhra"
+            ]
+          },
           "id": "p0z5nvhpjd3",
           "label": "Kushan and Later Andhra Periods",
           "localizedLabel": {
-            "eng-latn": "Kushan and Later Andhra"
+            "eng-latn": "Kushan and Later Andhra Periods"
           },
           "source": {
             "locator": "pages 319, 312",
@@ -60321,13 +61376,15 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhpsq5": {
-          "alternateLabel": [
-            "Maurya"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Maurya"
+            ]
+          },
           "id": "p0z5nvhpsq5",
           "label": "Maurya Period",
           "localizedLabel": {
-            "eng-latn": "Maurya"
+            "eng-latn": "Maurya Period"
           },
           "source": {
             "locator": "pages 319, 312",
@@ -60379,14 +61436,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhqwwx": {
-          "alternateLabel": [
-            "Early Classical"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Early Classical"
+            ]
+          },
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvhqwwx",
           "label": "Early Classical Period",
           "localizedLabel": {
-            "eng-latn": "Early Classical"
+            "eng-latn": "Early Classical Period"
           },
           "source": {
             "locator": "page 113",
@@ -60417,13 +61476,15 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvht3kw": {
-          "alternateLabel": [
-            "Minoan Old Palace"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Minoan Old Palace"
+            ]
+          },
           "id": "p0z5nvht3kw",
           "label": "Minoan Old Palace period",
           "localizedLabel": {
-            "eng-latn": "Minoan Old Palace"
+            "eng-latn": "Minoan Old Palace period"
           },
           "source": {
             "locator": "page 105",
@@ -60498,13 +61559,15 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhtdz8": {
-          "alternateLabel": [
-            "Vedic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Vedic"
+            ]
+          },
           "id": "p0z5nvhtdz8",
           "label": "Vedic Period",
           "localizedLabel": {
-            "eng-latn": "Vedic"
+            "eng-latn": "Vedic Period"
           },
           "source": {
             "locator": "page 341",
@@ -60623,14 +61686,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhw957": {
-          "alternateLabel": [
-            "Late Byzantine"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Late Byzantine"
+            ]
+          },
           "editorialNote": "For spatial coverage label, please see map on page 235.",
           "id": "p0z5nvhw957",
           "label": "Late Byzantine Period",
           "localizedLabel": {
-            "eng-latn": "Late Byzantine"
+            "eng-latn": "Late Byzantine Period"
           },
           "source": {
             "locator": "page 262",
@@ -60677,14 +61742,16 @@
           "type": "PeriodDefinition"
         },
         "p0z5nvhwr6d": {
-          "alternateLabel": [
-            "Archaic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Archaic"
+            ]
+          },
           "editorialNote": "For spatial coverage label, please see map on page 85.",
           "id": "p0z5nvhwr6d",
           "label": "Archaic Period",
           "localizedLabel": {
-            "eng-latn": "Archaic"
+            "eng-latn": "Archaic Period"
           },
           "source": {
             "locator": "page 113",
@@ -62093,13 +63160,15 @@
           "type": "PeriodDefinition"
         },
         "p0zmdxzbnh8": {
-          "alternateLabel": [
-            "Ubaid"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Ubaid"
+            ]
+          },
           "id": "p0zmdxzbnh8",
           "label": "\"Ubaid\"",
           "localizedLabel": {
-            "eng-latn": "Ubaid"
+            "eng-latn": "\"Ubaid\""
           },
           "spatialCoverage": [
             {
@@ -62125,13 +63194,15 @@
           "type": "PeriodDefinition"
         },
         "p0zmdxzd9wg": {
-          "alternateLabel": [
-            "Halaf Chalcolithic"
-          ],
+          "alternateLabel": {
+            "eng-latn": [
+              "Halaf Chalcolithic"
+            ]
+          },
           "id": "p0zmdxzd9wg",
           "label": "\"Halaf\" Chalcolithic",
           "localizedLabel": {
-            "eng-latn": "Halaf Chalcolithic"
+            "eng-latn": "\"Halaf\" Chalcolithic"
           },
           "spatialCoverage": [
             {

--- a/data.json
+++ b/data.json
@@ -28,13 +28,13 @@
     },
     "label": "http://www.w3.org/2004/02/skos/core#prefLabel",
     "latestYear": "periodo:latestYear",
+    "locator": "http://purl.org/ontology/bibo/locator",
+    "name": "http://xmlns.com/foaf/0.1/name",
+    "note": "http://www.w3.org/2004/02/skos/core#note",
     "originalLabel": {
       "@container": "@language",
       "@id": "http://www.w3.org/2004/02/skos/core#altLabel"
     },
-    "locator": "http://purl.org/ontology/bibo/locator",
-    "name": "http://xmlns.com/foaf/0.1/name",
-    "note": "http://www.w3.org/2004/02/skos/core#note",
     "partOf": {
       "@id": "http://purl.org/dc/terms/isPartOf",
       "@type": "@id"
@@ -131,10 +131,10 @@
         "p02sht94cwr": {
           "id": "p02sht94cwr",
           "label": "Jemdet Nasr",
+          "note": "See also Charvat 2002",
           "originalLabel": {
             "eng-latn": "Jemdet Nasr"
           },
-          "note": "See also Charvat 2002",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Iraq",
@@ -159,10 +159,10 @@
         "p02sht9fzvs": {
           "id": "p02sht9fzvs",
           "label": "Early Uruk",
+          "note": "See also Liverani 2006",
           "originalLabel": {
             "eng-latn": "Early Uruk"
           },
-          "note": "See also Liverani 2006",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Iraq",
@@ -187,10 +187,10 @@
         "p02sht9wp3g": {
           "id": "p02sht9wp3g",
           "label": "Late Uruk",
+          "note": "See also Liverani 2006",
           "originalLabel": {
             "eng-latn": "Late Uruk"
           },
-          "note": "See also Liverani 2006",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Iraq",
@@ -390,10 +390,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd23gj",
           "label": "Mesolithic Middle East (18000-9000 BC)",
+          "note": "Epipaleolithic-Protoneolithic ME",
           "originalLabel": {
             "eng-latn": "Mesolithic Middle East (18000-9000 BC)"
           },
-          "note": "Epipaleolithic-Protoneolithic ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/mesolithic-middle-east",
           "spatialCoverage": [
             {
@@ -438,10 +438,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd25c5",
           "label": "Mongol Middle East (AD 1258-1501)",
+          "note": "ME, Central Asia",
           "originalLabel": {
             "eng-latn": "Mongol Middle East (AD 1258-1501)"
           },
-          "note": "ME, Central Asia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/mongol-middle-east",
           "spatialCoverage": [
             {
@@ -510,10 +510,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd29mn",
           "label": "Urartian Eastern Anatolia (900-600 BC)",
+          "note": "eastern Anatolia",
           "originalLabel": {
             "eng-latn": "Urartian Eastern Anatolia (900-600 BC)"
           },
-          "note": "eastern Anatolia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/urartian-eastern-anatolia",
           "spatialCoverage": [
             {
@@ -550,10 +550,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd2cfk",
           "label": "Ottoman Rise (AD 1300-1453)",
+          "note": "ends with the conquest of Constantinople",
           "originalLabel": {
             "eng-latn": "Ottoman Rise (AD 1300-1453)"
           },
-          "note": "ends with the conquest of Constantinople",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ottoman-rise",
           "spatialCoverage": [
             {
@@ -605,10 +605,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd2rhh",
           "label": "Khwarezmian Middle East (AD 1077-1258)",
+          "note": "Khwarezmid",
           "originalLabel": {
             "eng-latn": "Khwarezmian Middle East (AD 1077-1258)"
           },
-          "note": "Khwarezmid",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/khwarezmian-middle-east",
           "spatialCoverage": [
             {
@@ -657,10 +657,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd389m",
           "label": "Classical (Greco-Roman; 550 BC-330 BC)",
+          "note": "The Classical period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 550 and end in the year 330 before the birth of Christ.",
           "originalLabel": {
             "eng-latn": "Classical (Greco-Roman; 550 BC-330 BC)"
           },
-          "note": "The Classical period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 550 and end in the year 330 before the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/classical",
           "spatialCoverage": [
             {
@@ -920,10 +920,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd47fw",
           "label": "Late Period Egypt (664-332)",
+          "note": "The Late Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "originalLabel": {
             "eng-latn": "Late Period Egypt (664-332)"
           },
-          "note": "The Late Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-period-egypt",
           "spatialCoverage": [
             {
@@ -956,10 +956,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd4mmt",
           "label": "2nd Millenium BCE",
+          "note": "The second millenium BCE as defined at http://en.wikipedia.org/wiki/2nd_millennium_BC",
           "originalLabel": {
             "eng-latn": "2nd Millenium BCE"
           },
-          "note": "The second millenium BCE as defined at http://en.wikipedia.org/wiki/2nd_millennium_BC",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/2nd-millenium-bce",
           "spatialCoverage": [
             {
@@ -1035,10 +1035,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd4n95",
           "label": "Samanid-Ghaznavid Iran (AD 819-1186)",
+          "note": "Iran",
           "originalLabel": {
             "eng-latn": "Samanid-Ghaznavid Iran (AD 819-1186)"
           },
-          "note": "Iran",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/samanid-ghaznavid-iran",
           "spatialCoverage": [
             {
@@ -1111,10 +1111,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd4rpp",
           "label": "Hellenistic Middle East (330-140 BC)",
+          "note": "Macedonian-Seleucid/Ptolemaic/Attalid/Greco-Bactrian",
           "originalLabel": {
             "eng-latn": "Hellenistic Middle East (330-140 BC)"
           },
-          "note": "Macedonian-Seleucid/Ptolemaic/Attalid/Greco-Bactrian",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-middle-east",
           "spatialCoverage": [
             {
@@ -1195,10 +1195,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd5222",
           "label": "Crusader-Ottoman Levant (AD 1099-1750)",
+          "note": "Crusader-Seljuq-Ayyubid-Mamluk-Ottoman Levant",
           "originalLabel": {
             "eng-latn": "Crusader-Ottoman Levant (AD 1099-1750)"
           },
-          "note": "Crusader-Seljuq-Ayyubid-Mamluk-Ottoman Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/crusader-ottoman-levant",
           "spatialCoverage": [
             {
@@ -1233,10 +1233,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd55sw",
           "label": "Hellenistic Greek, Roman Republic (330 BC-30 BC)",
+          "note": "The Hellenistic period in Greek history and the middle-to-late Republican period in Roman history. For the purposes of Pleiades, this period is said to begin in the year 330 and end in the year 30 before the birth of Christ.",
           "originalLabel": {
             "eng-latn": "Hellenistic Greek, Roman Republic (330 BC-30 BC)"
           },
-          "note": "The Hellenistic period in Greek history and the middle-to-late Republican period in Roman history. For the purposes of Pleiades, this period is said to begin in the year 330 and end in the year 30 before the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-republican",
           "spatialCoverage": [
             {
@@ -1568,10 +1568,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd5dbn",
           "label": "Late Bronze Age Southern Levant (1400-1200 BC)",
+          "note": "southern Levant",
           "originalLabel": {
             "eng-latn": "Late Bronze Age Southern Levant (1400-1200 BC)"
           },
-          "note": "southern Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-bronze-age-southern-levant",
           "spatialCoverage": [
             {
@@ -1616,10 +1616,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd5mwr",
           "label": "Transition Early-Middle Bronze Age Southern Levant (2100-1900 BC)",
+          "note": "southern Levant",
           "originalLabel": {
             "eng-latn": "Transition Early-Middle Bronze Age Southern Levant (2100-1900 BC)"
           },
-          "note": "southern Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/transition-early-middle-bronze-age-southern-levant",
           "spatialCoverage": [
             {
@@ -1664,10 +1664,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd5v96",
           "label": "Transition Roman Early Empire-Late Antique (AD 284-337)",
+          "note": "Mediterranean",
           "originalLabel": {
             "eng-latn": "Transition Roman Early Empire-Late Antique (AD 284-337)"
           },
-          "note": "Mediterranean",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/transition-roman-early-empire-late-antique",
           "spatialCoverage": [
             {
@@ -1751,10 +1751,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd69hp",
           "label": "Khedivate Egypt (AD 1800-1922)",
+          "note": "Muhammed Ali-Khedivate Egypt, Alawiyya Egypt, Anglo-Egyptian",
           "originalLabel": {
             "eng-latn": "Khedivate Egypt (AD 1800-1922)"
           },
-          "note": "Muhammed Ali-Khedivate Egypt, Alawiyya Egypt, Anglo-Egyptian",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/khedivate-egypt",
           "spatialCoverage": [
             {
@@ -1839,10 +1839,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd6hw5",
           "label": "Egyptian/Hittite Levant (1344-1212 BC)",
+          "note": "Levant",
           "originalLabel": {
             "eng-latn": "Egyptian/Hittite Levant (1344-1212 BC)"
           },
-          "note": "Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/egyptian-hittite-levant",
           "spatialCoverage": [
             {
@@ -1895,10 +1895,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd6nrz",
           "label": "Iron Age Britain (ca. 800 BC/BCE - ca. 100 AD/CE)",
+          "note": "A long time period associated with Iron Age Britain.",
           "originalLabel": {
             "eng-latn": "Iron Age Britain (ca. 800 BC/BCE - ca. 100 AD/CE)"
           },
-          "note": "A long time period associated with Iron Age Britain.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/iron-age-britain",
           "spatialCoverage": [
             {
@@ -1935,10 +1935,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd6psm",
           "label": "Late Antique (AD 300-AD 640)",
+          "note": "The Late Antique period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 300 and to end in the year 640 after the birth of Christ.",
           "originalLabel": {
             "eng-latn": "Late Antique (AD 300-AD 640)"
           },
-          "note": "The Late Antique period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 300 and to end in the year 640 after the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-antique",
           "spatialCoverage": [
             {
@@ -2302,10 +2302,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd6vvr",
           "label": "Middle Byzantine (AD 850-1200)",
+          "note": "Middle Byzantine period in areas where such designations are appropriate.",
           "originalLabel": {
             "eng-latn": "Middle Byzantine (AD 850-1200)"
           },
-          "note": "Middle Byzantine period in areas where such designations are appropriate.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-byzantine",
           "spatialCoverage": [
             {
@@ -2381,10 +2381,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd7s5r",
           "label": "Perso-Ottoman-Russian Caucasus (AD 1500-1918)",
+          "note": "Safavid-Qajar-Ottoman Empire-Russian Empire Caucasus",
           "originalLabel": {
             "eng-latn": "Perso-Ottoman-Russian Caucasus (AD 1500-1918)"
           },
-          "note": "Safavid-Qajar-Ottoman Empire-Russian Empire Caucasus",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/perso-ottoman-russian-caucasus",
           "spatialCoverage": [
             {
@@ -2437,10 +2437,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd825s",
           "label": "Hellenistic-Roman Early Empire (330 BC - AD 300)",
+          "note": "Mediterranean",
           "originalLabel": {
             "eng-latn": "Hellenistic-Roman Early Empire (330 BC - AD 300)"
           },
-          "note": "Mediterranean",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-roman-early-empire",
           "spatialCoverage": [
             {
@@ -2540,10 +2540,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd82ps",
           "label": "Middle Bronze Age Anatolia (1750-1450 BC)",
+          "note": "Anatolia",
           "originalLabel": {
             "eng-latn": "Middle Bronze Age Anatolia (1750-1450 BC)"
           },
-          "note": "Anatolia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-age-anatolia",
           "spatialCoverage": [
             {
@@ -2580,10 +2580,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd83qf",
           "label": "Late Antique/Sasanian Middle East (AD 300-640)",
+          "note": "ME",
           "originalLabel": {
             "eng-latn": "Late Antique/Sasanian Middle East (AD 300-640)"
           },
-          "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-antique-sasanian-middle-east",
           "spatialCoverage": [
             {
@@ -2668,10 +2668,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd93hp",
           "label": "Parthian Middle East (140 BC - AD 226)",
+          "note": "Arsacid ME",
           "originalLabel": {
             "eng-latn": "Parthian Middle East (140 BC - AD 226)"
           },
-          "note": "Arsacid ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/parthian-middle-east",
           "spatialCoverage": [
             {
@@ -2704,10 +2704,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd95m9",
           "label": "Ptolemaic Egypt (304-30 BCE/BC)",
+          "note": "The Ptolemaic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "originalLabel": {
             "eng-latn": "Ptolemaic Egypt (304-30 BCE/BC)"
           },
-          "note": "The Ptolemaic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ptolemaic-egypt",
           "spatialCoverage": [
             {
@@ -2740,10 +2740,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd97z7",
           "label": "Ottoman Empire (AD 1513-1918)",
+          "note": "ME, Balkan, Northern Africa",
           "originalLabel": {
             "eng-latn": "Ottoman Empire (AD 1513-1918)"
           },
-          "note": "ME, Balkan, Northern Africa",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ottoman-empire",
           "spatialCoverage": [
             {
@@ -2823,10 +2823,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd98jh",
           "label": "Early Medieval Caucasus (AD 850-1200)",
+          "note": "Bagratid, Kingdom of Armenia/Kingdom of Georgia",
           "originalLabel": {
             "eng-latn": "Early Medieval Caucasus (AD 850-1200)"
           },
-          "note": "Bagratid, Kingdom of Armenia/Kingdom of Georgia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-medieval-caucasus",
           "spatialCoverage": [
             {
@@ -2879,10 +2879,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd9h8w",
           "label": "1500 AD Middle East (AD 1500-1500)",
+          "note": "ME, Greece, Indus",
           "originalLabel": {
             "eng-latn": "1500 AD Middle East (AD 1500-1500)"
           },
-          "note": "ME, Greece, Indus",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/1500-ad-middle-east",
           "spatialCoverage": [
             {
@@ -2991,10 +2991,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskd9szx",
           "label": "Chalcolithic Iran (5000-2500 BC)",
+          "note": "Iran",
           "originalLabel": {
             "eng-latn": "Chalcolithic Iran (5000-2500 BC)"
           },
-          "note": "Iran",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/chalcolithic-iran",
           "spatialCoverage": [
             {
@@ -3031,10 +3031,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdbftw",
           "label": "Safavid Middle East (AD 1501-1725)",
+          "note": "Eastern ME, Central Asia",
           "originalLabel": {
             "eng-latn": "Safavid Middle East (AD 1501-1725)"
           },
-          "note": "Eastern ME, Central Asia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/safavid-middle-east",
           "spatialCoverage": [
             {
@@ -3087,10 +3087,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdbh6h",
           "label": "4th millenium BCE",
+          "note": "The fourth millenium BCE as defined at http://en.wikipedia.org/wiki/4th_millennium_BC",
           "originalLabel": {
             "eng-latn": "4th millenium BCE"
           },
-          "note": "The fourth millenium BCE as defined at http://en.wikipedia.org/wiki/4th_millennium_BC",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/4th-millenium-bce",
           "spatialCoverage": [
             {
@@ -3146,10 +3146,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdbvmg",
           "label": "Akkadian-Ur III Mesopotamia (2335-2000 BC)",
+          "note": "Akkadian-Neo-Sumerian Mesopotamia",
           "originalLabel": {
             "eng-latn": "Akkadian-Ur III Mesopotamia (2335-2000 BC)"
           },
-          "note": "Akkadian-Neo-Sumerian Mesopotamia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/akkadian-ur-iii-mesopotamia",
           "spatialCoverage": [
             {
@@ -3190,10 +3190,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdc5xs",
           "label": "Middle Nubian (2300-1600 BC)",
+          "note": "C-Group-Kerma-Middle Nubian-Pan-Grave-MK",
           "originalLabel": {
             "eng-latn": "Middle Nubian (2300-1600 BC)"
           },
-          "note": "C-Group-Kerma-Middle Nubian-Pan-Grave-MK",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-nubian",
           "spatialCoverage": [
             {
@@ -3225,10 +3225,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdc6nf",
           "label": "Middle Bronze-Early Iron Age Iran (2000-650 BC)",
+          "note": "Iran",
           "originalLabel": {
             "eng-latn": "Middle Bronze-Early Iron Age Iran (2000-650 BC)"
           },
-          "note": "Iran",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-early-iron-age-iran",
           "spatialCoverage": [
             {
@@ -3273,10 +3273,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdccmk",
           "label": "Colonial-Modern Middle East (AD 1800-2000)",
+          "note": "Late Ottoman-Colonial-Mandate Modern Middle east",
           "originalLabel": {
             "eng-latn": "Colonial-Modern Middle East (AD 1800-2000)"
           },
-          "note": "Late Ottoman-Colonial-Mandate Modern Middle east",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/colonial-modern-middle-east",
           "spatialCoverage": [
             {
@@ -3325,10 +3325,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdcctk",
           "label": "Roman Early Empire-Late Antique (30 BC - AD 640)",
+          "note": "Mediterranean",
           "originalLabel": {
             "eng-latn": "Roman Early Empire-Late Antique (30 BC - AD 640)"
           },
-          "note": "Mediterranean",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/roman-early-empire-late-antique",
           "spatialCoverage": [
             {
@@ -3436,10 +3436,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdcdz7",
           "label": "Mediaeval/Byzantine (AD 641-AD 1453)",
+          "note": "The Mediaeval period in the West, or the period from the end of Late Antiquity (640) to the fall of Constantinople in the East (1453).",
           "originalLabel": {
             "eng-latn": "Mediaeval/Byzantine (AD 641-AD 1453)"
           },
-          "note": "The Mediaeval period in the West, or the period from the end of Late Antiquity (640) to the fall of Constantinople in the East (1453).",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/mediaeval-byzantine",
           "spatialCoverage": [
             {
@@ -3551,10 +3551,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdcmjz",
           "label": "Middle Hittite Anatolia (1450-1200 BC)",
+          "note": "New Kingdom Hittite",
           "originalLabel": {
             "eng-latn": "Middle Hittite Anatolia (1450-1200 BC)"
           },
-          "note": "New Kingdom Hittite",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-hittite-anatolia",
           "spatialCoverage": [
             {
@@ -3595,10 +3595,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdcpjk",
           "label": "Proto-Byzantine (AD 500-650)",
+          "note": "Early Byzantine; includes Justinian I",
           "originalLabel": {
             "eng-latn": "Proto-Byzantine (AD 500-650)"
           },
-          "note": "Early Byzantine; includes Justinian I",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/proto-byzantine",
           "spatialCoverage": [
             {
@@ -3670,10 +3670,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdd2st",
           "label": "Neolithic Egypt (6000-4500 BCE/BC)",
+          "note": "The Neolithic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "originalLabel": {
             "eng-latn": "Neolithic Egypt (6000-4500 BCE/BC)"
           },
-          "note": "The Neolithic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-egypt",
           "spatialCoverage": [
             {
@@ -3710,10 +3710,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddb3j",
           "label": "New Kingdom Egypt (1548-1086)",
+          "note": "The New Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "originalLabel": {
             "eng-latn": "New Kingdom Egypt (1548-1086)"
           },
-          "note": "The New Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/new-kingdom-egypt",
           "spatialCoverage": [
             {
@@ -3754,10 +3754,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddbqj",
           "label": "Elamite Western Iran (3200-540 BC)",
+          "note": "Proto-Old-Middle-Neo-Elamite",
           "originalLabel": {
             "eng-latn": "Elamite Western Iran (3200-540 BC)"
           },
-          "note": "Proto-Old-Middle-Neo-Elamite",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/elamite-western-iran",
           "spatialCoverage": [
             {
@@ -3798,10 +3798,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddc9t",
           "label": "Neolithic Period on Malta (ca. 5,000-2,500BC)",
+          "note": "The neolithic or so-called \"New Stone Age\" as expressed in remains of physical culture on the island of Malta, where it appears to have lasted from around 5,000 to 2,500 BC",
           "originalLabel": {
             "eng-latn": "Neolithic Period on Malta (ca. 5,000-2,500BC)"
           },
-          "note": "The neolithic or so-called \"New Stone Age\" as expressed in remains of physical culture on the island of Malta, where it appears to have lasted from around 5,000 to 2,500 BC",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-malta",
           "spatialCoverage": [
             {
@@ -3834,10 +3834,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddvwn",
           "label": "Achaemenid-Roman Republic Middle East (540-30 BC)",
+          "note": "ME",
           "originalLabel": {
             "eng-latn": "Achaemenid-Roman Republic Middle East (540-30 BC)"
           },
-          "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/achaemenid-roman-republic-middle-east",
           "spatialCoverage": [
             {
@@ -3978,10 +3978,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskddwzm",
           "label": "Hellenistic-Parthian Middle East (330 BC - AD 226)",
+          "note": "Seleucid-Early Roman-Arsacid Middle East",
           "originalLabel": {
             "eng-latn": "Hellenistic-Parthian Middle East (330 BC - AD 226)"
           },
-          "note": "Seleucid-Early Roman-Arsacid Middle East",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-parthian-middle-east",
           "spatialCoverage": [
             {
@@ -4014,10 +4014,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdf7wk",
           "label": "Early Ottoman Empire (AD 1453-1683)",
+          "note": "ends with the siege of Vienna",
           "originalLabel": {
             "eng-latn": "Early Ottoman Empire (AD 1453-1683)"
           },
-          "note": "ends with the siege of Vienna",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-ottoman-empire",
           "spatialCoverage": [
             {
@@ -4109,10 +4109,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfbcg",
           "label": "Late Ottoman Empire (AD 1683-1918)",
+          "note": "ME, Balkan, Northern Africa",
           "originalLabel": {
             "eng-latn": "Late Ottoman Empire (AD 1683-1918)"
           },
-          "note": "ME, Balkan, Northern Africa",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-ottoman-empire",
           "spatialCoverage": [
             {
@@ -4220,10 +4220,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfd83",
           "label": "Bronze Age Britain (ca. 2500 - ca. 800 BC/BCE)",
+          "note": "A long time period associated with Bronze Age Britain.",
           "originalLabel": {
             "eng-latn": "Bronze Age Britain (ca. 2500 - ca. 800 BC/BCE)"
           },
-          "note": "A long time period associated with Bronze Age Britain.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/bronze-age-britain",
           "spatialCoverage": [
             {
@@ -4256,10 +4256,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfnrs",
           "label": "Late Nubian (1600-350 BC)",
+          "note": "NK-Kushite-Meroitic",
           "originalLabel": {
             "eng-latn": "Late Nubian (1600-350 BC)"
           },
-          "note": "NK-Kushite-Meroitic",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-nubian",
           "spatialCoverage": [
             {
@@ -4291,10 +4291,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfpqr",
           "label": "Later 2nd Millennium BC Mesopotamia (1600-1000 BC)",
+          "note": "Middle Assyrian/Middle Babylonian/Kassite Mesopotamia, LBA-Early Iron Age Mesopotamia, incl. Sea Peoples",
           "originalLabel": {
             "eng-latn": "Later 2nd Millennium BC Mesopotamia (1600-1000 BC)"
           },
-          "note": "Middle Assyrian/Middle Babylonian/Kassite Mesopotamia, LBA-Early Iron Age Mesopotamia, incl. Sea Peoples",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/later-2nd-millennium-bc-mesopotamia",
           "spatialCoverage": [
             {
@@ -4339,10 +4339,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdfrrp",
           "label": "Mesolithic Levant (18000-9500 BC)",
+          "note": "Epipaleolithic-Protoneolithic Levant, Kebaran-Natufian",
           "originalLabel": {
             "eng-latn": "Mesolithic Levant (18000-9500 BC)"
           },
-          "note": "Epipaleolithic-Protoneolithic Levant, Kebaran-Natufian",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/mesolithic-levant",
           "spatialCoverage": [
             {
@@ -4383,10 +4383,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdftkm",
           "label": "Ptolemaic-Roman Egypt (304 BC - AD 640)",
+          "note": "Egypt",
           "originalLabel": {
             "eng-latn": "Ptolemaic-Roman Egypt (304 BC - AD 640)"
           },
-          "note": "Egypt",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ptolemaic-roman-egypt",
           "spatialCoverage": [
             {
@@ -4435,10 +4435,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdg8s5",
           "label": "Crusader/Seljuq-Ayyubid Levant (AD 1099-1291)",
+          "note": "Latin",
           "originalLabel": {
             "eng-latn": "Crusader/Seljuq-Ayyubid Levant (AD 1099-1291)"
           },
-          "note": "Latin",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/crusader-seljuq-ayyubid-levant",
           "spatialCoverage": [
             {
@@ -4503,10 +4503,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgh6j",
           "label": "Modern (AD 1700-Present)",
+          "note": "Our present, modern era.",
           "originalLabel": {
             "eng-latn": "Modern (AD 1700-Present)"
           },
-          "note": "Our present, modern era.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/modern",
           "spatialCoverage": [
             {
@@ -4834,10 +4834,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgmtf",
           "label": "Old Kingdom Egypt (2670-2168 BCE/BC)",
+          "note": "The Old Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "originalLabel": {
             "eng-latn": "Old Kingdom Egypt (2670-2168 BCE/BC)"
           },
-          "note": "The Old Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/old-kingdom-egypt",
           "spatialCoverage": [
             {
@@ -4870,10 +4870,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgn3q",
           "label": "Pre-Pottery Neolithic Middle East (9000-6000 BC)",
+          "note": "Aceramic Neolithic ME",
           "originalLabel": {
             "eng-latn": "Pre-Pottery Neolithic Middle East (9000-6000 BC)"
           },
-          "note": "Aceramic Neolithic ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/pre-pottery-neolithic-middle-east",
           "spatialCoverage": [
             {
@@ -4910,10 +4910,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgpzc",
           "label": "Timurid Middle East (AD 1370-1501)",
+          "note": "Eastern ME, Central Asia",
           "originalLabel": {
             "eng-latn": "Timurid Middle East (AD 1370-1501)"
           },
-          "note": "Eastern ME, Central Asia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/timurid-middle-east",
           "spatialCoverage": [
             {
@@ -4982,10 +4982,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdgq4n",
           "label": "Middle Kingdom Egypt (2010-1640 BCE/BC)",
+          "note": "The Middle Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "originalLabel": {
             "eng-latn": "Middle Kingdom Egypt (2010-1640 BCE/BC)"
           },
-          "note": "The Middle Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-kingdom-egypt",
           "spatialCoverage": [
             {
@@ -5022,10 +5022,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdh9h2",
           "label": "Ubaid-Early Dynastic II Mesopotamia (5500-2600 BC)",
+          "note": "Late Chalcolithic-ED II Mesopotamia, Ubaid-Uruk-Jemdet Nasr-ED Mesopotamia",
           "originalLabel": {
             "eng-latn": "Ubaid-Early Dynastic II Mesopotamia (5500-2600 BC)"
           },
-          "note": "Late Chalcolithic-ED II Mesopotamia, Ubaid-Uruk-Jemdet Nasr-ED Mesopotamia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ubaid-early-dynastic-ii-mesopotamia",
           "spatialCoverage": [
             {
@@ -5070,10 +5070,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdhc9m",
           "label": "Early Bronze Age Southern Levant (3300-2000 BC)",
+          "note": "southern Levant",
           "originalLabel": {
             "eng-latn": "Early Bronze Age Southern Levant (3300-2000 BC)"
           },
-          "note": "southern Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-bronze-age-southern-levant",
           "spatialCoverage": [
             {
@@ -5118,10 +5118,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdhqrw",
           "label": "Roman Middle East (140 BC - AD 640)",
+          "note": "ME",
           "originalLabel": {
             "eng-latn": "Roman Middle East (140 BC - AD 640)"
           },
-          "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/roman-middle-east",
           "spatialCoverage": [
             {
@@ -5198,10 +5198,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdj3g6",
           "label": "Caliphate-Umayyad Middle East (AD 632-750)",
+          "note": "Early Islamic, Rashidun-Umayyad (starts with death of Muhammed who only controlled Arabia)",
           "originalLabel": {
             "eng-latn": "Caliphate-Umayyad Middle East (AD 632-750)"
           },
-          "note": "Early Islamic, Rashidun-Umayyad (starts with death of Muhammed who only controlled Arabia)",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/caliphate-umayyad-middle-east",
           "spatialCoverage": [
             {
@@ -5294,10 +5294,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdj8bb",
           "label": "Seljuq-Khwarezmian Middle East (AD 1037-1258)",
+          "note": "ME",
           "originalLabel": {
             "eng-latn": "Seljuq-Khwarezmian Middle East (AD 1037-1258)"
           },
-          "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/seljuq-khwarezmian-middle-east",
           "spatialCoverage": [
             {
@@ -5346,10 +5346,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjbp8",
           "label": "Early Byzantine (AD 650-850)",
+          "note": "Early Byzantine Period in areas where such designations are appropriate.",
           "originalLabel": {
             "eng-latn": "Early Byzantine (AD 650-850)"
           },
-          "note": "Early Byzantine Period in areas where such designations are appropriate.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-byzantine",
           "spatialCoverage": [
             {
@@ -5421,10 +5421,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjcqv",
           "label": "Middle Geometric (Greek; 850-750 BC)",
+          "note": "The Middle Geometric period in ancient Greece, from 850-750 before the birth of Christ.",
           "originalLabel": {
             "eng-latn": "Middle Geometric (Greek; 850-750 BC)"
           },
-          "note": "The Middle Geometric period in ancient Greece, from 850-750 before the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-geometric",
           "spatialCoverage": [
             {
@@ -5464,10 +5464,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjhsq",
           "label": "Pottery Neolithic Middle East (6000-4500 BC)",
+          "note": "ME",
           "originalLabel": {
             "eng-latn": "Pottery Neolithic Middle East (6000-4500 BC)"
           },
-          "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/pottery-neolithic-middle-east",
           "spatialCoverage": [
             {
@@ -5524,10 +5524,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjqsh",
           "label": "Bronze Age Malta (ca. 2,500-700 BC)",
+          "note": "The Bronze age as represented in the remains of physical culture from the island of Malta.",
           "originalLabel": {
             "eng-latn": "Bronze Age Malta (ca. 2,500-700 BC)"
           },
-          "note": "The Bronze age as represented in the remains of physical culture from the island of Malta.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/bronze-age-malta",
           "spatialCoverage": [
             {
@@ -5560,10 +5560,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjrcs",
           "label": "Middle-Late Iron Age Anatolia (700-500 BC)",
+          "note": "Anatolia",
           "originalLabel": {
             "eng-latn": "Middle-Late Iron Age Anatolia (700-500 BC)"
           },
-          "note": "Anatolia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-late-iron-age-anatolia",
           "spatialCoverage": [
             {
@@ -5608,10 +5608,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdjw3b",
           "label": "Neolithic Middle East (9000-4500 BC)",
+          "note": "ME",
           "originalLabel": {
             "eng-latn": "Neolithic Middle East (9000-4500 BC)"
           },
-          "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-middle-east",
           "spatialCoverage": [
             {
@@ -5652,10 +5652,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdk2k5",
           "label": "Iron Age Italy (Latial Culture I, 1000-900 BC)",
+          "note": "Latial I is concentrated around Rome, the Alban Hills, and the Monti della Tolfa.",
           "originalLabel": {
             "eng-latn": "Iron Age Italy (Latial Culture I, 1000-900 BC)"
           },
-          "note": "Latial I is concentrated around Rome, the Alban Hills, and the Monti della Tolfa.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/iron-age-italy-latial-culture-i-1000-900-bc",
           "spatialCoverage": [
             {
@@ -5688,10 +5688,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdk582",
           "label": "Ilkhanate Middle East (AD 1258-1335)",
+          "note": "Ilkhanid, Hulagu, Early Mongol",
           "originalLabel": {
             "eng-latn": "Ilkhanate Middle East (AD 1258-1335)"
           },
-          "note": "Ilkhanid, Hulagu, Early Mongol",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ilkhanate-middle-east",
           "spatialCoverage": [
             {
@@ -5768,10 +5768,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdm4tb",
           "label": "Early Iron Age Anatolia (1200-700 BC)",
+          "note": "incl. Mitanni",
           "originalLabel": {
             "eng-latn": "Early Iron Age Anatolia (1200-700 BC)"
           },
-          "note": "incl. Mitanni",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-iron-age-anatolia",
           "spatialCoverage": [
             {
@@ -5820,10 +5820,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdm62k",
           "label": "Old Nubian (3800-2300 BC)",
+          "note": "A-Group/Old Nubian-Middle Nubian-OK",
           "originalLabel": {
             "eng-latn": "Old Nubian (3800-2300 BC)"
           },
-          "note": "A-Group/Old Nubian-Middle Nubian-OK",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/old-nubian",
           "spatialCoverage": [
             {
@@ -5855,10 +5855,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdmzfr",
           "label": "Third Intermediate Period Egypt (1086-664)",
+          "note": "The Third Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "originalLabel": {
             "eng-latn": "Third Intermediate Period Egypt (1086-664)"
           },
-          "note": "The Third Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/third-intermediate-period-egypt",
           "spatialCoverage": [
             {
@@ -5895,10 +5895,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnjq5",
           "label": "1200 BC Middle East",
+          "note": "ME, Greece",
           "originalLabel": {
             "eng-latn": "1200 BC Middle East"
           },
-          "note": "ME, Greece",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/1200-bc-middle-east",
           "spatialCoverage": [
             {
@@ -5999,10 +5999,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnnpp",
           "label": "Ummayad Period (661-750CE)",
+          "note": "The period of the Umayyad Caliphate as defined by http://en.wikipedia.org/wiki/Umayyad_Caliphate",
           "originalLabel": {
             "eng-latn": "Ummayad Period (661-750CE)"
           },
-          "note": "The period of the Umayyad Caliphate as defined by http://en.wikipedia.org/wiki/Umayyad_Caliphate",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ummayad",
           "spatialCoverage": [
             {
@@ -6042,10 +6042,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnwd4",
           "label": "Archaic (Greco-Roman; 750-550 BCE/BC)",
+          "note": "The Archaic period in Greek and Roman history. For the purposes of Pleiades, this period is seen to begin in the year 750 and end in the year 550 before the birth of Christ.",
           "originalLabel": {
             "eng-latn": "Archaic (Greco-Roman; 750-550 BCE/BC)"
           },
-          "note": "The Archaic period in Greek and Roman history. For the purposes of Pleiades, this period is seen to begin in the year 750 and end in the year 550 before the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/archaic",
           "spatialCoverage": [
             {
@@ -6221,10 +6221,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnxfq",
           "label": "2nd Millennium BC Egypt (2000-1000 BC)",
+          "note": "Egypt",
           "originalLabel": {
             "eng-latn": "2nd Millennium BC Egypt (2000-1000 BC)"
           },
-          "note": "Egypt",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/2nd-millennium-bc-egypt",
           "spatialCoverage": [
             {
@@ -6265,10 +6265,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdnzgc",
           "label": "Early Bronze Age Anatolia (2000-1750 BC)",
+          "note": "Karum Anatolia",
           "originalLabel": {
             "eng-latn": "Early Bronze Age Anatolia (2000-1750 BC)"
           },
-          "note": "Karum Anatolia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-bronze-age-anatolia",
           "spatialCoverage": [
             {
@@ -6301,10 +6301,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdp535",
           "label": "Mamluk Middle East (AD 1258-1516)",
+          "note": "Western ME",
           "originalLabel": {
             "eng-latn": "Mamluk Middle East (AD 1258-1516)"
           },
-          "note": "Western ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/mamluk-middle-east",
           "spatialCoverage": [
             {
@@ -6337,10 +6337,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpj3d",
           "label": "Neolithic Period (British Isles; 4,000-2,500 BC)",
+          "note": "The Neolithic period in the British Isles, after Wikipedia, Neolithic British Isles, http://en.wikipedia.org/wiki/Neolithic_British_Isles.",
           "originalLabel": {
             "eng-latn": "Neolithic Period (British Isles; 4,000-2,500 BC)"
           },
-          "note": "The Neolithic period in the British Isles, after Wikipedia, Neolithic British Isles, http://en.wikipedia.org/wiki/Neolithic_British_Isles.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-british",
           "spatialCoverage": [
             {
@@ -6373,10 +6373,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpjk3",
           "label": "Late Antique-Late Byzantine (AD 300-1450)",
+          "note": "ME",
           "originalLabel": {
             "eng-latn": "Late Antique-Late Byzantine (AD 300-1450)"
           },
-          "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-antique-late-byzantine",
           "spatialCoverage": [
             {
@@ -6424,10 +6424,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpqmv",
           "label": "2nd Millennium BC Levant (2000-1000 BC)",
+          "note": "MBA Levant-LBA Levant-Iron Age I Levant (not sure as these are all taken from southern Levant periodisation)",
           "originalLabel": {
             "eng-latn": "2nd Millennium BC Levant (2000-1000 BC)"
           },
-          "note": "MBA Levant-LBA Levant-Iron Age I Levant (not sure as these are all taken from southern Levant periodisation)",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/2nd-millennium-bc-levant",
           "spatialCoverage": [
             {
@@ -6484,10 +6484,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpxwb",
           "label": "Abassid Middle East (AD 750-940)",
+          "note": "ME, northern Africa",
           "originalLabel": {
             "eng-latn": "Abassid Middle East (AD 750-940)"
           },
-          "note": "ME, northern Africa",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/abassid-middle-east",
           "spatialCoverage": [
             {
@@ -6576,10 +6576,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdpzn9",
           "label": "Roman-Early Byzantine Middle East (140 BC - AD 850)",
+          "note": "ME",
           "originalLabel": {
             "eng-latn": "Roman-Early Byzantine Middle East (140 BC - AD 850)"
           },
-          "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/roman-early-byzantine-middle-east",
           "spatialCoverage": [
             {
@@ -6620,10 +6620,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdq5md",
           "label": "Late Byzantine/Ottoman Rise (AD 1200-1453)",
+          "note": "Aegean, Balkan & Anatolia",
           "originalLabel": {
             "eng-latn": "Late Byzantine/Ottoman Rise (AD 1200-1453)"
           },
-          "note": "Aegean, Balkan & Anatolia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-byzantine-ottoman-rise",
           "spatialCoverage": [
             {
@@ -6679,10 +6679,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdqq4g",
           "label": "Crusader/Byzantine/Seljuq Middle East (AD 1081-1204)",
+          "note": "Latin/1st-4th Crusades-end of Middle Byzantine-Rum/Seljuq",
           "originalLabel": {
             "eng-latn": "Crusader/Byzantine/Seljuq Middle East (AD 1081-1204)"
           },
-          "note": "Latin/1st-4th Crusades-end of Middle Byzantine-Rum/Seljuq",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/crusader-byzantine-seljuq-middle-east",
           "spatialCoverage": [
             {
@@ -6735,10 +6735,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdqzgv",
           "label": "Middle Bronze Age Southern Levant (2000-1400 BC)",
+          "note": "southern Levant",
           "originalLabel": {
             "eng-latn": "Middle Bronze Age Southern Levant (2000-1400 BC)"
           },
-          "note": "southern Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-age-southern-levant",
           "spatialCoverage": [
             {
@@ -6779,10 +6779,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdr3vd",
           "label": "Early Geometric (Greek; 900-850 BC)",
+          "note": "The Early Geometric period in ancient Greece, from 900-850 before the birth of Christ.",
           "originalLabel": {
             "eng-latn": "Early Geometric (Greek; 900-850 BC)"
           },
-          "note": "The Early Geometric period in ancient Greece, from 900-850 before the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-geometric",
           "spatialCoverage": [
             {
@@ -6826,10 +6826,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdr7sw",
           "label": "Old Babylonian/Assyrian Mesopotamia (2000-1600 BC)",
+          "note": "Mesopotamia",
           "originalLabel": {
             "eng-latn": "Old Babylonian/Assyrian Mesopotamia (2000-1600 BC)"
           },
-          "note": "Mesopotamia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/old-babylonian-assyrian-mesopotamia",
           "spatialCoverage": [
             {
@@ -6878,10 +6878,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrh3m",
           "label": "Ottoman Decline-Mandate Middle East (AD 1900-1950)",
+          "note": "ME",
           "originalLabel": {
             "eng-latn": "Ottoman Decline-Mandate Middle East (AD 1900-1950)"
           },
-          "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ottoman-decline-mandate-middle-east",
           "spatialCoverage": [
             {
@@ -6970,10 +6970,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrkh7",
           "label": "Ubaid period in Mesopotamia (ca. 6500 to 3800 BC)",
+          "note": "The prehistoric Ubaid period of Mesopotamia, as defined by Wikipedia following Carter, Robert A. and Philip, Graham Beyond the Ubaid: Transformation and Integration in the Late Prehistoric Societies of the Middle East (Studies in Ancient Oriental Civilization, Number 63) The Oriental Institute of the University of Chicago (2010) ISBN 978-1-885923-66-0 p.2, at http://oi.uchicago.edu/research/pubs/catalog/saoc/saoc63.html",
           "originalLabel": {
             "eng-latn": "Ubaid period in Mesopotamia (ca. 6500 to 3800 BC)"
           },
-          "note": "The prehistoric Ubaid period of Mesopotamia, as defined by Wikipedia following Carter, Robert A. and Philip, Graham Beyond the Ubaid: Transformation and Integration in the Late Prehistoric Societies of the Middle East (Studies in Ancient Oriental Civilization, Number 63) The Oriental Institute of the University of Chicago (2010) ISBN 978-1-885923-66-0 p.2, at http://oi.uchicago.edu/research/pubs/catalog/saoc/saoc63.html",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/ubaid",
           "spatialCoverage": [
             {
@@ -7010,10 +7010,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrtx9",
           "label": "Rum/Crusader Anatolia (AD 1077-1307)",
+          "note": "Seljuk-Latin States/Francocracy",
           "originalLabel": {
             "eng-latn": "Rum/Crusader Anatolia (AD 1077-1307)"
           },
-          "note": "Seljuk-Latin States/Francocracy",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/rum-crusader-anatolia",
           "spatialCoverage": [
             {
@@ -7058,10 +7058,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrv58",
           "label": "13th Century AD Eastern Mediterranean (AD 1200-1300)",
+          "note": "Late Byzantine-Ayyubid-Mamluk Western Middle East",
           "originalLabel": {
             "eng-latn": "13th Century AD Eastern Mediterranean (AD 1200-1300)"
           },
-          "note": "Late Byzantine-Ayyubid-Mamluk Western Middle East",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/13th-century-ad-eastern-mediterranean",
           "spatialCoverage": [
             {
@@ -7094,10 +7094,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdrx4h",
           "label": "Late Helladic (Mainland Greece; 1600-1200 BC)",
+          "note": "The Late Helladic period in the Greek mainland, after Preziosi and Hitchcock, Aegean Art and Architecture, Oxford History of Art, 1998.",
           "originalLabel": {
             "eng-latn": "Late Helladic (Mainland Greece; 1600-1200 BC)"
           },
-          "note": "The Late Helladic period in the Greek mainland, after Preziosi and Hitchcock, Aegean Art and Architecture, Oxford History of Art, 1998.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/late-helladic",
           "spatialCoverage": [
             {
@@ -7130,10 +7130,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskds7zt",
           "label": "Modern Middle East (AD 1918-2000)",
+          "note": "ME",
           "originalLabel": {
             "eng-latn": "Modern Middle East (AD 1918-2000)"
           },
-          "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/modern-middle-east",
           "spatialCoverage": [
             {
@@ -7246,10 +7246,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskds845",
           "label": "Sassanian Middle East (AD 262-700)",
+          "note": "Sassanid",
           "originalLabel": {
             "eng-latn": "Sassanian Middle East (AD 262-700)"
           },
-          "note": "Sassanid",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/sassanian-middle-east",
           "spatialCoverage": [
             {
@@ -7282,10 +7282,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdsdnb",
           "label": "Early Dynastic Mesopotamia (2950-2350 BC)",
+          "note": "Mesopotamia",
           "originalLabel": {
             "eng-latn": "Early Dynastic Mesopotamia (2950-2350 BC)"
           },
-          "note": "Mesopotamia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-dynastic-mesopotamia",
           "spatialCoverage": [
             {
@@ -7334,10 +7334,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdtg2h",
           "label": "Middle Minoan (Crete; 2000-1600 BC/BCE)",
+          "note": "The Middle Minoan period on Crete, as defined in C. Shelmerdine, The Cambridge Companion to the Aegean Bronze Age (2008), p. 4, figure 1.1.",
           "originalLabel": {
             "eng-latn": "Middle Minoan (Crete; 2000-1600 BC/BCE)"
           },
-          "note": "The Middle Minoan period on Crete, as defined in C. Shelmerdine, The Cambridge Companion to the Aegean Bronze Age (2008), p. 4, figure 1.1.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/middleminoan",
           "spatialCoverage": [
             {
@@ -7370,10 +7370,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdtn5z",
           "label": "Fatimid Middle East (AD 950-1150)",
+          "note": "Western ME, northern Africa",
           "originalLabel": {
             "eng-latn": "Fatimid Middle East (AD 950-1150)"
           },
-          "note": "Western ME, northern Africa",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/fatimid-middle-east",
           "spatialCoverage": [
             {
@@ -7406,10 +7406,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdtwrq",
           "label": "Chalcolithic Mesopotamia (6200-3750 BC)",
+          "note": "Copper Age Mesopotamia, Halaf-Ubaid-Early Uruk Mesopotamia",
           "originalLabel": {
             "eng-latn": "Chalcolithic Mesopotamia (6200-3750 BC)"
           },
-          "note": "Copper Age Mesopotamia, Halaf-Ubaid-Early Uruk Mesopotamia",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/chalcolithic-mesopotamia",
           "spatialCoverage": [
             {
@@ -7454,10 +7454,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdv8qb",
           "label": "Neo-Hittite Northern Levant (1200-700 BC)",
+          "note": "Syro-Hittite Northern Levant",
           "originalLabel": {
             "eng-latn": "Neo-Hittite Northern Levant (1200-700 BC)"
           },
-          "note": "Syro-Hittite Northern Levant",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neo-hittite-northern-levant",
           "spatialCoverage": [
             {
@@ -7490,10 +7490,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdvds6",
           "label": "Persian-Medieval Caucasus (AD 600-1500)",
+          "note": "Persian-Arabic-Early Medieval-Middle Medieval-Turco-Mongol/Late Medieval Caucasus",
           "originalLabel": {
             "eng-latn": "Persian-Medieval Caucasus (AD 600-1500)"
           },
-          "note": "Persian-Arabic-Early Medieval-Middle Medieval-Turco-Mongol/Late Medieval Caucasus",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/persian-medieval-caucasus",
           "spatialCoverage": [
             {
@@ -7537,10 +7537,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdvwkb",
           "label": "3rd millennium BC",
+          "note": "The 3rd millennium BC spans the Early to Middle Bronze Age. As described at http://en.wikipedia.org/wiki/3rd_millennium_BC.",
           "originalLabel": {
             "eng-latn": "3rd millennium BC"
           },
-          "note": "The 3rd millennium BC spans the Early to Middle Bronze Age. As described at http://en.wikipedia.org/wiki/3rd_millennium_BC.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/3rd-millennium-bc",
           "spatialCoverage": [
             {
@@ -7616,10 +7616,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdw46d",
           "label": "Neolithic Period in the Eastern Mediterranean (ca. 10,000-3,300 BC)",
+          "note": "The so-called \"Neolithic\" or \"New Stone Age\" period as defined in the Eastern portion of the Mediterranean basin, lasting roughly from 10,000 - 3,300 BC. See further: http://ancienthistory.about.com/od/artarchaeologyarchitect/g/neolithic.htm",
           "originalLabel": {
             "eng-latn": "Neolithic Period in the Eastern Mediterranean (ca. 10,000-3,300 BC)"
           },
-          "note": "The so-called \"Neolithic\" or \"New Stone Age\" period as defined in the Eastern portion of the Mediterranean basin, lasting roughly from 10,000 - 3,300 BC. See further: http://ancienthistory.about.com/od/artarchaeologyarchitect/g/neolithic.htm",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neolithic-eastern-med",
           "spatialCoverage": [
             {
@@ -7660,10 +7660,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdwdtr",
           "label": "Early-Middle Bronze Age Iran (2500-1500 BC)",
+          "note": "Iran",
           "originalLabel": {
             "eng-latn": "Early-Middle Bronze Age Iran (2500-1500 BC)"
           },
-          "note": "Iran",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/early-middle-bronze-age-iran",
           "spatialCoverage": [
             {
@@ -7696,10 +7696,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxgnx",
           "label": "Neo-Assyrian/Babylonian Middle East (720-540 BC)",
+          "note": "ME",
           "originalLabel": {
             "eng-latn": "Neo-Assyrian/Babylonian Middle East (720-540 BC)"
           },
-          "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/neo-assyrian-babylonian-middle-east",
           "spatialCoverage": [
             {
@@ -7768,10 +7768,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxjnj",
           "label": "First Intermediate Period Egypt (2168-2010 BCE/BC)",
+          "note": "The First Intermediate Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "originalLabel": {
             "eng-latn": "First Intermediate Period Egypt (2168-2010 BCE/BC)"
           },
-          "note": "The First Intermediate Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/first-intermediate-period-egypt",
           "spatialCoverage": [
             {
@@ -7804,10 +7804,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxnwr",
           "label": "Macedonian Egypt (332-304 BCE/BC)",
+          "note": "The Macedonian period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "originalLabel": {
             "eng-latn": "Macedonian Egypt (332-304 BCE/BC)"
           },
-          "note": "The Macedonian period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/macedonian-egypt",
           "spatialCoverage": [
             {
@@ -7842,10 +7842,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxnzf",
           "label": "Roman, early Empire (30 BC-AD 300)",
+          "note": "The Roman period (i.e., the early Roman Empire) in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 30 before the birth of Christ and to end in the year 300 after the birth of Christ.",
           "originalLabel": {
             "eng-latn": "Roman, early Empire (30 BC-AD 300)"
           },
-          "note": "The Roman period (i.e., the early Roman Empire) in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 30 before the birth of Christ and to end in the year 300 after the birth of Christ.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/roman",
           "spatialCoverage": [
             {
@@ -8280,10 +8280,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdxwnh",
           "label": "Roman Early Empire/Parthian Middle East (30 BC - AD 226)",
+          "note": "Early Roman/Parthian",
           "originalLabel": {
             "eng-latn": "Roman Early Empire/Parthian Middle East (30 BC - AD 226)"
           },
-          "note": "Early Roman/Parthian",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/roman-early-empire-parthian-middle-east",
           "spatialCoverage": [
             {
@@ -8364,10 +8364,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdz28z",
           "label": "Paleolithic Middle East (2600000-18000 BC)",
+          "note": "ME",
           "originalLabel": {
             "eng-latn": "Paleolithic Middle East (2600000-18000 BC)"
           },
-          "note": "ME",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/paleolithic-middle-east",
           "spatialCoverage": [
             {
@@ -8428,10 +8428,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdzc7b",
           "label": "Predynastic Egypt (4500-2950 BCE/BC)",
+          "note": "The predynastic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "originalLabel": {
             "eng-latn": "Predynastic Egypt (4500-2950 BCE/BC)"
           },
-          "note": "The predynastic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/predynastic-egypt",
           "spatialCoverage": [
             {
@@ -8464,10 +8464,10 @@
           "editorialNote": "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ",
           "id": "p03wskdzd99",
           "label": "Second Intermediate Period Egypt (1640-1548)",
+          "note": "The Second Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "originalLabel": {
             "eng-latn": "Second Intermediate Period Egypt (1640-1548)"
           },
-          "note": "The Second Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm.",
           "sameAs": "http://pleiades.stoa.org/vocabularies/time-periods/second-intermediate-period-egypt",
           "spatialCoverage": [
             {
@@ -8709,10 +8709,10 @@
           "editorialNote": "unsure why listed in GeoDia with dates 3700-3500 B.C.",
           "id": "p047fhm4kqv",
           "label": "Susa II archaeological period",
+          "note": "Prehistoric Susa II, corresponds to Mesopotamian Ubaid period.",
           "originalLabel": {
             "eng-latn": "Susa II archaeological period"
           },
-          "note": "Prehistoric Susa II, corresponds to Mesopotamian Ubaid period.",
           "source": {
             "locator": "page xviii",
             "partOf": "http://www.worldcat.org/oclc/26257582"
@@ -8833,10 +8833,10 @@
           "editorialNote": "GeoDia listed the two archaeological periods of Susa I (4200-3700 B.C.) and Susa II (3700-3500 B.C.).",
           "id": "p047fhm6zwb",
           "label": "Susa I archaeological period",
+          "note": "This period designates prehistoric Susa and corresponds to Ubaid period in Mesopotamia.",
           "originalLabel": {
             "eng-latn": "Susa I archaeological period"
           },
-          "note": "This period designates prehistoric Susa and corresponds to Ubaid period in Mesopotamia.",
           "source": {
             "locator": "page xviii",
             "partOf": "http://www.worldcat.org/oclc/26257582"
@@ -9504,10 +9504,10 @@
           "editorialNote": "Listed as historic period, not archaeological period.",
           "id": "p047fhmxww6",
           "label": "Protoliterate: Proto-Elamite",
+          "note": "This period corresponds to Proto-Literate period in Mesopotamia.",
           "originalLabel": {
             "eng-latn": "Protoliterate: Proto-Elamite"
           },
-          "note": "This period corresponds to Proto-Literate period in Mesopotamia.",
           "source": {
             "locator": "page xviii",
             "partOf": "http://www.worldcat.org/oclc/26257582"
@@ -9729,10 +9729,10 @@
           },
           "id": "p05krdx3c5h",
           "label": "Middle Helladic",
+          "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
           "originalLabel": {
             "eng-latn": "Middle Helladic"
           },
-          "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
           "source": {
             "locator": "page 307",
             "partOf": "http://www.worldcat.org/oclc/37663433"
@@ -10061,10 +10061,10 @@
         "p05krdxjp3v": {
           "id": "p05krdxjp3v",
           "label": "Late Helladic I",
+          "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
           "originalLabel": {
             "eng-latn": "Late Helladic I"
           },
-          "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
           "source": {
             "locator": "page 307",
             "partOf": "http://www.worldcat.org/oclc/37663433"
@@ -10845,10 +10845,10 @@
         "p06ptzsnj58": {
           "id": "p06ptzsnj58",
           "label": "Archaic",
+          "note": "Derived from Leptis Magna Forum Vetus excavations, \"level 4\"; absolute dates determined from Greek material (term. post quem: Late Proto-Corinthian). On Liby-phoenicians, see Birley (1988), Lancel (1995).",
           "originalLabel": {
             "eng-latn": "Archaic"
           },
-          "note": "Derived from Leptis Magna Forum Vetus excavations, \"level 4\"; absolute dates determined from Greek material (term. post quem: Late Proto-Corinthian). On Liby-phoenicians, see Birley (1988), Lancel (1995).",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Libya",
@@ -17086,10 +17086,10 @@
           },
           "id": "p06xc6mvjx2",
           "label": "Classical Iberian Period",
+          "note": "Equivalent to Iberian III (450-350 B.C.) and IV (350-200 B.C.) - cf. M. Diaz-Andreu & S. Keay, 1997. The Archaeology of Iberia; Dominguez in C. Sanchez & G.R. Tsetskhladze, 2001. Greek Pottery from the Iberian Peninsula.",
           "originalLabel": {
             "eng-latn": "Classical Iberian Period"
           },
-          "note": "Equivalent to Iberian III (450-350 B.C.) and IV (350-200 B.C.) - cf. M. Diaz-Andreu & S. Keay, 1997. The Archaeology of Iberia; Dominguez in C. Sanchez & G.R. Tsetskhladze, 2001. Greek Pottery from the Iberian Peninsula.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Spain",
@@ -17524,10 +17524,10 @@
         "p077pzfpw3k": {
           "id": "p077pzfpw3k",
           "label": "Julio-Claudian",
+          "note": "Includes the year of the four emperors for purposes of timeline continuity.",
           "originalLabel": {
             "eng-latn": "Julio-Claudian"
           },
-          "note": "Includes the year of the four emperors for purposes of timeline continuity.",
           "source": {
             "locator": "page 485",
             "partOf": "http://www.worldcat.org/oclc/52728992"
@@ -18214,10 +18214,10 @@
           },
           "id": "p07h9k6b656",
           "label": "Indígena-Romano",
+          "note": "The Indigenous-Roman and Early Roman subdivisions of Roman Period have identical dates, but they refer to very different cultural contexts.",
           "originalLabel": {
             "spa-latn": "Indígena-Romano"
           },
-          "note": "The Indigenous-Roman and Early Roman subdivisions of Roman Period have identical dates, but they refer to very different cultural contexts.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Galicia_(Spain)",
@@ -18295,10 +18295,10 @@
           },
           "id": "p07h9k6ch24",
           "label": "Época Romana",
+          "note": "The Indigenous-Roman and Early Roman subdivisions of Roman Period have identical dates, but they refer to very different cultural contexts.",
           "originalLabel": {
             "spa-latn": "Época Romana"
           },
-          "note": "The Indigenous-Roman and Early Roman subdivisions of Roman Period have identical dates, but they refer to very different cultural contexts.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Galicia_(Spain)",
@@ -18616,10 +18616,10 @@
           },
           "id": "p07h9k6n24z",
           "label": "Neolítico",
+          "note": "The Neolithic category is split between Early Prehistory and Late Prehistory.",
           "originalLabel": {
             "spa-latn": "Neolítico"
           },
-          "note": "The Neolithic category is split between Early Prehistory and Late Prehistory.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Galicia_(Spain)",
@@ -19449,10 +19449,10 @@
         "p083p5r9nnz": {
           "id": "p083p5r9nnz",
           "label": "Gutian",
+          "note": "According to Gates, Gutian domination of Mesopotamia was ended by Ur-Nammu, the first ruler of the Third dynasty of Ur (2100 B.C.-2000 B.C.), which contradicts the end date of 2000 BC (p. 55).",
           "originalLabel": {
             "eng-latn": "Gutian"
           },
-          "note": "According to Gates, Gutian domination of Mesopotamia was ended by Ur-Nammu, the first ruler of the Third dynasty of Ur (2100 B.C.-2000 B.C.), which contradicts the end date of 2000 BC (p. 55).",
           "source": {
             "locator": "page 52",
             "partOf": "http://www.worldcat.org/oclc/51042563"
@@ -21262,10 +21262,10 @@
           },
           "id": "p086kj9235v",
           "label": "British 1763-1783",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "British 1763-1783"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -21295,10 +21295,10 @@
           },
           "id": "p086kj924nt",
           "label": "18th Century::3rd quarter (1750 - 1774)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "18th Century::3rd quarter (1750 - 1774)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -21323,10 +21323,10 @@
         "p086kj926q4": {
           "id": "p086kj926q4",
           "label": "Archaic, indeterminate",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Archaic, indeterminate"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -21351,10 +21351,10 @@
         "p086kj927td": {
           "id": "p086kj927td",
           "label": "Fort Ancient",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Fort Ancient"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -21379,10 +21379,10 @@
         "p086kj9298n": {
           "id": "p086kj9298n",
           "label": "Icarian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR5",
           "originalLabel": {
             "eng-latn": "Icarian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR5",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -21407,10 +21407,10 @@
         "p086kj929mz": {
           "id": "p086kj929mz",
           "label": "Middle Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -21435,10 +21435,10 @@
         "p086kj92dpj": {
           "id": "p086kj92dpj",
           "label": "Lamar",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Lamar"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -21463,10 +21463,10 @@
         "p086kj92h3r": {
           "id": "p086kj92h3r",
           "label": "St. Johns Ia",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "St. Johns Ia"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -21496,10 +21496,10 @@
           },
           "id": "p086kj92hb4",
           "label": "Glades II, A.D. 750-1200",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Glades II, A.D. 750-1200"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -21524,10 +21524,10 @@
         "p086kj92ks2": {
           "id": "p086kj92ks2",
           "label": "Adena",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR46",
           "originalLabel": {
             "eng-latn": "Adena"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR46",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -21552,10 +21552,10 @@
         "p086kj92kvp": {
           "id": "p086kj92kvp",
           "label": "Nebo Hill",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR31",
           "originalLabel": {
             "eng-latn": "Nebo Hill"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR31",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -21580,10 +21580,10 @@
         "p086kj92p98": {
           "id": "p086kj92p98",
           "label": "Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA23",
           "originalLabel": {
             "eng-latn": "Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA23",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -21608,10 +21608,10 @@
         "p086kj92s2s": {
           "id": "p086kj92s2s",
           "label": "Glades IIIa",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Glades IIIa"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -21636,10 +21636,10 @@
         "p086kj92scs": {
           "id": "p086kj92scs",
           "label": "19th cent. urban",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR116",
           "originalLabel": {
             "eng-latn": "19th cent. urban"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR116",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -21664,10 +21664,10 @@
         "p086kj92svg": {
           "id": "p086kj92svg",
           "label": "Any Archaic Period",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Any Archaic Period"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -21697,10 +21697,10 @@
           },
           "id": "p086kj92szg",
           "label": "Glades III, A.D. 1000-1700",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Glades III, A.D. 1000-1700"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -21725,10 +21725,10 @@
         "p086kj92tdf": {
           "id": "p086kj92tdf",
           "label": "Green River",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Green River"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -21753,10 +21753,10 @@
         "p086kj92vmq": {
           "id": "p086kj92vmq",
           "label": "20th Century",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "20th Century"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -21781,10 +21781,10 @@
         "p086kj92w8p": {
           "id": "p086kj92w8p",
           "label": "Amana Colonists",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR68",
           "originalLabel": {
             "eng-latn": "Amana Colonists"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR68",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -21809,10 +21809,10 @@
         "p086kj92x6b": {
           "id": "p086kj92x6b",
           "label": "Mid-late 20th century commerce",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR112",
           "originalLabel": {
             "eng-latn": "Mid-late 20th century commerce"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR112",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -21837,10 +21837,10 @@
         "p086kj92xvn": {
           "id": "p086kj92xvn",
           "label": "Linn",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR82",
           "originalLabel": {
             "eng-latn": "Linn"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR82",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -21870,10 +21870,10 @@
           },
           "id": "p086kj932pt",
           "label": "Indian Pond A.D. 950-contact",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Indian Pond A.D. 950-contact"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -21898,10 +21898,10 @@
         "p086kj9334s": {
           "id": "p086kj9334s",
           "label": "Late Paleoindian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Late Paleoindian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -21926,10 +21926,10 @@
         "p086kj9346r": {
           "id": "p086kj9346r",
           "label": "Indeterminate",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Indeterminate"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -21954,10 +21954,10 @@
         "p086kj934tr": {
           "id": "p086kj934tr",
           "label": "late Early Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR100",
           "originalLabel": {
             "eng-latn": "late Early Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR100",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -21982,10 +21982,10 @@
         "p086kj9372b": {
           "id": "p086kj9372b",
           "label": "Historic American Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Historic American Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -22010,10 +22010,10 @@
         "p086kj9373n": {
           "id": "p086kj9373n",
           "label": "Prairie/Plains Late Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR15",
           "originalLabel": {
             "eng-latn": "Prairie/Plains Late Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR15",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -22038,10 +22038,10 @@
         "p086kj9377z": {
           "id": "p086kj9377z",
           "label": "Sac and Fox",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR42",
           "originalLabel": {
             "eng-latn": "Sac and Fox"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR42",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -22071,10 +22071,10 @@
           },
           "id": "p086kj93btj",
           "label": "18th Century::1st half (1700 - 1749)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "18th Century::1st half (1700 - 1749)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -22104,10 +22104,10 @@
           },
           "id": "p086kj93gmq",
           "label": "Paleoindian, 10000 B.C.-8500 B.C.",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Paleoindian, 10000 B.C.-8500 B.C."
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -22132,10 +22132,10 @@
         "p086kj93h92": {
           "id": "p086kj93h92",
           "label": "contemporary with Hartley phase",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR59",
           "originalLabel": {
             "eng-latn": "contemporary with Hartley phase"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR59",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -22165,10 +22165,10 @@
           },
           "id": "p086kj93hq2",
           "label": "WW I & Aftermath 1917-1920",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "WW I & Aftermath 1917-1920"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -22193,10 +22193,10 @@
         "p086kj93pnt": {
           "id": "p086kj93pnt",
           "label": "Santa Rosa-Swift Creek",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Santa Rosa-Swift Creek"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -22221,10 +22221,10 @@
         "p086kj93pxh": {
           "id": "p086kj93pxh",
           "label": "Early Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Early Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -22249,10 +22249,10 @@
         "p086kj93qxs": {
           "id": "p086kj93qxs",
           "label": "Glenwood",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR50",
           "originalLabel": {
             "eng-latn": "Glenwood"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR50",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -22277,10 +22277,10 @@
         "p086kj93r5r": {
           "id": "p086kj93r5r",
           "label": "Yankeetown",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Yankeetown"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -22305,10 +22305,10 @@
         "p086kj93rh4": {
           "id": "p086kj93rh4",
           "label": "Cumberland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Cumberland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -22333,10 +22333,10 @@
         "p086kj93snq": {
           "id": "p086kj93snq",
           "label": "Great Oasis or Oneota",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR69",
           "originalLabel": {
             "eng-latn": "Great Oasis or Oneota"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR69",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -22361,10 +22361,10 @@
         "p086kj93std": {
           "id": "p086kj93std",
           "label": "Upper Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Upper Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -22389,10 +22389,10 @@
         "p086kj93tb2": {
           "id": "p086kj93tb2",
           "label": "St. Johns Ib",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "St. Johns Ib"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -22417,10 +22417,10 @@
         "p086kj93v9z": {
           "id": "p086kj93v9z",
           "label": "Central Plains Tradition(?)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR55",
           "originalLabel": {
             "eng-latn": "Central Plains Tradition(?)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR55",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -22445,10 +22445,10 @@
         "p086kj93wsx": {
           "id": "p086kj93wsx",
           "label": "St. Johns IIb",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "St. Johns IIb"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -22473,10 +22473,10 @@
         "p086kj944pp": {
           "id": "p086kj944pp",
           "label": "Lewis",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Lewis"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -22501,10 +22501,10 @@
         "p086kj944wp": {
           "id": "p086kj944wp",
           "label": "Helton phase",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR110",
           "originalLabel": {
             "eng-latn": "Helton phase"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR110",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -22534,10 +22534,10 @@
           },
           "id": "p086kj946k9",
           "label": "Antebellum (1821-1861)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA34",
           "originalLabel": {
             "eng-latn": "Antebellum (1821-1861)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA34",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -22562,10 +22562,10 @@
         "p086kj946qm": {
           "id": "p086kj946qm",
           "label": "Historic, Native American (Seminole)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Historic, Native American (Seminole)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -22590,10 +22590,10 @@
         "p086kj947j8": {
           "id": "p086kj947j8",
           "label": "Meskwaki",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR25",
           "originalLabel": {
             "eng-latn": "Meskwaki"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR25",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -22623,10 +22623,10 @@
           },
           "id": "p086kj948gv",
           "label": "18th Century::2nd quarter (1725 - 1749)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "18th Century::2nd quarter (1725 - 1749)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -22651,10 +22651,10 @@
         "p086kj9499h": {
           "id": "p086kj9499h",
           "label": "Weaver-like",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR83",
           "originalLabel": {
             "eng-latn": "Weaver-like"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR83",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -22679,10 +22679,10 @@
         "p086kj94b8g": {
           "id": "p086kj94b8g",
           "label": "Hopewellian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Hopewellian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -22712,10 +22712,10 @@
           },
           "id": "p086kj94c64",
           "label": "19th Century::4th quarter (1875 - 1899)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "19th Century::4th quarter (1875 - 1899)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -22740,10 +22740,10 @@
         "p086kj94d3d": {
           "id": "p086kj94d3d",
           "label": "Woodland, Undifferentiated",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Woodland, Undifferentiated"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -22773,10 +22773,10 @@
           },
           "id": "p086kj94dk3",
           "label": "19th Century::1st half (1800 - 1849)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "19th Century::1st half (1800 - 1849)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -22801,10 +22801,10 @@
         "p086kj94g2n": {
           "id": "p086kj94g2n",
           "label": "War of 1812",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR144",
           "originalLabel": {
             "eng-latn": "War of 1812"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR144",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -22834,10 +22834,10 @@
           },
           "id": "p086kj94mbh",
           "label": "20th Century::2nd half (1950 - 1999)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "20th Century::2nd half (1950 - 1999)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -22867,10 +22867,10 @@
           },
           "id": "p086kj94nmg",
           "label": "20th Century::1st quarter (1900 - 1924)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "20th Century::1st quarter (1900 - 1924)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -22900,10 +22900,10 @@
           },
           "id": "p086kj94pwf",
           "label": "Post-Reconstruction 1880-1897",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Post-Reconstruction 1880-1897"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -22928,10 +22928,10 @@
         "p086kj94t5m": {
           "id": "p086kj94t5m",
           "label": "Middle Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA13",
           "originalLabel": {
             "eng-latn": "Middle Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA13",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -22956,10 +22956,10 @@
         "p086kj94t9x": {
           "id": "p086kj94t9x",
           "label": "Reported Site",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Reported Site"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -22984,10 +22984,10 @@
         "p086kj94tsm": {
           "id": "p086kj94tsm",
           "label": "Pleistocene",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR41",
           "originalLabel": {
             "eng-latn": "Pleistocene"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR41",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23012,10 +23012,10 @@
         "p086kj94vq8": {
           "id": "p086kj94vq8",
           "label": "Great Oasis",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR17",
           "originalLabel": {
             "eng-latn": "Great Oasis"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR17",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23040,10 +23040,10 @@
         "p086kj955k8": {
           "id": "p086kj955k8",
           "label": "Oneota",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR6",
           "originalLabel": {
             "eng-latn": "Oneota"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR6",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23068,10 +23068,10 @@
         "p086kj955xk": {
           "id": "p086kj955xk",
           "label": "Unknown",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Unknown"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -23096,10 +23096,10 @@
         "p086kj9562j": {
           "id": "p086kj9562j",
           "label": "Dalton",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Dalton"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -23124,10 +23124,10 @@
         "p086kj9568j": {
           "id": "p086kj9568j",
           "label": "General Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "General Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -23152,10 +23152,10 @@
         "p086kj958hg": {
           "id": "p086kj958hg",
           "label": "Angel",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Angel"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -23180,10 +23180,10 @@
         "p086kj959mr": {
           "id": "p086kj959mr",
           "label": "late Middle Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR13",
           "originalLabel": {
             "eng-latn": "late Middle Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR13",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23213,10 +23213,10 @@
           },
           "id": "p086kj95c6c",
           "label": "Statehood & Antebellum 1845-1860",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Statehood & Antebellum 1845-1860"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -23241,10 +23241,10 @@
         "p086kj95gpw": {
           "id": "p086kj95gpw",
           "label": "possibly Hanna",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR105",
           "originalLabel": {
             "eng-latn": "possibly Hanna"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR105",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23274,10 +23274,10 @@
           },
           "id": "p086kj95kss",
           "label": "17th Century::2nd quarter (1625 - 1649)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "17th Century::2nd quarter (1625 - 1649)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -23302,10 +23302,10 @@
         "p086kj95kzg": {
           "id": "p086kj95kzg",
           "label": "Historic, Native American (Cherokee)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Historic, Native American (Cherokee)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -23330,10 +23330,10 @@
         "p086kj95ntq": {
           "id": "p086kj95ntq",
           "label": "Lane Farm",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR78",
           "originalLabel": {
             "eng-latn": "Lane Farm"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR78",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23358,10 +23358,10 @@
         "p086kj95q9b": {
           "id": "p086kj95q9b",
           "label": "late 19th -20th cent residential",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR119",
           "originalLabel": {
             "eng-latn": "late 19th -20th cent residential"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR119",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23386,10 +23386,10 @@
         "p086kj95vg6": {
           "id": "p086kj95vg6",
           "label": "Weeden Island 3",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Weeden Island 3"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -23414,10 +23414,10 @@
         "p086kj95wkg": {
           "id": "p086kj95wkg",
           "label": "Oneota, Correctionville phase",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR65",
           "originalLabel": {
             "eng-latn": "Oneota, Correctionville phase"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR65",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23442,10 +23442,10 @@
         "p086kj95z7q": {
           "id": "p086kj95z7q",
           "label": "Protohistoric",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Protohistoric"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -23470,10 +23470,10 @@
         "p086kj962v9": {
           "id": "p086kj962v9",
           "label": "Baytown",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Baytown"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -23498,10 +23498,10 @@
         "p086kj963bk": {
           "id": "p086kj963bk",
           "label": "Urban Industrial",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Urban Industrial"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -23526,10 +23526,10 @@
         "p086kj963pw": {
           "id": "p086kj963pw",
           "label": "Middle Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Middle Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -23554,10 +23554,10 @@
         "p086kj964jv": {
           "id": "p086kj964jv",
           "label": "St. Johns I",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "St. Johns I"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -23582,10 +23582,10 @@
         "p086kj964zv": {
           "id": "p086kj964zv",
           "label": "Hopewell",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR70",
           "originalLabel": {
             "eng-latn": "Hopewell"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR70",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23610,10 +23610,10 @@
         "p086kj965kh": {
           "id": "p086kj965kh",
           "label": "Potano unspecified",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Potano unspecified"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -23638,10 +23638,10 @@
         "p086kj966m5": {
           "id": "p086kj966m5",
           "label": "Terminal Middle Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Terminal Middle Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -23666,10 +23666,10 @@
         "p086kj966ws": {
           "id": "p086kj966ws",
           "label": "19th-20th cent urban",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR118",
           "originalLabel": {
             "eng-latn": "19th-20th cent urban"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR118",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23694,10 +23694,10 @@
         "p086kj967xf": {
           "id": "p086kj967xf",
           "label": "War of 1812",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR125",
           "originalLabel": {
             "eng-latn": "War of 1812"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR125",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23722,10 +23722,10 @@
         "p086kj9688d": {
           "id": "p086kj9688d",
           "label": "Early Woodland, indet",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Early Woodland, indet"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -23750,10 +23750,10 @@
         "p086kj96bwz": {
           "id": "p086kj96bwz",
           "label": "Historic, Native American (Yuchi)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Historic, Native American (Yuchi)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -23778,10 +23778,10 @@
         "p086kj96cdm": {
           "id": "p086kj96cdm",
           "label": "Woodland, indet.",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Woodland, indet."
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -23806,10 +23806,10 @@
         "p086kj96dwk": {
           "id": "p086kj96dwk",
           "label": "Depression era",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR127",
           "originalLabel": {
             "eng-latn": "Depression era"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR127",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23834,10 +23834,10 @@
         "p086kj96fkv": {
           "id": "p086kj96fkv",
           "label": "Late Woodland/Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Late Woodland/Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -23862,10 +23862,10 @@
         "p086kj96g7t": {
           "id": "p086kj96g7t",
           "label": "Plains Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR24",
           "originalLabel": {
             "eng-latn": "Plains Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR24",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -23884,10 +23884,10 @@
         "p086kj96jx4": {
           "id": "p086kj96jx4",
           "label": "Historic Non-Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Historic Non-Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -23912,10 +23912,10 @@
         "p086kj96mkc": {
           "id": "p086kj96mkc",
           "label": "Indet. Mississippi",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Indet. Mississippi"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -23940,10 +23940,10 @@
         "p086kj96mr2": {
           "id": "p086kj96mr2",
           "label": "Middle Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Middle Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -23968,10 +23968,10 @@
         "p086kj96s5t": {
           "id": "p086kj96s5t",
           "label": "Early Side Notched",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Early Side Notched"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -23996,10 +23996,10 @@
         "p086kj96tvs": {
           "id": "p086kj96tvs",
           "label": "Glades IIa",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Glades IIa"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -24029,10 +24029,10 @@
           },
           "id": "p086kj96z3n",
           "label": "Early Woodland (1200 B.C. - 299 A.D.)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Early Woodland (1200 B.C. - 299 A.D.)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -24057,10 +24057,10 @@
         "p086kj97594": {
           "id": "p086kj97594",
           "label": "Middle Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -24085,10 +24085,10 @@
         "p086kj978jb": {
           "id": "p086kj978jb",
           "label": "Malabar",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Malabar"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -24113,10 +24113,10 @@
         "p086kj979h9": {
           "id": "p086kj979h9",
           "label": "Middle Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -24141,10 +24141,10 @@
         "p086kj97dst": {
           "id": "p086kj97dst",
           "label": "Crawford Phase",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR104",
           "originalLabel": {
             "eng-latn": "Crawford Phase"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR104",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -24169,10 +24169,10 @@
         "p086kj97f3g": {
           "id": "p086kj97f3g",
           "label": "Historic, Native American (Chatot)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Historic, Native American (Chatot)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -24197,10 +24197,10 @@
         "p086kj97frs": {
           "id": "p086kj97frs",
           "label": "Paleo-Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA12",
           "originalLabel": {
             "eng-latn": "Paleo-Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA12",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -24225,10 +24225,10 @@
         "p086kj97fw5": {
           "id": "p086kj97fw5",
           "label": "Central Plains Tradition",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR32",
           "originalLabel": {
             "eng-latn": "Central Plains Tradition"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR32",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -24253,10 +24253,10 @@
         "p086kj97gdr": {
           "id": "p086kj97gdr",
           "label": "Late Paleoindian/Early Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Late Paleoindian/Early Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -24281,10 +24281,10 @@
         "p086kj97j6c": {
           "id": "p086kj97j6c",
           "label": "Maple Creek",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Maple Creek"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -24309,10 +24309,10 @@
         "p086kj97kxn": {
           "id": "p086kj97kxn",
           "label": "Middle Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -24337,10 +24337,10 @@
         "p086kj97nm8": {
           "id": "p086kj97nm8",
           "label": "Early Archaic Kirk",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Early Archaic Kirk"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -24365,10 +24365,10 @@
         "p086kj97nww": {
           "id": "p086kj97nww",
           "label": "Middle Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA20",
           "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA20",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -24393,10 +24393,10 @@
         "p086kj97q3t": {
           "id": "p086kj97q3t",
           "label": "16th Century",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "16th Century"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -24421,10 +24421,10 @@
         "p086kj97sfr": {
           "id": "p086kj97sfr",
           "label": "Lake Benton",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR136",
           "originalLabel": {
             "eng-latn": "Lake Benton"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR136",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -24454,10 +24454,10 @@
           },
           "id": "p086kj97wnn",
           "label": "19th Century::3rd quarter (1850 - 1874)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "19th Century::3rd quarter (1850 - 1874)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -24482,10 +24482,10 @@
         "p086kj97zn8": {
           "id": "p086kj97zn8",
           "label": "Proto-historic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Proto-historic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -24510,10 +24510,10 @@
         "p086kj97zsk": {
           "id": "p086kj97zsk",
           "label": "Fox",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR40",
           "originalLabel": {
             "eng-latn": "Fox"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR40",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -24538,10 +24538,10 @@
         "p086kj982fs": {
           "id": "p086kj982fs",
           "label": "Frontier",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Frontier"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -24571,10 +24571,10 @@
           },
           "id": "p086kj983gf",
           "label": "The New Dominion (1946 - 1988)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "The New Dominion (1946 - 1988)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -24599,10 +24599,10 @@
         "p086kj9848q": {
           "id": "p086kj9848q",
           "label": "Early Paleoindian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Early Paleoindian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -24627,10 +24627,10 @@
         "p086kj98493": {
           "id": "p086kj98493",
           "label": "Late Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA14",
           "originalLabel": {
             "eng-latn": "Late Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA14",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -24655,10 +24655,10 @@
         "p086kj985c2": {
           "id": "p086kj985c2",
           "label": "Hemphill",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR74",
           "originalLabel": {
             "eng-latn": "Hemphill"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR74",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -24683,10 +24683,10 @@
         "p086kj9875m": {
           "id": "p086kj9875m",
           "label": "Orange",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Orange"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -24711,10 +24711,10 @@
         "p086kj989mj": {
           "id": "p086kj989mj",
           "label": "Historic, Native American (Creek)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Historic, Native American (Creek)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -24744,10 +24744,10 @@
           },
           "id": "p086kj98d84",
           "label": "St. Johns, 700 B.C.-A.D. 1500",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "St. Johns, 700 B.C.-A.D. 1500"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -24772,10 +24772,10 @@
         "p086kj98drr": {
           "id": "p086kj98drr",
           "label": "Historic, Native American (Tenesaw)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Historic, Native American (Tenesaw)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -24805,10 +24805,10 @@
           },
           "id": "p086kj98fpd",
           "label": "Woodland (1200 B.C. - 1606 A.D.)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Woodland (1200 B.C. - 1606 A.D.)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -24833,10 +24833,10 @@
         "p086kj98hzn": {
           "id": "p086kj98hzn",
           "label": "Mormon (alleged)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR80",
           "originalLabel": {
             "eng-latn": "Mormon (alleged)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR80",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -24866,10 +24866,10 @@
           },
           "id": "p086kj98jxm",
           "label": "Reconstruction 1866-1879",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Reconstruction 1866-1879"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -24894,10 +24894,10 @@
         "p086kj98kck": {
           "id": "p086kj98kck",
           "label": "Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -24922,10 +24922,10 @@
         "p086kj98mgv": {
           "id": "p086kj98mgv",
           "label": "Early Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR130",
           "originalLabel": {
             "eng-latn": "Early Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR130",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -24950,10 +24950,10 @@
         "p086kj98njt": {
           "id": "p086kj98njt",
           "label": "Amana",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR66",
           "originalLabel": {
             "eng-latn": "Amana"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR66",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -24978,10 +24978,10 @@
         "p086kj98p5g": {
           "id": "p086kj98p5g",
           "label": "Late 19th-Early 20th Century",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR139",
           "originalLabel": {
             "eng-latn": "Late 19th-Early 20th Century"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR139",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -25006,10 +25006,10 @@
         "p086kj98p9s": {
           "id": "p086kj98p9s",
           "label": "Early Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR141",
           "originalLabel": {
             "eng-latn": "Early Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR141",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -25034,10 +25034,10 @@
         "p086kj98pds": {
           "id": "p086kj98pds",
           "label": "Upper Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Upper Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -25062,10 +25062,10 @@
         "p086kj98qx4": {
           "id": "p086kj98qx4",
           "label": "Glades IIIb",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Glades IIIb"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -25090,10 +25090,10 @@
         "p086kj98scc": {
           "id": "p086kj98scc",
           "label": "Dalton-Henderson",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Dalton-Henderson"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -25118,10 +25118,10 @@
         "p086kj98shp": {
           "id": "p086kj98shp",
           "label": "Post War",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Post War"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -25151,10 +25151,10 @@
           },
           "id": "p086kj98vgx",
           "label": "Territorial (1804-1820)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA17",
           "originalLabel": {
             "eng-latn": "Territorial (1804-1820)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA17",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -25186,10 +25186,10 @@
           },
           "id": "p086kj98vq9",
           "label": "Seminole, 2nd War to 3rd 1835-1855",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Seminole, 2nd War to 3rd 1835-1855"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -25214,10 +25214,10 @@
         "p086kj98vrm": {
           "id": "p086kj98vrm",
           "label": "Black Sand complex",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR84",
           "originalLabel": {
             "eng-latn": "Black Sand complex"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR84",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -25242,10 +25242,10 @@
         "p086kj98xn7": {
           "id": "p086kj98xn7",
           "label": "Early Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Early Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -25270,10 +25270,10 @@
         "p086kj98z7h": {
           "id": "p086kj98z7h",
           "label": "Belle Glade III",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Belle Glade III"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -25303,10 +25303,10 @@
           },
           "id": "p086kj9947n",
           "label": "17th Century::4th quarter (1675 - 1699)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "17th Century::4th quarter (1675 - 1699)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -25331,10 +25331,10 @@
         "p086kj995k9": {
           "id": "p086kj995k9",
           "label": "Titterington Phase",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR60",
           "originalLabel": {
             "eng-latn": "Titterington Phase"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR60",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -25364,10 +25364,10 @@
           },
           "id": "p086kj996ck",
           "label": "WW II & Aftermath 1941-1950",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "WW II & Aftermath 1941-1950"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -25397,10 +25397,10 @@
           },
           "id": "p086kj997fj",
           "label": "Belle Glade, 700 B.C.-A.D. 1700",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Belle Glade, 700 B.C.-A.D. 1700"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -25430,10 +25430,10 @@
           },
           "id": "p086kj997h7",
           "label": "17th Century::1st half (1600 - 1649)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "17th Century::1st half (1600 - 1649)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -25465,10 +25465,10 @@
           },
           "id": "p086kj998dh",
           "label": "Seminole, 1st War to 2nd 1817-1834",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Seminole, 1st War to 2nd 1817-1834"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -25493,10 +25493,10 @@
         "p086kj998w6": {
           "id": "p086kj998w6",
           "label": "Graham Cave",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR99",
           "originalLabel": {
             "eng-latn": "Graham Cave"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR99",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -25521,10 +25521,10 @@
         "p086kj99cbq": {
           "id": "p086kj99cbq",
           "label": "Pammel",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR76",
           "originalLabel": {
             "eng-latn": "Pammel"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR76",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -25549,10 +25549,10 @@
         "p086kj99dsc": {
           "id": "p086kj99dsc",
           "label": "Late Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Late Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -25577,10 +25577,10 @@
         "p086kj99fnb": {
           "id": "p086kj99fnb",
           "label": "Moingona",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR58",
           "originalLabel": {
             "eng-latn": "Moingona"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR58",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -25605,10 +25605,10 @@
         "p086kj99hxk": {
           "id": "p086kj99hxk",
           "label": "Early Paleo-Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Early Paleo-Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -25638,10 +25638,10 @@
           },
           "id": "p086kj99m9g",
           "label": "American Acquisition & Development 1821-45",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "American Acquisition & Development 1821-45"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -25666,10 +25666,10 @@
         "p086kj99mzs": {
           "id": "p086kj99mzs",
           "label": "Clovis",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR14",
           "originalLabel": {
             "eng-latn": "Clovis"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR14",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -25694,10 +25694,10 @@
         "p086kj99nj4": {
           "id": "p086kj99nj4",
           "label": "Prehistoric-Unspecified",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Prehistoric-Unspecified"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -25722,10 +25722,10 @@
         "p086kj99pfd": {
           "id": "p086kj99pfd",
           "label": "Marion",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR49",
           "originalLabel": {
             "eng-latn": "Marion"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR49",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -25750,10 +25750,10 @@
         "p086kj99t98": {
           "id": "p086kj99t98",
           "label": "Glades Ib",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Glades Ib"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -25778,10 +25778,10 @@
         "p086kj99tcw": {
           "id": "p086kj99tcw",
           "label": "late Late Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR18",
           "originalLabel": {
             "eng-latn": "late Late Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR18",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -25806,10 +25806,10 @@
         "p086kj99tsw": {
           "id": "p086kj99tsw",
           "label": "Hopewell",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR35",
           "originalLabel": {
             "eng-latn": "Hopewell"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR35",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -25839,10 +25839,10 @@
           },
           "id": "p086kj99vs7",
           "label": "18th Century::2nd/3rd quarter (1725 - 1774)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "18th Century::2nd/3rd quarter (1725 - 1774)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -25867,10 +25867,10 @@
         "p086kj99w9t": {
           "id": "p086kj99w9t",
           "label": "Late Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Late Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -25895,10 +25895,10 @@
         "p086kj99wch": {
           "id": "p086kj99wch",
           "label": "Early Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Early Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -25923,10 +25923,10 @@
         "p086kj99x65": {
           "id": "p086kj99x65",
           "label": "Caborn-Welborn",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Caborn-Welborn"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -25951,10 +25951,10 @@
         "p086kj9b2cn": {
           "id": "p086kj9b2cn",
           "label": "Prehistoric-Ceramic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Prehistoric-Ceramic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -25984,10 +25984,10 @@
           },
           "id": "p086kj9b399",
           "label": "19th Century::2nd/3rd quarter (1825 - 1874)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "19th Century::2nd/3rd quarter (1825 - 1874)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -26012,10 +26012,10 @@
         "p086kj9b43k": {
           "id": "p086kj9b43k",
           "label": "Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -26040,10 +26040,10 @@
         "p086kj9b7ns": {
           "id": "p086kj9b7ns",
           "label": "Fox Lake",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR137",
           "originalLabel": {
             "eng-latn": "Fox Lake"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR137",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -26068,10 +26068,10 @@
         "p086kj9b8xr": {
           "id": "p086kj9b8xr",
           "label": "Middle Gulf Formational",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Middle Gulf Formational"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -26101,10 +26101,10 @@
           },
           "id": "p086kj9b8z4",
           "label": "Swift Creek, 300 B.C.-A.D. 450",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Swift Creek, 300 B.C.-A.D. 450"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -26134,10 +26134,10 @@
           },
           "id": "p086kj9b92q",
           "label": "20th Century::2nd/3rd quarter (1925 - 1974)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "20th Century::2nd/3rd quarter (1925 - 1974)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -26162,10 +26162,10 @@
         "p086kj9bbs2": {
           "id": "p086kj9bbs2",
           "label": "Middle Archaic, indet.",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Middle Archaic, indet."
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -26195,10 +26195,10 @@
           },
           "id": "p086kj9bcrz",
           "label": "Cades Pond 300 B.C.-A.D. 800",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Cades Pond 300 B.C.-A.D. 800"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -26223,10 +26223,10 @@
         "p086kj9bfh8": {
           "id": "p086kj9bfh8",
           "label": "Louisa Phase",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR90",
           "originalLabel": {
             "eng-latn": "Louisa Phase"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR90",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -26251,10 +26251,10 @@
         "p086kj9bhmt": {
           "id": "p086kj9bhmt",
           "label": "Historic Oneota",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR9",
           "originalLabel": {
             "eng-latn": "Historic Oneota"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR9",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -26284,10 +26284,10 @@
           },
           "id": "p086kj9bj2s",
           "label": "Manasota, 700 B.C.-A.D. 700",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Manasota, 700 B.C.-A.D. 700"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -26312,10 +26312,10 @@
         "p086kj9bmcd": {
           "id": "p086kj9bmcd",
           "label": "Swift Creek-Late",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Swift Creek-Late"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -26340,10 +26340,10 @@
         "p086kj9bp8z": {
           "id": "p086kj9bp8z",
           "label": "Early Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Early Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -26368,10 +26368,10 @@
         "p086kj9bqrx": {
           "id": "p086kj9bqrx",
           "label": "Historic Native American",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA15",
           "originalLabel": {
             "eng-latn": "Historic Native American"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA15",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -26396,10 +26396,10 @@
         "p086kj9bqtm": {
           "id": "p086kj9bqtm",
           "label": "Late Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Late Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -26424,10 +26424,10 @@
         "p086kj9bssv": {
           "id": "p086kj9bssv",
           "label": "Early Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Early Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -26452,10 +26452,10 @@
         "p086kj9bvn5": {
           "id": "p086kj9bvn5",
           "label": "Early Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Early Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -26480,10 +26480,10 @@
         "p086kj9bxjq": {
           "id": "p086kj9bxjq",
           "label": "Gulf Formational, Undifferentiated",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Gulf Formational, Undifferentiated"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -26508,10 +26508,10 @@
         "p086kj9bxs3": {
           "id": "p086kj9bxs3",
           "label": "Cemetery",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR122",
           "originalLabel": {
             "eng-latn": "Cemetery"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR122",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -26536,10 +26536,10 @@
         "p086kj9bz5c": {
           "id": "p086kj9bz5c",
           "label": "Loseke Creek Variant",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR97",
           "originalLabel": {
             "eng-latn": "Loseke Creek Variant"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR97",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -26564,10 +26564,10 @@
         "p086kj9bzwc": {
           "id": "p086kj9bzwc",
           "label": "Gast phase",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR103",
           "originalLabel": {
             "eng-latn": "Gast phase"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR103",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -26597,10 +26597,10 @@
           },
           "id": "p086kj9bzz2",
           "label": "18th Century::1st quarter (1700 - 1724)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "18th Century::1st quarter (1700 - 1724)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -26630,10 +26630,10 @@
           },
           "id": "p086kj9c327",
           "label": "Seminole 1716-present",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Seminole 1716-present"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -26658,10 +26658,10 @@
         "p086kj9c357": {
           "id": "p086kj9c357",
           "label": "Early Industrial",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Early Industrial"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -26686,10 +26686,10 @@
         "p086kj9c5bg": {
           "id": "p086kj9c5bg",
           "label": "Caloosahatchee IV",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Caloosahatchee IV"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -26714,10 +26714,10 @@
         "p086kj9c5ws": {
           "id": "p086kj9c5ws",
           "label": "Historic, Native American (Mobile)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Historic, Native American (Mobile)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -26742,10 +26742,10 @@
         "p086kj9c97n": {
           "id": "p086kj9c97n",
           "label": "Pensacola",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Pensacola"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -26775,10 +26775,10 @@
           },
           "id": "p086kj9c9vn",
           "label": "Spanish-American War 1898-1916",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Spanish-American War 1898-1916"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -26803,10 +26803,10 @@
         "p086kj9cbfx": {
           "id": "p086kj9cbfx",
           "label": "Jonathan Creek",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Jonathan Creek"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -26831,10 +26831,10 @@
         "p086kj9cckk": {
           "id": "p086kj9cckk",
           "label": "Hardin",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR108",
           "originalLabel": {
             "eng-latn": "Hardin"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR108",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -26866,10 +26866,10 @@
           },
           "id": "p086kj9ccn8",
           "label": "Seminole, 3rd War onward, 1856-",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Seminole, 3rd War onward, 1856-"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -26894,10 +26894,10 @@
         "p086kj9cdh7": {
           "id": "p086kj9cdh7",
           "label": "Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -26922,10 +26922,10 @@
         "p086kj9cfg6": {
           "id": "p086kj9cfg6",
           "label": "Protohistoric",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Protohistoric"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -26950,10 +26950,10 @@
         "p086kj9cgb5": {
           "id": "p086kj9cgb5",
           "label": "Middle/Late Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Middle/Late Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -26978,10 +26978,10 @@
         "p086kj9cgts": {
           "id": "p086kj9cgts",
           "label": "Protohistoric",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Protohistoric"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -27006,10 +27006,10 @@
         "p086kj9cj23": {
           "id": "p086kj9cj23",
           "label": "Mississippian, Undifferentiated",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Mississippian, Undifferentiated"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -27034,10 +27034,10 @@
         "p086kj9ck2c": {
           "id": "p086kj9ck2c",
           "label": "Loseke",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR134",
           "originalLabel": {
             "eng-latn": "Loseke"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR134",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -27067,10 +27067,10 @@
           },
           "id": "p086kj9cm7b",
           "label": "World War I to World War II (1917 - 1945)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "World War I to World War II (1917 - 1945)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -27095,10 +27095,10 @@
         "p086kj9cmbb": {
           "id": "p086kj9cmbb",
           "label": "Blacksand",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR133",
           "originalLabel": {
             "eng-latn": "Blacksand"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR133",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -27123,10 +27123,10 @@
         "p086kj9cnsx": {
           "id": "p086kj9cnsx",
           "label": "Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -27151,10 +27151,10 @@
         "p086kj9cpjw": {
           "id": "p086kj9cpjw",
           "label": "Late Archaic/Early Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Late Archaic/Early Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -27179,10 +27179,10 @@
         "p086kj9cq8j": {
           "id": "p086kj9cq8j",
           "label": "Early Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Early Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -27207,10 +27207,10 @@
         "p086kj9crzh": {
           "id": "p086kj9crzh",
           "label": "Middle Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR142",
           "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR142",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -27235,10 +27235,10 @@
         "p086kj9css5": {
           "id": "p086kj9css5",
           "label": "Late Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Late Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -27268,10 +27268,10 @@
           },
           "id": "p086kj9ctdr",
           "label": "Contact Period (1607 - 1750)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Contact Period (1607 - 1750)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -27296,10 +27296,10 @@
         "p086kj9cttr": {
           "id": "p086kj9cttr",
           "label": "Sterns Creek",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR52",
           "originalLabel": {
             "eng-latn": "Sterns Creek"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR52",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -27324,10 +27324,10 @@
         "p086kj9cx9n": {
           "id": "p086kj9cx9n",
           "label": "Historic, Native American (Choctaw)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Historic, Native American (Choctaw)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -27352,10 +27352,10 @@
         "p086kj9cxbz": {
           "id": "p086kj9cxbz",
           "label": "Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -27380,10 +27380,10 @@
         "p086kj9czgm": {
           "id": "p086kj9czgm",
           "label": "Early Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Early Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -27408,10 +27408,10 @@
         "p086kj9czv9": {
           "id": "p086kj9czv9",
           "label": "Pioneer Iowa, Wisconsin Territory to early statehood",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR140",
           "originalLabel": {
             "eng-latn": "Pioneer Iowa, Wisconsin Territory to early statehood"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR140",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -27436,10 +27436,10 @@
         "p086kj9d2g6": {
           "id": "p086kj9d2g6",
           "label": "Sioux",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR57",
           "originalLabel": {
             "eng-latn": "Sioux"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR57",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -27464,10 +27464,10 @@
         "p086kj9d5hd": {
           "id": "p086kj9d5hd",
           "label": "Colonial",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Colonial"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -27492,10 +27492,10 @@
         "p086kj9d5nq": {
           "id": "p086kj9d5nq",
           "label": "Late Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Late Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -27520,10 +27520,10 @@
         "p086kj9d6kc": {
           "id": "p086kj9d6kc",
           "label": "Alachua",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Alachua"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -27548,10 +27548,10 @@
         "p086kj9d6mp": {
           "id": "p086kj9d6mp",
           "label": "Osceola",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR28",
           "originalLabel": {
             "eng-latn": "Osceola"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR28",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -27581,10 +27581,10 @@
           },
           "id": "p086kj9d84m",
           "label": "20th Century (1900 - 1999)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "20th Century (1900 - 1999)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -27609,10 +27609,10 @@
         "p086kj9d9c8": {
           "id": "p086kj9d9c8",
           "label": "Old Copper Culture",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR30",
           "originalLabel": {
             "eng-latn": "Old Copper Culture"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR30",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -27637,10 +27637,10 @@
         "p086kj9d9xk": {
           "id": "p086kj9d9xk",
           "label": "Medley",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Medley"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -27665,10 +27665,10 @@
         "p086kj9dbcj": {
           "id": "p086kj9dbcj",
           "label": "Fayette",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Fayette"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -27693,10 +27693,10 @@
         "p086kj9dbv7": {
           "id": "p086kj9dbv7",
           "label": "German Amana Colonists",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR61",
           "originalLabel": {
             "eng-latn": "German Amana Colonists"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR61",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -27721,10 +27721,10 @@
         "p086kj9dcst": {
           "id": "p086kj9dcst",
           "label": "Prehistoric-Aceramic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Prehistoric-Aceramic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -27749,10 +27749,10 @@
         "p086kj9ddg5": {
           "id": "p086kj9ddg5",
           "label": "Undifferentiated Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Undifferentiated Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -27782,10 +27782,10 @@
           },
           "id": "p086kj9dfv4",
           "label": "Safety Harbor, A.D. 1000-1500",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Safety Harbor, A.D. 1000-1500"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -27810,10 +27810,10 @@
         "p086kj9dfz4": {
           "id": "p086kj9dfz4",
           "label": "Early Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Early Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -27838,10 +27838,10 @@
         "p086kj9dgd3": {
           "id": "p086kj9dgd3",
           "label": "Late Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR56",
           "originalLabel": {
             "eng-latn": "Late Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR56",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -27866,10 +27866,10 @@
         "p086kj9dgnd": {
           "id": "p086kj9dgnd",
           "label": "Elliots Point",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Elliots Point"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -27894,10 +27894,10 @@
         "p086kj9dkj9": {
           "id": "p086kj9dkj9",
           "label": "Quaker",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR64",
           "originalLabel": {
             "eng-latn": "Quaker"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR64",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -27922,10 +27922,10 @@
         "p086kj9dng7": {
           "id": "p086kj9dng7",
           "label": "Middle Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Middle Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -27950,10 +27950,10 @@
         "p086kj9dqjg": {
           "id": "p086kj9dqjg",
           "label": "Multi",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Multi"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -27978,10 +27978,10 @@
         "p086kj9drbr": {
           "id": "p086kj9drbr",
           "label": "Caloosahatchee I",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Caloosahatchee I"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -28006,10 +28006,10 @@
         "p086kj9dt92": {
           "id": "p086kj9dt92",
           "label": "Late Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Late Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -28034,10 +28034,10 @@
         "p086kj9dzbj": {
           "id": "p086kj9dzbj",
           "label": "Historic Native American",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Historic Native American"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -28062,10 +28062,10 @@
         "p086kj9f4k2": {
           "id": "p086kj9f4k2",
           "label": "Nebraska",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR54",
           "originalLabel": {
             "eng-latn": "Nebraska"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR54",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -28090,10 +28090,10 @@
         "p086kj9f56n": {
           "id": "p086kj9f56n",
           "label": "Terminal Late Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Terminal Late Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -28118,10 +28118,10 @@
         "p086kj9f7x8": {
           "id": "p086kj9f7x8",
           "label": "Santa Rosa",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Santa Rosa"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -28146,10 +28146,10 @@
         "p086kj9f83j": {
           "id": "p086kj9f83j",
           "label": "20th century",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR73",
           "originalLabel": {
             "eng-latn": "20th century"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR73",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -28174,10 +28174,10 @@
         "p086kj9fc9f": {
           "id": "p086kj9fc9f",
           "label": "LW & Miss - FA",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "LW & Miss - FA"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -28207,10 +28207,10 @@
           },
           "id": "p086kj9fcmf",
           "label": "Middle Archaic (6500 - 3001 B.C.)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Middle Archaic (6500 - 3001 B.C.)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -28235,10 +28235,10 @@
         "p086kj9ff2p": {
           "id": "p086kj9ff2p",
           "label": "Spring Hollow; Weaver",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR85",
           "originalLabel": {
             "eng-latn": "Spring Hollow; Weaver"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR85",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -28263,10 +28263,10 @@
         "p086kj9ffx2": {
           "id": "p086kj9ffx2",
           "label": "Oto",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR33",
           "originalLabel": {
             "eng-latn": "Oto"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR33",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -28291,10 +28291,10 @@
         "p086kj9fgzn": {
           "id": "p086kj9fgzn",
           "label": "Pre-Contact",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Pre-Contact"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -28319,10 +28319,10 @@
         "p086kj9fhtm": {
           "id": "p086kj9fhtm",
           "label": "pre 1873",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR124",
           "originalLabel": {
             "eng-latn": "pre 1873"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR124",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -28352,10 +28352,10 @@
           },
           "id": "p086kj9fnds",
           "label": "17th Century::1st quarter (1600 - 1624)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "17th Century::1st quarter (1600 - 1624)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -28385,10 +28385,10 @@
           },
           "id": "p086kj9frv2",
           "label": "17th Century::2nd half (1650 - 1699)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "17th Century::2nd half (1650 - 1699)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -28413,10 +28413,10 @@
         "p086kj9fstz": {
           "id": "p086kj9fstz",
           "label": "Belle Glade II",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Belle Glade II"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -28441,10 +28441,10 @@
         "p086kj9ftd9": {
           "id": "p086kj9ftd9",
           "label": "Glenwood(?)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR53",
           "originalLabel": {
             "eng-latn": "Glenwood(?)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR53",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -28469,10 +28469,10 @@
         "p086kj9fwr7": {
           "id": "p086kj9fwr7",
           "label": "Quad",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Quad"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -28497,10 +28497,10 @@
         "p086kj9fxt6": {
           "id": "p086kj9fxt6",
           "label": "Pioneer",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR132",
           "originalLabel": {
             "eng-latn": "Pioneer"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR132",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -28525,10 +28525,10 @@
         "p086kj9g2q2": {
           "id": "p086kj9g2q2",
           "label": "Late Paleo-Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR128",
           "originalLabel": {
             "eng-latn": "Late Paleo-Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR128",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -28558,10 +28558,10 @@
           },
           "id": "p086kj9g4c9",
           "label": "Colonial (1700-1803)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA8",
           "originalLabel": {
             "eng-latn": "Colonial (1700-1803)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA8",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -28586,10 +28586,10 @@
         "p086kj9g4dm": {
           "id": "p086kj9g4dm",
           "label": "Any Woodland Period",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Any Woodland Period"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -28614,10 +28614,10 @@
         "p086kj9g4hm": {
           "id": "p086kj9g4hm",
           "label": "Wahpekute Dakota",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR114",
           "originalLabel": {
             "eng-latn": "Wahpekute Dakota"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR114",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -28642,10 +28642,10 @@
         "p086kj9g7w6": {
           "id": "p086kj9g7w6",
           "label": "Late Prehistoric",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Late Prehistoric"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -28670,10 +28670,10 @@
         "p086kj9g8sg": {
           "id": "p086kj9g8sg",
           "label": "Oneota/Ioway/Oto",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR37",
           "originalLabel": {
             "eng-latn": "Oneota/Ioway/Oto"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR37",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -28698,10 +28698,10 @@
         "p086kj9g9jf": {
           "id": "p086kj9g9jf",
           "label": "Prehistoric",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA35",
           "originalLabel": {
             "eng-latn": "Prehistoric"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA35",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -28731,10 +28731,10 @@
           },
           "id": "p086kj9gbmd",
           "label": "18th Century (1700 - 1799)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "18th Century (1700 - 1799)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -28759,10 +28759,10 @@
         "p086kj9gbqd": {
           "id": "p086kj9gbqd",
           "label": "Black Sand",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR12",
           "originalLabel": {
             "eng-latn": "Black Sand"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR12",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -28787,10 +28787,10 @@
         "p086kj9gdmz": {
           "id": "p086kj9gdmz",
           "label": "Malabar II",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Malabar II"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -28815,10 +28815,10 @@
         "p086kj9ghf7": {
           "id": "p086kj9ghf7",
           "label": "Creek-Lower",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Creek-Lower"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -28843,10 +28843,10 @@
         "p086kj9gkmg": {
           "id": "p086kj9gkmg",
           "label": "Late Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Late Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -28871,10 +28871,10 @@
         "p086kj9gkqg": {
           "id": "p086kj9gkqg",
           "label": "Early Pioneer",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR120",
           "originalLabel": {
             "eng-latn": "Early Pioneer"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR120",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -28899,10 +28899,10 @@
         "p086kj9gn2q": {
           "id": "p086kj9gn2q",
           "label": "Paleoindian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Paleoindian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -28927,10 +28927,10 @@
         "p086kj9gn8q": {
           "id": "p086kj9gn8q",
           "label": "Early Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Early Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -28955,10 +28955,10 @@
         "p086kj9gpvp": {
           "id": "p086kj9gpvp",
           "label": "Lg SN Cluster",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Lg SN Cluster"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -28983,10 +28983,10 @@
         "p086kj9grkm": {
           "id": "p086kj9grkm",
           "label": "Unidentified",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Unidentified"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -29011,10 +29011,10 @@
         "p086kj9gt6j": {
           "id": "p086kj9gt6j",
           "label": "Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA25",
           "originalLabel": {
             "eng-latn": "Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA25",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -29039,10 +29039,10 @@
         "p086kj9gtbv": {
           "id": "p086kj9gtbv",
           "label": "European Miscellaneous",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "European Miscellaneous"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -29067,10 +29067,10 @@
         "p086kj9gxdf": {
           "id": "p086kj9gxdf",
           "label": "Havana",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR21",
           "originalLabel": {
             "eng-latn": "Havana"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR21",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -29095,10 +29095,10 @@
         "p086kj9gzcd": {
           "id": "p086kj9gzcd",
           "label": "Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR29",
           "originalLabel": {
             "eng-latn": "Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR29",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -29123,10 +29123,10 @@
         "p086kj9gzj3": {
           "id": "p086kj9gzj3",
           "label": "Caloosahatchee III",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Caloosahatchee III"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -29151,10 +29151,10 @@
         "p086kj9h22x": {
           "id": "p086kj9h22x",
           "label": "1880 to 2008",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR138",
           "originalLabel": {
             "eng-latn": "1880 to 2008"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR138",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -29179,10 +29179,10 @@
         "p086kj9h358": {
           "id": "p086kj9h358",
           "label": "Early Swift Creek",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Early Swift Creek"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -29207,10 +29207,10 @@
         "p086kj9h447": {
           "id": "p086kj9h447",
           "label": "Late Paleo-Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR143",
           "originalLabel": {
             "eng-latn": "Late Paleo-Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR143",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -29240,10 +29240,10 @@
           },
           "id": "p086kj9h55t",
           "label": "Nineteenth C. American 1821-1899",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Nineteenth C. American 1821-1899"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -29268,10 +29268,10 @@
         "p086kj9hb3n": {
           "id": "p086kj9hb3n",
           "label": "Thebes-Lost Lake",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Thebes-Lost Lake"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -29296,10 +29296,10 @@
         "p086kj9hb5b": {
           "id": "p086kj9hb5b",
           "label": "Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA21",
           "originalLabel": {
             "eng-latn": "Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA21",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -29324,10 +29324,10 @@
         "p086kj9hfdj": {
           "id": "p086kj9hfdj",
           "label": "Paleoindian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Paleoindian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -29357,10 +29357,10 @@
           },
           "id": "p086kj9hk3q",
           "label": "17th Century (1600 - 1699)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "17th Century (1600 - 1699)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -29385,10 +29385,10 @@
         "p086kj9hq48": {
           "id": "p086kj9hq48",
           "label": "Historical",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Historical"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -29413,10 +29413,10 @@
         "p086kj9hqkk": {
           "id": "p086kj9hqkk",
           "label": "Apalachee",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Apalachee"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -29446,10 +29446,10 @@
           },
           "id": "p086kj9hqsk",
           "label": "Post Cold War (1989 - Present)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Post Cold War (1989 - Present)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -29474,10 +29474,10 @@
         "p086kj9hrkv": {
           "id": "p086kj9hrkv",
           "label": "Pammel Creek",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR79",
           "originalLabel": {
             "eng-latn": "Pammel Creek"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR79",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -29502,10 +29502,10 @@
         "p086kj9ht5g": {
           "id": "p086kj9ht5g",
           "label": "Crab Orchard",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Crab Orchard"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -29530,10 +29530,10 @@
         "p086kj9hvkr": {
           "id": "p086kj9hvkr",
           "label": "Red Ochre",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR102",
           "originalLabel": {
             "eng-latn": "Red Ochre"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR102",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -29558,10 +29558,10 @@
         "p086kj9hxn2": {
           "id": "p086kj9hxn2",
           "label": "Unknown Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Unknown Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -29586,10 +29586,10 @@
         "p086kj9j2k7": {
           "id": "p086kj9j2k7",
           "label": "Late Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Late Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -29620,10 +29620,10 @@
           },
           "id": "p086kj9j3tt",
           "label": "Terminal Late Woodland (Emergent Miss.)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA16",
           "originalLabel": {
             "eng-latn": "Terminal Late Woodland (Emergent Miss.)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA16",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -29648,10 +29648,10 @@
         "p086kj9j4fg": {
           "id": "p086kj9j4fg",
           "label": "General Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "General Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -29676,10 +29676,10 @@
         "p086kj9j5rr": {
           "id": "p086kj9j5rr",
           "label": "Weeden Island II",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Weeden Island II"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -29709,10 +29709,10 @@
           },
           "id": "p086kj9j8fn",
           "label": "Antebellum Period (1830 - 1860)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Antebellum Period (1830 - 1860)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -29742,10 +29742,10 @@
           },
           "id": "p086kj9j8wz",
           "label": "Twentieth C American",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Twentieth C American"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -29770,10 +29770,10 @@
         "p086kj9j94x": {
           "id": "p086kj9j94x",
           "label": "WWI military structure remains",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR86",
           "originalLabel": {
             "eng-latn": "WWI military structure remains"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR86",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -29798,10 +29798,10 @@
         "p086kj9j989": {
           "id": "p086kj9j989",
           "label": "Late Paleo Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Late Paleo Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -29826,10 +29826,10 @@
         "p086kj9jc8v": {
           "id": "p086kj9jc8v",
           "label": "Early Paleoindian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Early Paleoindian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -29854,10 +29854,10 @@
         "p086kj9jcrj": {
           "id": "p086kj9jcrj",
           "label": "Suwannee Valley Culture",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Suwannee Valley Culture"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -29882,10 +29882,10 @@
         "p086kj9jd26": {
           "id": "p086kj9jd26",
           "label": "Belle Glade I",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Belle Glade I"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -29910,10 +29910,10 @@
         "p086kj9jg7f": {
           "id": "p086kj9jg7f",
           "label": "Mill Phase",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR8",
           "originalLabel": {
             "eng-latn": "Mill Phase"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR8",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -29938,10 +29938,10 @@
         "p086kj9jggr": {
           "id": "p086kj9jggr",
           "label": "African-American",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "African-American"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -29966,10 +29966,10 @@
         "p086kj9jhs3": {
           "id": "p086kj9jhs3",
           "label": "Middle Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR129",
           "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR129",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -29999,10 +29999,10 @@
           },
           "id": "p086kj9jkgn",
           "label": "Late Archaic (3000 - 1201 B.C.)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Late Archaic (3000 - 1201 B.C.)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -30027,10 +30027,10 @@
         "p086kj9jkrb": {
           "id": "p086kj9jkrb",
           "label": "Early Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Early Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -30060,10 +30060,10 @@
           },
           "id": "p086kj9jn9k",
           "label": "Civil War (1861 - 1865)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Civil War (1861 - 1865)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -30093,10 +30093,10 @@
           },
           "id": "p086kj9jndk",
           "label": "Seminole-Colonization Period 1750-1816",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Seminole-Colonization Period 1750-1816"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -30121,10 +30121,10 @@
         "p086kj9jpmv": {
           "id": "p086kj9jpmv",
           "label": "Winnebago",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR38",
           "originalLabel": {
             "eng-latn": "Winnebago"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR38",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -30154,10 +30154,10 @@
           },
           "id": "p086kj9jqnh",
           "label": "Early National Period (1790 - 1829)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Early National Period (1790 - 1829)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -30182,10 +30182,10 @@
         "p086kj9jrg5": {
           "id": "p086kj9jrg5",
           "label": "St. Johns IIc",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "St. Johns IIc"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -30210,10 +30210,10 @@
         "p086kj9jvdc": {
           "id": "p086kj9jvdc",
           "label": "Glades IIIc",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Glades IIIc"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -30238,10 +30238,10 @@
         "p086kj9jvrp": {
           "id": "p086kj9jvrp",
           "label": "Archaic unspecified",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Archaic unspecified"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -30271,10 +30271,10 @@
           },
           "id": "p086kj9jvw2",
           "label": "Late Woodland (1000 - 1606)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Late Woodland (1000 - 1606)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -30299,10 +30299,10 @@
         "p086kj9jzcw": {
           "id": "p086kj9jzcw",
           "label": "early Late Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR10",
           "originalLabel": {
             "eng-latn": "early Late Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR10",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -30327,10 +30327,10 @@
         "p086kj9jzkw": {
           "id": "p086kj9jzkw",
           "label": "Early Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA9",
           "originalLabel": {
             "eng-latn": "Early Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA9",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -30355,10 +30355,10 @@
         "p086kj9kbct": {
           "id": "p086kj9kbct",
           "label": "Middle Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -30388,10 +30388,10 @@
           },
           "id": "p086kj9kft3",
           "label": "17th Century::3rd quarter (1650 - 1674)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "17th Century::3rd quarter (1650 - 1674)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -30416,10 +30416,10 @@
         "p086kj9kfzd": {
           "id": "p086kj9kfzd",
           "label": "Perico Island",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Perico Island"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -30449,10 +30449,10 @@
           },
           "id": "p086kj9kh9n",
           "label": "Glades I, 1000 B.C.-A.D. 750",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Glades I, 1000 B.C.-A.D. 750"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -30477,10 +30477,10 @@
         "p086kj9kknk": {
           "id": "p086kj9kknk",
           "label": "Late Paleoindian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Late Paleoindian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -30510,10 +30510,10 @@
           },
           "id": "p086kj9kkzk",
           "label": "Transitional, 1000 B.C.-700 B.C.",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Transitional, 1000 B.C.-700 B.C."
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -30538,10 +30538,10 @@
         "p086kj9km57": {
           "id": "p086kj9km57",
           "label": "Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -30566,10 +30566,10 @@
         "p086kj9kr9q": {
           "id": "p086kj9kr9q",
           "label": "Archaic-Late",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Archaic-Late"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -30594,10 +30594,10 @@
         "p086kj9ksh2": {
           "id": "p086kj9ksh2",
           "label": "Pre-Clovis",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA11",
           "originalLabel": {
             "eng-latn": "Pre-Clovis"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA11",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -30622,10 +30622,10 @@
         "p086kj9ktwz": {
           "id": "p086kj9ktwz",
           "label": "Gast",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR115",
           "originalLabel": {
             "eng-latn": "Gast"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR115",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -30650,10 +30650,10 @@
         "p086kj9kv3m": {
           "id": "p086kj9kv3m",
           "label": "Hopewell/Havana",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR107",
           "originalLabel": {
             "eng-latn": "Hopewell/Havana"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR107",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -30683,10 +30683,10 @@
           },
           "id": "p086kj9kvs9",
           "label": "Colony to Nation (1751 - 1789)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Colony to Nation (1751 - 1789)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -30716,10 +30716,10 @@
           },
           "id": "p086kj9kwkk",
           "label": "Ft. Walton A.D. 1000-1500",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Ft. Walton A.D. 1000-1500"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -30744,10 +30744,10 @@
         "p086kj9kx67": {
           "id": "p086kj9kx67",
           "label": "Malabar I",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Malabar I"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -30772,10 +30772,10 @@
         "p086kj9kxpv": {
           "id": "p086kj9kxpv",
           "label": "Late Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Late Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -30805,10 +30805,10 @@
           },
           "id": "p086kj9kxzj",
           "label": "20th Century::1st half (1900 - 1949)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "20th Century::1st half (1900 - 1949)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -30833,10 +30833,10 @@
         "p086kj9kzth": {
           "id": "p086kj9kzth",
           "label": "Middle Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -30861,10 +30861,10 @@
         "p086kj9m263": {
           "id": "p086kj9m263",
           "label": "Paleoindian, Undifferentiated",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Paleoindian, Undifferentiated"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -30894,10 +30894,10 @@
           },
           "id": "p086kj9m2fd",
           "label": "Urban / Industrial (1900-1960)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA18",
           "originalLabel": {
             "eng-latn": "Urban / Industrial (1900-1960)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA18",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -30922,10 +30922,10 @@
         "p086kj9m39c": {
           "id": "p086kj9m39c",
           "label": "Late Archaic, indet.",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Late Archaic, indet."
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -30950,10 +30950,10 @@
         "p086kj9m5wm": {
           "id": "p086kj9m5wm",
           "label": "First Spanish, Early 1600-1699",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "First Spanish, Early 1600-1699"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -30983,10 +30983,10 @@
           },
           "id": "p086kj9m6nk",
           "label": "18th Century::2nd half (1750 - 1799)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "18th Century::2nd half (1750 - 1799)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -31011,10 +31011,10 @@
         "p086kj9m757": {
           "id": "p086kj9m757",
           "label": "Glades IIc",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Glades IIc"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -31039,10 +31039,10 @@
         "p086kj9m8ch": {
           "id": "p086kj9m8ch",
           "label": "Clovis",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Clovis"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -31067,10 +31067,10 @@
         "p086kj9m9gs": {
           "id": "p086kj9m9gs",
           "label": "General Paleo Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "General Paleo Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -31095,10 +31095,10 @@
         "p086kj9mb3f": {
           "id": "p086kj9mb3f",
           "label": "Glades IIb",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Glades IIb"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -31123,10 +31123,10 @@
         "p086kj9mdwp": {
           "id": "p086kj9mdwp",
           "label": "Riverton",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Riverton"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -31151,10 +31151,10 @@
         "p086kj9mf4n": {
           "id": "p086kj9mf4n",
           "label": "Historic, Undifferentiated",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Historic, Undifferentiated"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -31179,10 +31179,10 @@
         "p086kj9mkdh": {
           "id": "p086kj9mkdh",
           "label": "Nebraska Phase",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR26",
           "originalLabel": {
             "eng-latn": "Nebraska Phase"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR26",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -31207,10 +31207,10 @@
         "p086kj9mr3z": {
           "id": "p086kj9mr3z",
           "label": "Mill Creek",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR7",
           "originalLabel": {
             "eng-latn": "Mill Creek"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR7",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -31235,10 +31235,10 @@
         "p086kj9mtdk": {
           "id": "p086kj9mtdk",
           "label": "Middle Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -31263,10 +31263,10 @@
         "p086kj9mtxk": {
           "id": "p086kj9mtxk",
           "label": "1870-1998",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR94",
           "originalLabel": {
             "eng-latn": "1870-1998"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR94",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -31291,10 +31291,10 @@
         "p086kj9n54j": {
           "id": "p086kj9n54j",
           "label": "Pelican Lake",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR75",
           "originalLabel": {
             "eng-latn": "Pelican Lake"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR75",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -31324,10 +31324,10 @@
           },
           "id": "p086kj9n5x7",
           "label": "Boom Times 1921-1929",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Boom Times 1921-1929"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -31352,10 +31352,10 @@
         "p086kj9ndfm": {
           "id": "p086kj9ndfm",
           "label": "Archaic, Early Big Sandy",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Archaic, Early Big Sandy"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -31380,10 +31380,10 @@
         "p086kj9ndsx": {
           "id": "p086kj9ndsx",
           "label": "Norwood",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Norwood"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -31408,10 +31408,10 @@
         "p086kj9nfg8": {
           "id": "p086kj9nfg8",
           "label": "Contact Era Prehistoric",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Contact Era Prehistoric"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -31436,10 +31436,10 @@
         "p086kj9nkmr": {
           "id": "p086kj9nkmr",
           "label": "Ioway",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR34",
           "originalLabel": {
             "eng-latn": "Ioway"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR34",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -31464,10 +31464,10 @@
         "p086kj9nm4d": {
           "id": "p086kj9nm4d",
           "label": "Sac?",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR89",
           "originalLabel": {
             "eng-latn": "Sac?"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR89",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -31492,10 +31492,10 @@
         "p086kj9nmgq": {
           "id": "p086kj9nmgq",
           "label": "Louisa",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR92",
           "originalLabel": {
             "eng-latn": "Louisa"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR92",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -31525,10 +31525,10 @@
           },
           "id": "p086kj9np4z",
           "label": "1870 - 1930",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR95",
           "originalLabel": {
             "eng-latn": "1870 - 1930"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR95",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -31553,10 +31553,10 @@
         "p086kj9npfz": {
           "id": "p086kj9npfz",
           "label": "Late Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Late Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -31581,10 +31581,10 @@
         "p086kj9nqcm": {
           "id": "p086kj9nqcm",
           "label": "Early Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA29",
           "originalLabel": {
             "eng-latn": "Early Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA29",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -31609,10 +31609,10 @@
         "p086kj9ntb6": {
           "id": "p086kj9ntb6",
           "label": "James Bayou",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "James Bayou"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -31637,10 +31637,10 @@
         "p086kj9ntgh": {
           "id": "p086kj9ntgh",
           "label": "Liverpool",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR27",
           "originalLabel": {
             "eng-latn": "Liverpool"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR27",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -31665,10 +31665,10 @@
         "p086kj9nvrg": {
           "id": "p086kj9nvrg",
           "label": "Skidmore",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Skidmore"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -31693,10 +31693,10 @@
         "p086kj9nzgp": {
           "id": "p086kj9nzgp",
           "label": "Late Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Late Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -31721,10 +31721,10 @@
         "p086kj9p2c8": {
           "id": "p086kj9p2c8",
           "label": "Historic Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Historic Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -31749,10 +31749,10 @@
         "p086kj9p3qv": {
           "id": "p086kj9p3qv",
           "label": "Late Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA27",
           "originalLabel": {
             "eng-latn": "Late Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA27",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -31777,10 +31777,10 @@
         "p086kj9p63r": {
           "id": "p086kj9p63r",
           "label": "Historic, Native American (Tomeh)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Historic, Native American (Tomeh)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -31805,10 +31805,10 @@
         "p086kj9p68f": {
           "id": "p086kj9p68f",
           "label": "Keyes",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR11",
           "originalLabel": {
             "eng-latn": "Keyes"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR11",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -31833,10 +31833,10 @@
         "p086kj9pbdx": {
           "id": "p086kj9pbdx",
           "label": "Prehistoric, unspecified",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Prehistoric, unspecified"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -31861,10 +31861,10 @@
         "p086kj9pbf9": {
           "id": "p086kj9pbf9",
           "label": "Faulkner",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Faulkner"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -31889,10 +31889,10 @@
         "p086kj9pdhj": {
           "id": "p086kj9pdhj",
           "label": "Newtown",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Newtown"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -31917,10 +31917,10 @@
         "p086kj9pf2h": {
           "id": "p086kj9pf2h",
           "label": "Pioneer",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Pioneer"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -31945,10 +31945,10 @@
         "p086kj9ph84": {
           "id": "p086kj9ph84",
           "label": "Unknown historic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Unknown historic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -31973,10 +31973,10 @@
         "p086kj9phrr": {
           "id": "p086kj9phrr",
           "label": "Belle Glade IV",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Belle Glade IV"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -32001,10 +32001,10 @@
         "p086kj9pk32": {
           "id": "p086kj9pk32",
           "label": "19th century urban",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR131",
           "originalLabel": {
             "eng-latn": "19th century urban"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR131",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -32029,10 +32029,10 @@
         "p086kj9pk8p": {
           "id": "p086kj9pk8p",
           "label": "Late Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Late Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -32057,10 +32057,10 @@
         "p086kj9pkgp": {
           "id": "p086kj9pkgp",
           "label": "Weeden Island 4",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Weeden Island 4"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -32085,10 +32085,10 @@
         "p086kj9pmnn": {
           "id": "p086kj9pmnn",
           "label": "Middle Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -32113,10 +32113,10 @@
         "p086kj9pn59": {
           "id": "p086kj9pn59",
           "label": "Middle Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR36",
           "originalLabel": {
             "eng-latn": "Middle Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR36",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -32141,10 +32141,10 @@
         "p086kj9ppwk": {
           "id": "p086kj9ppwk",
           "label": "early Middle Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR72",
           "originalLabel": {
             "eng-latn": "early Middle Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR72",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -32169,10 +32169,10 @@
         "p086kj9pr3h": {
           "id": "p086kj9pr3h",
           "label": "Mt. Taylor",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Mt. Taylor"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -32202,10 +32202,10 @@
           },
           "id": "p086kj9pr6h",
           "label": "Modern (Post 1950)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Modern (Post 1950)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -32230,10 +32230,10 @@
         "p086kj9prmh": {
           "id": "p086kj9prmh",
           "label": "Dorena",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Dorena"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -32258,10 +32258,10 @@
         "p086kj9pshs": {
           "id": "p086kj9pshs",
           "label": "Madison Phase",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR19",
           "originalLabel": {
             "eng-latn": "Madison Phase"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR19",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -32286,10 +32286,10 @@
         "p086kj9ptt4": {
           "id": "p086kj9ptt4",
           "label": "<c.1950",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR109",
           "originalLabel": {
             "eng-latn": "<c.1950"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR109",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -32319,10 +32319,10 @@
           },
           "id": "p086kj9pv4q",
           "label": "19th Century::1st quarter (1800 - 1825)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "19th Century::1st quarter (1800 - 1825)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -32352,10 +32352,10 @@
           },
           "id": "p086kj9pxcn",
           "label": "19th Century::2nd half (1850 - 1899)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "19th Century::2nd half (1850 - 1899)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -32385,10 +32385,10 @@
           },
           "id": "p086kj9q8fx",
           "label": "St. Johns II, A.D. 800-1500",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "St. Johns II, A.D. 800-1500"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -32413,10 +32413,10 @@
         "p086kj9qdms": {
           "id": "p086kj9qdms",
           "label": "Middle Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -32441,10 +32441,10 @@
         "p086kj9qgvq": {
           "id": "p086kj9qgvq",
           "label": "Terminal Late Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Terminal Late Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -32469,10 +32469,10 @@
         "p086kj9qmp8": {
           "id": "p086kj9qmp8",
           "label": "Folsom",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR16",
           "originalLabel": {
             "eng-latn": "Folsom"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR16",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -32497,10 +32497,10 @@
         "p086kj9qn8j": {
           "id": "p086kj9qn8j",
           "label": "Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -32525,10 +32525,10 @@
         "p086kj9qp5t": {
           "id": "p086kj9qp5t",
           "label": "Millville",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR81",
           "originalLabel": {
             "eng-latn": "Millville"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR81",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -32553,10 +32553,10 @@
         "p086kj9qppt": {
           "id": "p086kj9qppt",
           "label": "Orr phase",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR93",
           "originalLabel": {
             "eng-latn": "Orr phase"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR93",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -32586,10 +32586,10 @@
           },
           "id": "p086kj9qq6g",
           "label": "Spanish-Second Period 1783-1821",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Spanish-Second Period 1783-1821"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -32614,10 +32614,10 @@
         "p086kj9qqdg": {
           "id": "p086kj9qqdg",
           "label": "Hoecake",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Hoecake"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -32642,10 +32642,10 @@
         "p086kj9qqfs": {
           "id": "p086kj9qqfs",
           "label": "Clovis/Gainey",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR111",
           "originalLabel": {
             "eng-latn": "Clovis/Gainey"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR111",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -32670,10 +32670,10 @@
         "p086kj9qt22": {
           "id": "p086kj9qt22",
           "label": "Weeden Island 2",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Weeden Island 2"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -32703,10 +32703,10 @@
           },
           "id": "p086kj9qtfp",
           "label": "Spanish-First Period 1513-1763",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Spanish-First Period 1513-1763"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -32731,10 +32731,10 @@
         "p086kj9qxjk": {
           "id": "p086kj9qxjk",
           "label": "Late Gulf Formational",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Late Gulf Formational"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -32764,10 +32764,10 @@
           },
           "id": "p086kj9qztj",
           "label": "Prehistoric/Unknown (15000 B.C. - 1606 A.D.)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Prehistoric/Unknown (15000 B.C. - 1606 A.D.)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -32792,10 +32792,10 @@
         "p086kj9qzzv": {
           "id": "p086kj9qzzv",
           "label": "French",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "French"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -32820,10 +32820,10 @@
         "p086kj9r59z": {
           "id": "p086kj9r59z",
           "label": "Paleo Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Paleo Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -32848,10 +32848,10 @@
         "p086kj9rbs5": {
           "id": "p086kj9rbs5",
           "label": "St. Augustine",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "St. Augustine"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -32876,10 +32876,10 @@
         "p086kj9rdfd": {
           "id": "p086kj9rdfd",
           "label": "Spanish-1st or 2nd",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Spanish-1st or 2nd"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -32904,10 +32904,10 @@
         "p086kj9rhj9": {
           "id": "p086kj9rhj9",
           "label": "Other",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA19",
           "originalLabel": {
             "eng-latn": "Other"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA19",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -32932,10 +32932,10 @@
         "p086kj9rj2w": {
           "id": "p086kj9rj2w",
           "label": "General Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "General Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -32960,10 +32960,10 @@
         "p086kj9rkxj": {
           "id": "p086kj9rkxj",
           "label": "Bifurcate",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Bifurcate"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -32988,10 +32988,10 @@
         "p086kj9rm6t": {
           "id": "p086kj9rm6t",
           "label": "Historic, Native American (Natchez)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Historic, Native American (Natchez)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -33021,10 +33021,10 @@
           },
           "id": "p086kj9rn4g",
           "label": "American 1821-present",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "American 1821-present"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -33049,10 +33049,10 @@
         "p086kj9rvj8": {
           "id": "p086kj9rvj8",
           "label": "Frederick?",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR91",
           "originalLabel": {
             "eng-latn": "Frederick?"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR91",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -33077,10 +33077,10 @@
         "p086kj9rwbj": {
           "id": "p086kj9rwbj",
           "label": "Weeden Island 5",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Weeden Island 5"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -33105,10 +33105,10 @@
         "p086kj9rwzj": {
           "id": "p086kj9rwzj",
           "label": "German Amana Colonist",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR62",
           "originalLabel": {
             "eng-latn": "German Amana Colonist"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR62",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -33138,10 +33138,10 @@
           },
           "id": "p086kj9rxqh",
           "label": "Civil War 1861-1865",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Civil War 1861-1865"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -33166,10 +33166,10 @@
         "p086kj9rxvt": {
           "id": "p086kj9rxvt",
           "label": "Agate Basin",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR88",
           "originalLabel": {
             "eng-latn": "Agate Basin"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR88",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -33194,10 +33194,10 @@
         "p086kj9s35b": {
           "id": "p086kj9s35b",
           "label": "Middle-Late Woodland, indet.",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Middle-Late Woodland, indet."
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -33222,10 +33222,10 @@
         "p086kj9s48m": {
           "id": "p086kj9s48m",
           "label": "Eighteenth Century Spanish 1700-1763",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Eighteenth Century Spanish 1700-1763"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -33250,10 +33250,10 @@
         "p086kj9s4pm": {
           "id": "p086kj9s4pm",
           "label": "Paleo-Early",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Paleo-Early"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -33278,10 +33278,10 @@
         "p086kj9s4tx": {
           "id": "p086kj9s4tx",
           "label": "Not Reported",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA30",
           "originalLabel": {
             "eng-latn": "Not Reported"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA30",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -33306,10 +33306,10 @@
         "p086kj9s5ww": {
           "id": "p086kj9s5ww",
           "label": "Early Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Early Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -33334,10 +33334,10 @@
         "p086kj9s6bv": {
           "id": "p086kj9s6bv",
           "label": "Mann",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Mann"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -33362,10 +33362,10 @@
         "p086kj9sdpz": {
           "id": "p086kj9sdpz",
           "label": "Quaker?",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR63",
           "originalLabel": {
             "eng-latn": "Quaker?"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR63",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -33395,10 +33395,10 @@
           },
           "id": "p086kj9sf59",
           "label": "18th Century::4th quarter (1775 - 1799)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "18th Century::4th quarter (1775 - 1799)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -33428,10 +33428,10 @@
           },
           "id": "p086kj9sfdm",
           "label": "20th Century::4th quarter (1975 - 1999)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "20th Century::4th quarter (1975 - 1999)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -33456,10 +33456,10 @@
         "p086kj9sg6w": {
           "id": "p086kj9sg6w",
           "label": "Late Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA24",
           "originalLabel": {
             "eng-latn": "Late Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA24",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -33484,10 +33484,10 @@
         "p086kj9shbj": {
           "id": "p086kj9shbj",
           "label": "Caloosahatchee IIA",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Caloosahatchee IIA"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -33512,10 +33512,10 @@
         "p086kj9sp72": {
           "id": "p086kj9sp72",
           "label": "Indet. Fort Ancient",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Indet. Fort Ancient"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -33540,10 +33540,10 @@
         "p086kj9sphp": {
           "id": "p086kj9sphp",
           "label": "Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -33573,10 +33573,10 @@
           },
           "id": "p086kj9srkx",
           "label": "Glades, 1000 B.C.-A.D. 1700",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Glades, 1000 B.C.-A.D. 1700"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -33606,10 +33606,10 @@
           },
           "id": "p086kj9srm9",
           "label": "Paleo-Indian (15000 - 8501 B.C.)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Paleo-Indian (15000 - 8501 B.C.)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -33634,10 +33634,10 @@
         "p086kj9ssnw": {
           "id": "p086kj9ssnw",
           "label": "Hell Gap",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR47",
           "originalLabel": {
             "eng-latn": "Hell Gap"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR47",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -33662,10 +33662,10 @@
         "p086kj9sttv": {
           "id": "p086kj9sttv",
           "label": "Early Paleo Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Early Paleo Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4197000",
@@ -33690,10 +33690,10 @@
         "p086kj9svgt": {
           "id": "p086kj9svgt",
           "label": "Middle Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA28",
           "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA28",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -33718,10 +33718,10 @@
         "p086kj9sw6g": {
           "id": "p086kj9sw6g",
           "label": "Adena",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Adena"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -33746,10 +33746,10 @@
         "p086kj9swk5": {
           "id": "p086kj9swk5",
           "label": "18th Century",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "18th Century"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -33779,10 +33779,10 @@
           },
           "id": "p086kj9sxn4",
           "label": "Early Industrial (1866-1899)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA32",
           "originalLabel": {
             "eng-latn": "Early Industrial (1866-1899)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA32",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -33807,10 +33807,10 @@
         "p086kj9sxxr": {
           "id": "p086kj9sxxr",
           "label": "Historic, Native American (Apalachee)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Historic, Native American (Apalachee)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -33835,10 +33835,10 @@
         "p086kj9szbd": {
           "id": "p086kj9szbd",
           "label": "Sac",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR48",
           "originalLabel": {
             "eng-latn": "Sac"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR48",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -33863,10 +33863,10 @@
         "p086kj9szpq": {
           "id": "p086kj9szpq",
           "label": "Possible Paleoindian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Possible Paleoindian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -33891,10 +33891,10 @@
         "p086kj9szvd": {
           "id": "p086kj9szvd",
           "label": "Middle Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -33919,10 +33919,10 @@
         "p086kj9t437": {
           "id": "p086kj9t437",
           "label": "17th Century",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "17th Century"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -33947,10 +33947,10 @@
         "p086kj9t69s": {
           "id": "p086kj9t69s",
           "label": "Tri Pt Only",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Tri Pt Only"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -33975,10 +33975,10 @@
         "p086kj9t6r5": {
           "id": "p086kj9t6r5",
           "label": "Historic/Unknown",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Historic/Unknown"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -34008,10 +34008,10 @@
           },
           "id": "p086kj9t9hp",
           "label": "Early Archaic (8500 - 6501 B.C.)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Early Archaic (8500 - 6501 B.C.)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -34036,10 +34036,10 @@
         "p086kj9tbgn": {
           "id": "p086kj9tbgn",
           "label": "Early-Middle Archaic, indet.",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Early-Middle Archaic, indet."
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -34064,10 +34064,10 @@
         "p086kj9tc2x": {
           "id": "p086kj9tc2x",
           "label": "Allamakee Phase",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR22",
           "originalLabel": {
             "eng-latn": "Allamakee Phase"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR22",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -34092,10 +34092,10 @@
         "p086kj9tcwx": {
           "id": "p086kj9tcwx",
           "label": "Paleo-indian, undefined",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Paleo-indian, undefined"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -34120,10 +34120,10 @@
         "p086kj9thdg": {
           "id": "p086kj9thdg",
           "label": "Weaver",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR20",
           "originalLabel": {
             "eng-latn": "Weaver"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR20",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -34153,10 +34153,10 @@
           },
           "id": "p086kj9tj9r",
           "label": "Archaic (8500 - 1201 B.C.)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Archaic (8500 - 1201 B.C.)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -34181,10 +34181,10 @@
         "p086kj9tjj4": {
           "id": "p086kj9tjj4",
           "label": "Caloosahatchee IIB",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Caloosahatchee IIB"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -34209,10 +34209,10 @@
         "p086kj9tqd8": {
           "id": "p086kj9tqd8",
           "label": "Missouri Bluffs",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR51",
           "originalLabel": {
             "eng-latn": "Missouri Bluffs"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR51",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -34237,10 +34237,10 @@
         "p086kj9tqsw": {
           "id": "p086kj9tqsw",
           "label": "Quakers",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR71",
           "originalLabel": {
             "eng-latn": "Quakers"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR71",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -34265,10 +34265,10 @@
         "p086kj9tqzk": {
           "id": "p086kj9tqzk",
           "label": "19th Century",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "19th Century"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -34298,10 +34298,10 @@
           },
           "id": "p086kj9tr4v",
           "label": "Civil War (1861-1865)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA33",
           "originalLabel": {
             "eng-latn": "Civil War (1861-1865)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA33",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -34326,10 +34326,10 @@
         "p086kj9tr6j": {
           "id": "p086kj9tr6j",
           "label": "Judge Tobin",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR121",
           "originalLabel": {
             "eng-latn": "Judge Tobin"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR121",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -34359,10 +34359,10 @@
           },
           "id": "p086kj9ttng",
           "label": "Early/Middle Woodland (1200 B.C. - 999 A.D.)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Early/Middle Woodland (1200 B.C. - 999 A.D.)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -34392,10 +34392,10 @@
           },
           "id": "p086kj9twsd",
           "label": "Depression/New Deal 1930-1940",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Depression/New Deal 1930-1940"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -34425,10 +34425,10 @@
           },
           "id": "p086kj9v37h",
           "label": "Caloosahatchee 500 B.C.-1700 A.D.",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Caloosahatchee 500 B.C.-1700 A.D."
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -34458,10 +34458,10 @@
           },
           "id": "p086kj9v6zd",
           "label": "Hickory Pond, A.D. 800-1250",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Hickory Pond, A.D. 800-1250"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -34491,10 +34491,10 @@
           },
           "id": "p086kj9v8jz",
           "label": "Deptford 700 B.C.-300 B.C.",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Deptford 700 B.C.-300 B.C."
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -34519,10 +34519,10 @@
         "p086kj9vbx8": {
           "id": "p086kj9vbx8",
           "label": "Unidentified Prehistoric",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Unidentified Prehistoric"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -34547,10 +34547,10 @@
         "p086kj9vc57": {
           "id": "p086kj9vc57",
           "label": "Possible Meskwaki",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR67",
           "originalLabel": {
             "eng-latn": "Possible Meskwaki"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR67",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -34575,10 +34575,10 @@
         "p086kj9vh3q": {
           "id": "p086kj9vh3q",
           "label": "Contact",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Contact"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -34603,10 +34603,10 @@
         "p086kj9vqdh": {
           "id": "p086kj9vqdh",
           "label": "Indet. Prehistoric",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Indet. Prehistoric"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -34631,10 +34631,10 @@
         "p086kj9vqjt": {
           "id": "p086kj9vqjt",
           "label": "Durst",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR43",
           "originalLabel": {
             "eng-latn": "Durst"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR43",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -34659,10 +34659,10 @@
         "p086kj9vv5c": {
           "id": "p086kj9vv5c",
           "label": "Tablerock",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Tablerock"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -34687,10 +34687,10 @@
         "p086kj9vv6p": {
           "id": "p086kj9vv6p",
           "label": "Protohistoric",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Protohistoric"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -34715,10 +34715,10 @@
         "p086kj9vvr2": {
           "id": "p086kj9vvr2",
           "label": "early Middle Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR101",
           "originalLabel": {
             "eng-latn": "early Middle Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR101",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -34743,10 +34743,10 @@
         "p086kj9vxnm": {
           "id": "p086kj9vxnm",
           "label": "early 19th century",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR135",
           "originalLabel": {
             "eng-latn": "early 19th century"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR135",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -34776,10 +34776,10 @@
           },
           "id": "p086kj9vzjw",
           "label": "Weeden Island A.D. 450-1000",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Weeden Island A.D. 450-1000"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -34804,10 +34804,10 @@
         "p086kj9w265": {
           "id": "p086kj9w265",
           "label": "Allamakee",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR77",
           "originalLabel": {
             "eng-latn": "Allamakee"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR77",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -34832,10 +34832,10 @@
         "p086kj9w6vn": {
           "id": "p086kj9w6vn",
           "label": "Kolomoki",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Kolomoki"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -34860,10 +34860,10 @@
         "p086kj9w7rx": {
           "id": "p086kj9w7rx",
           "label": "Late Paleo-Indian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Late Paleo-Indian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -34888,10 +34888,10 @@
         "p086kj9w8v8": {
           "id": "p086kj9w8v8",
           "label": "ca. 1930s-1940s",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR126",
           "originalLabel": {
             "eng-latn": "ca. 1930s-1940s"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR126",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -34921,10 +34921,10 @@
           },
           "id": "p086kj9w9vj",
           "label": "Reconstruction and Growth (1866 - 1916)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Reconstruction and Growth (1866 - 1916)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -34949,10 +34949,10 @@
         "p086kj9wb7t": {
           "id": "p086kj9wb7t",
           "label": "Weeden Island I",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Weeden Island I"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -34982,10 +34982,10 @@
           },
           "id": "p086kj9wbvt",
           "label": "19th Century (1800 - 1899)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "19th Century (1800 - 1899)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -35010,10 +35010,10 @@
         "p086kj9wghp": {
           "id": "p086kj9wghp",
           "label": "Historic-Unspecified",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Historic-Unspecified"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -35038,10 +35038,10 @@
         "p086kj9wk7w": {
           "id": "p086kj9wk7w",
           "label": "Havana/ Hopewell",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR106",
           "originalLabel": {
             "eng-latn": "Havana/ Hopewell"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR106",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -35066,10 +35066,10 @@
         "p086kj9wmf7": {
           "id": "p086kj9wmf7",
           "label": "Dutch",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Dutch"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -35094,10 +35094,10 @@
         "p086kj9wn5t": {
           "id": "p086kj9wn5t",
           "label": "Late Woodland, indet.",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Late Woodland, indet."
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -35122,10 +35122,10 @@
         "p086kj9wtwb": {
           "id": "p086kj9wtwb",
           "label": "Protohistoric, Undifferentiated",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Protohistoric, Undifferentiated"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -35155,10 +35155,10 @@
           },
           "id": "p086kj9wzb6",
           "label": "20th Century::2nd quarter (1925 - 1949)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "20th Century::2nd quarter (1925 - 1949)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -35188,10 +35188,10 @@
           },
           "id": "p086kj9x24q",
           "label": "17th Century::2nd/3rd quarter (1625 - 1674)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "17th Century::2nd/3rd quarter (1625 - 1674)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -35216,10 +35216,10 @@
         "p086kj9x4kn": {
           "id": "p086kj9x4kn",
           "label": "Early Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Early Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -35244,10 +35244,10 @@
         "p086kj9x64w": {
           "id": "p086kj9x64w",
           "label": "Middle Woodland, indet",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Middle Woodland, indet"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -35272,10 +35272,10 @@
         "p086kj9x8h6": {
           "id": "p086kj9x8h6",
           "label": "Historic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Historic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -35300,10 +35300,10 @@
         "p086kj9xc33": {
           "id": "p086kj9xc33",
           "label": "Middle Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Middle Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -35333,10 +35333,10 @@
           },
           "id": "p086kj9xd3c",
           "label": "20th Century::3rd quarter (1950 - 1974)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "20th Century::3rd quarter (1950 - 1974)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -35361,10 +35361,10 @@
         "p086kj9xfhn": {
           "id": "p086kj9xfhn",
           "label": "Red Ocher",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR39",
           "originalLabel": {
             "eng-latn": "Red Ocher"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR39",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -35389,10 +35389,10 @@
         "p086kj9xgsm": {
           "id": "p086kj9xgsm",
           "label": "Dalton",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA22",
           "originalLabel": {
             "eng-latn": "Dalton"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA22",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -35417,10 +35417,10 @@
         "p086kj9xj27": {
           "id": "p086kj9xj27",
           "label": "Pottawattamie",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR45",
           "originalLabel": {
             "eng-latn": "Pottawattamie"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR45",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -35445,10 +35445,10 @@
         "p086kj9xp73": {
           "id": "p086kj9xp73",
           "label": "Wahpkute band of the Santee Dakota Sioux",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR87",
           "originalLabel": {
             "eng-latn": "Wahpkute band of the Santee Dakota Sioux"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR87",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -35473,10 +35473,10 @@
         "p086kj9xr2z": {
           "id": "p086kj9xr2z",
           "label": "Historic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA31",
           "originalLabel": {
             "eng-latn": "Historic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA31",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -35501,10 +35501,10 @@
         "p086kj9xshm": {
           "id": "p086kj9xshm",
           "label": "Middle Paleoindian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Middle Paleoindian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -35529,10 +35529,10 @@
         "p086kj9xt78": {
           "id": "p086kj9xt78",
           "label": "Englewood",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Englewood"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -35557,10 +35557,10 @@
         "p086kj9xt8k": {
           "id": "p086kj9xt8k",
           "label": "Late Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "originalLabel": {
             "eng-latn": "Late Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/BZDUM226; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/EKDFFCRW; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/SDTCT3E6; http://zotero.org/groups/dinaa_resources/items/collectionKey/QUECFEQZ/itemKey/VGJV6NB3; ",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4896861",
@@ -35590,10 +35590,10 @@
           },
           "id": "p086kj9xtn8",
           "label": "First Spanish Period 1513-1599",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "First Spanish Period 1513-1599"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -35618,10 +35618,10 @@
         "p086kj9xzq4": {
           "id": "p086kj9xzq4",
           "label": "Early Gulf Formational",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Early Gulf Formational"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -35646,10 +35646,10 @@
         "p086kj9z468": {
           "id": "p086kj9z468",
           "label": "Webb and Funk Survey",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Webb and Funk Survey"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -35674,10 +35674,10 @@
         "p086kj9z47k": {
           "id": "p086kj9z47k",
           "label": "Indeterminate",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Indeterminate"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -35702,10 +35702,10 @@
         "p086kj9z4d8": {
           "id": "p086kj9z4d8",
           "label": "Mormon",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR44",
           "originalLabel": {
             "eng-latn": "Mormon"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR44",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -35730,10 +35730,10 @@
         "p086kj9z527": {
           "id": "p086kj9z527",
           "label": "St. Johns IIa",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "St. Johns IIa"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -35758,10 +35758,10 @@
         "p086kj9z557": {
           "id": "p086kj9z557",
           "label": "Dalton",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR23",
           "originalLabel": {
             "eng-latn": "Dalton"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR23",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -35786,10 +35786,10 @@
         "p086kj9z66t": {
           "id": "p086kj9z66t",
           "label": "19th urban",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR117",
           "originalLabel": {
             "eng-latn": "19th urban"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR117",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -35814,10 +35814,10 @@
         "p086kj9z6ph": {
           "id": "p086kj9z6ph",
           "label": "Prehistoric and Historic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Prehistoric and Historic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -35842,10 +35842,10 @@
         "p086kj9z854": {
           "id": "p086kj9z854",
           "label": "High Rim Horizon",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR96",
           "originalLabel": {
             "eng-latn": "High Rim Horizon"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR96",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -35870,10 +35870,10 @@
         "p086kj9z8c4": {
           "id": "p086kj9z8c4",
           "label": "Middle-Late Archaic, indet.",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Middle-Late Archaic, indet."
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -35898,10 +35898,10 @@
         "p086kj9zb5p": {
           "id": "p086kj9zb5p",
           "label": "post 1937",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR123",
           "originalLabel": {
             "eng-latn": "post 1937"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR123",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -35926,10 +35926,10 @@
         "p086kj9zbh2": {
           "id": "p086kj9zbh2",
           "label": "or Turin",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR98",
           "originalLabel": {
             "eng-latn": "or Turin"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR98",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -35954,10 +35954,10 @@
         "p086kj9zd59": {
           "id": "p086kj9zd59",
           "label": "Cahokia",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR113",
           "originalLabel": {
             "eng-latn": "Cahokia"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR113",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4862182",
@@ -35982,10 +35982,10 @@
         "p086kj9zdk9": {
           "id": "p086kj9zdk9",
           "label": "Italian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Italian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -36010,10 +36010,10 @@
         "p086kj9zgh7": {
           "id": "p086kj9zgh7",
           "label": "Historic Euro-american",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Historic Euro-american"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -36038,10 +36038,10 @@
         "p086kj9zj3s": {
           "id": "p086kj9zj3s",
           "label": "Unknown Prehistoric",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "Unknown Prehistoric"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4597040",
@@ -36066,10 +36066,10 @@
         "p086kj9zjcg": {
           "id": "p086kj9zjcg",
           "label": "Glades Ia",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Glades Ia"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -36094,10 +36094,10 @@
         "p086kj9zm53": {
           "id": "p086kj9zm53",
           "label": "Kirk-Palmer",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Kirk-Palmer"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -36122,10 +36122,10 @@
         "p086kj9zn6p": {
           "id": "p086kj9zn6p",
           "label": "Weeden Island 1",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Weeden Island 1"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -36150,10 +36150,10 @@
         "p086kj9zpqz": {
           "id": "p086kj9zpqz",
           "label": "Late Archaic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Late Archaic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -36178,10 +36178,10 @@
         "p086kj9zqnm": {
           "id": "p086kj9zqnm",
           "label": "Proto-Historic",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA10",
           "originalLabel": {
             "eng-latn": "Proto-Historic"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA10",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -36206,10 +36206,10 @@
         "p086kj9zs5j": {
           "id": "p086kj9zs5j",
           "label": "Late Prehistoric, indet.",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "originalLabel": {
             "eng-latn": "Late Prehistoric, indet."
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/ZESDFR8Z",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254925",
@@ -36239,10 +36239,10 @@
           },
           "id": "p086kj9zswj",
           "label": "19th Century::2nd quarter (1825 - 1849)",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "originalLabel": {
             "eng-latn": "19th Century::2nd quarter (1825 - 1849)"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/6254928",
@@ -36267,10 +36267,10 @@
         "p086kj9ztd6": {
           "id": "p086kj9ztd6",
           "label": "Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "originalLabel": {
             "eng-latn": "Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4155751",
@@ -36295,10 +36295,10 @@
         "p086kj9ztfh": {
           "id": "p086kj9ztfh",
           "label": "Early Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA26",
           "originalLabel": {
             "eng-latn": "Early Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA26",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4398678",
@@ -36323,10 +36323,10 @@
         "p086kj9zxq3": {
           "id": "p086kj9zxq3",
           "label": "Early Mississippian",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "originalLabel": {
             "eng-latn": "Early Mississippian"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/JZ893GWN",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4829764",
@@ -36351,10 +36351,10 @@
         "p086kj9zzfp": {
           "id": "p086kj9zzfp",
           "label": "Middle Woodland",
+          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "originalLabel": {
             "eng-latn": "Middle Woodland"
           },
-          "note": "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/TME669FT",
           "spatialCoverage": [
             {
               "id": "http://www.geonames.org/4921868",
@@ -36418,10 +36418,10 @@
         "p08h8hs24xm": {
           "id": "p08h8hs24xm",
           "label": "Final Neolithic",
+          "note": "Applies to \"Mainland Greece in general\", including Thessaly and the Peloponnese.",
           "originalLabel": {
             "eng-latn": "Final Neolithic"
           },
-          "note": "Applies to \"Mainland Greece in general\", including Thessaly and the Peloponnese.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Greece",
@@ -36445,10 +36445,10 @@
         "p08h8hsj4h8": {
           "id": "p08h8hsj4h8",
           "label": "Late Neolithic",
+          "note": "Applies to \"Mainland Greece in general\", including Thessaly and the Peloponnese.",
           "originalLabel": {
             "eng-latn": "Late Neolithic"
           },
-          "note": "Applies to \"Mainland Greece in general\", including Thessaly and the Peloponnese.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Greece",
@@ -36472,10 +36472,10 @@
         "p08h8hstvzv": {
           "id": "p08h8hstvzv",
           "label": "Middle Neolithic",
+          "note": "Applies to \"Mainland Greece in general\", including Thessaly and the Peloponnese.",
           "originalLabel": {
             "eng-latn": "Middle Neolithic"
           },
-          "note": "Applies to \"Mainland Greece in general\", including Thessaly and the Peloponnese.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Greece",
@@ -38257,10 +38257,10 @@
         "p0bsjms2dzb": {
           "id": "p0bsjms2dzb",
           "label": "Republican",
+          "note": "Beginning-date corresponds with the end of the Celtiberian wars; outside of the Celtiberian homeland, the Republican period in Spain begins 218 B.C. (Second Punic War).",
           "originalLabel": {
             "eng-latn": "Republican"
           },
-          "note": "Beginning-date corresponds with the end of the Celtiberian wars; outside of the Celtiberian homeland, the Republican period in Spain begins 218 B.C. (Second Punic War).",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Spain",
@@ -39365,10 +39365,10 @@
           },
           "id": "p0cmdf94cnf",
           "label": "Late Lydian",
+          "note": "From chronology chart on p. 12; = Achaemenid period",
           "originalLabel": {
             "eng-latn": "Late Lydian"
           },
-          "note": "From chronology chart on p. 12; = Achaemenid period",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Turkey",
@@ -39398,10 +39398,10 @@
           },
           "id": "p0cmdf9kmfv",
           "label": "Middle Lydian",
+          "note": "R's Middle Lydian period is coterminous with the Mermnad dynasty: chronological chart on p. 12",
           "originalLabel": {
             "eng-latn": "Middle Lydian"
           },
-          "note": "R's Middle Lydian period is coterminous with the Mermnad dynasty: chronological chart on p. 12",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Turkey",
@@ -39431,10 +39431,10 @@
           },
           "id": "p0cmdf9ntkh",
           "label": "Early Lydian",
+          "note": "From chronological table on p. 12; = Lydian \"Early Iron Age\"",
           "originalLabel": {
             "eng-latn": "Early Lydian"
           },
-          "note": "From chronological table on p. 12; = Lydian \"Early Iron Age\"",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Turkey",
@@ -39758,10 +39758,10 @@
           "editorialNote": "unsure why GeoDia dates are 2130-2055 B.C.",
           "id": "p0cp447jts9",
           "label": "First Intermediate Period",
+          "note": "Robins' chronology is being used in preference to Freeman's, since it seems to represent the general textbook situation more accurately.",
           "originalLabel": {
             "eng-latn": "First Intermediate Period"
           },
-          "note": "Robins' chronology is being used in preference to Freeman's, since it seems to represent the general textbook situation more accurately.",
           "source": {
             "locator": "page 8",
             "partOf": "http://www.worldcat.org/oclc/45184072"
@@ -40248,10 +40248,10 @@
         "p0dfzs7sjcq": {
           "id": "p0dfzs7sjcq",
           "label": "Lerna III",
+          "note": "Applies to Lerna; equivalent to Lerna III. CC307C, Spring 2011, group 1: Jelyne Jesusa and Kevin Sartin.",
           "originalLabel": {
             "eng-latn": "Lerna III"
           },
-          "note": "Applies to Lerna; equivalent to Lerna III. CC307C, Spring 2011, group 1: Jelyne Jesusa and Kevin Sartin.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Greece",
@@ -40299,10 +40299,10 @@
         "p0dhmkc4kxb": {
           "id": "p0dhmkc4kxb",
           "label": "Herakleid",
+          "note": "chronological table on p. 4",
           "originalLabel": {
             "eng-latn": "Herakleid"
           },
-          "note": "chronological table on p. 4",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Turkey",
@@ -40326,10 +40326,10 @@
         "p0dhmkc7dmm": {
           "id": "p0dhmkc7dmm",
           "label": "Archaic",
+          "note": "chronological table on p. 4; not dividing the archaic period by dynasties (all Mermnad, not usually used to refer to material) or using \"Orientalizing\" (since Lydia the source of much of what is called \"Orientalizing\" in Greece)",
           "originalLabel": {
             "eng-latn": "Archaic"
           },
-          "note": "chronological table on p. 4; not dividing the archaic period by dynasties (all Mermnad, not usually used to refer to material) or using \"Orientalizing\" (since Lydia the source of much of what is called \"Orientalizing\" in Greece)",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Turkey",
@@ -40388,10 +40388,10 @@
           },
           "id": "p0dntkb67vz",
           "label": "Fase III",
+          "note": "This period only applies to the indigenous necropolis of Monte Casasia in Sicily. The end date is provided by the assumption that the site was destroyed by the Carthaginians in 405 B.C.",
           "originalLabel": {
             "ita-latn": "Fase III"
           },
-          "note": "This period only applies to the indigenous necropolis of Monte Casasia in Sicily. The end date is provided by the assumption that the site was destroyed by the Carthaginians in 405 B.C.",
           "source": {
             "locator": "page 555",
             "partOf": "http://www.worldcat.org/oclc/758533779"
@@ -40424,10 +40424,10 @@
           },
           "id": "p0dntkbc6tn",
           "label": "Fase II",
+          "note": "This period only applies to the indigenous necropolis of Monte Casasia in Sicily.",
           "originalLabel": {
             "ita-latn": "Fase II"
           },
-          "note": "This period only applies to the indigenous necropolis of Monte Casasia in Sicily.",
           "source": {
             "locator": "page 555",
             "partOf": "http://www.worldcat.org/oclc/758533779"
@@ -40462,10 +40462,10 @@
           },
           "id": "p0dntkbcv4m",
           "label": "Fase I",
+          "note": "This periodization only applies to the indigenous necropolis at Monte Casasia in Sicily.",
           "originalLabel": {
             "ita-latn": "Fase I"
           },
-          "note": "This periodization only applies to the indigenous necropolis at Monte Casasia in Sicily.",
           "source": {
             "locator": "page 554",
             "partOf": "http://www.worldcat.org/oclc/758533779"
@@ -41819,10 +41819,10 @@
         "p0gjgrs45g4": {
           "id": "p0gjgrs45g4",
           "label": "Mesolithic",
+          "note": "Can be split into Early and Late.",
           "originalLabel": {
             "eng-latn": "Mesolithic"
           },
-          "note": "Can be split into Early and Late.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
@@ -41901,10 +41901,10 @@
         "p0gjgrs69ws": {
           "id": "p0gjgrs69ws",
           "label": "Roman",
+          "note": "Can be split into Early and Late.",
           "originalLabel": {
             "eng-latn": "Roman"
           },
-          "note": "Can be split into Early and Late.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
@@ -41956,10 +41956,10 @@
         "p0gjgrs6sgx": {
           "id": "p0gjgrs6sgx",
           "label": "Post-Medieval",
+          "note": "Early post-medieval is generally used for the 16th century and sometimes for the 17th century. The term 'middle post-medieval' is not used, and there is debate as to what constitutes the late post-medieval period. For the 18th century, it is best to stick simply to 'post-medieval' and qualify it using calendar dates.",
           "originalLabel": {
             "eng-latn": "Post-Medieval"
           },
-          "note": "Early post-medieval is generally used for the 16th century and sometimes for the 17th century. The term 'middle post-medieval' is not used, and there is debate as to what constitutes the late post-medieval period. For the 18th century, it is best to stick simply to 'post-medieval' and qualify it using calendar dates.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
@@ -41984,10 +41984,10 @@
         "p0gjgrs6zcf": {
           "id": "p0gjgrs6zcf",
           "label": "Palaeolithic",
+          "note": "Generally split into Lower, Middle and Upper, which we will translate into Early, Middle and Late.",
           "originalLabel": {
             "eng-latn": "Palaeolithic"
           },
-          "note": "Generally split into Lower, Middle and Upper, which we will translate into Early, Middle and Late.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
@@ -42228,10 +42228,10 @@
         "p0gjgrsg24g": {
           "id": "p0gjgrsg24g",
           "label": "Byzantine",
+          "note": "This period does not appear in the EH timeline. When this broad period is used, the database will automatically map it onto either Iron Age (for the earlier coins) or Roman (for the later coins) depending on the precise years entered.",
           "originalLabel": {
             "eng-latn": "Byzantine"
           },
-          "note": "This period does not appear in the EH timeline. When this broad period is used, the database will automatically map it onto either Iron Age (for the earlier coins) or Roman (for the later coins) depending on the precise years entered.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
@@ -42283,10 +42283,10 @@
         "p0gjgrshhcw": {
           "id": "p0gjgrshhcw",
           "label": "Early Medieval",
+          "note": "This period is diverse and must be qualified wherever possible with Early, Middle or Late. The currently accepted chronology (spring 2013) is given below, but this is likely to change in the near future. English Heritage do not specify the boundaries of these sub-periods.",
           "originalLabel": {
             "eng-latn": "Early Medieval"
           },
-          "note": "This period is diverse and must be qualified wherever possible with Early, Middle or Late. The currently accepted chronology (spring 2013) is given below, but this is likely to change in the near future. English Heritage do not specify the boundaries of these sub-periods.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
@@ -42311,10 +42311,10 @@
         "p0gjgrsmhnc": {
           "id": "p0gjgrsmhnc",
           "label": "Greek and Roman Provincial",
+          "note": "This period does not appear in the EH timeline. When this broad period is used, the database will automatically map it onto either Iron Age (for the earlier coins) or Roman (for the later coins) depending on the precise years entered.",
           "originalLabel": {
             "eng-latn": "Greek and Roman Provincial"
           },
-          "note": "This period does not appear in the EH timeline. When this broad period is used, the database will automatically map it onto either Iron Age (for the earlier coins) or Roman (for the later coins) depending on the precise years entered.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
@@ -42594,10 +42594,10 @@
         "p0gjgrsxwzx": {
           "id": "p0gjgrsxwzx",
           "label": "Medieval",
+          "note": "English Heritage do not specify the boundaries of any sub-periods within the Medieval period.",
           "originalLabel": {
             "eng-latn": "Medieval"
           },
-          "note": "English Heritage do not specify the boundaries of any sub-periods within the Medieval period.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
@@ -42702,10 +42702,10 @@
         "p0hvcwrjpsf": {
           "id": "p0hvcwrjpsf",
           "label": "Early Iron Age",
+          "note": "Contemporary with Hallstatt B-D (S. Germany). Overlaps LBA III/ Tartessian period, 750-600 B.C. (- cf. M. Diaz-Andreu & S. Keay, 1997. The Archaeology of Iberia.); includes Iberian I (600-500 B.C.) and II (500-450 B.C.) (ibid.). See also T. Chapa & M. Belen, 1997. La Edad del Hierro.",
           "originalLabel": {
             "eng-latn": "Early Iron Age"
           },
-          "note": "Contemporary with Hallstatt B-D (S. Germany). Overlaps LBA III/ Tartessian period, 750-600 B.C. (- cf. M. Diaz-Andreu & S. Keay, 1997. The Archaeology of Iberia.); includes Iberian I (600-500 B.C.) and II (500-450 B.C.) (ibid.). See also T. Chapa & M. Belen, 1997. La Edad del Hierro.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Spain",
@@ -42827,10 +42827,10 @@
           "editorialNote": "Removed due to inferences in GeoDia: al-'Ubaid (5500-4000 B.C.), Uruk (4000-3250 B.C.), Jamdat Nasr periods (3250-3000 B.C.), and Ur of the Chaldees (1150-800 B.C.). Note this quote p.15: \"At an archaeological congress of excavators held at Baghdad in 1929 it was agreed that the early stages of human settlement in south Mesopotamia could be classified n successive phases which should be called, after the places where the evidence for each was first discovered, the al-'Ubaid period, the Uruk period, the Jamdat Nasr period, and then the Early Dynastic period, towards the end of which (in IIIb) comes the First Dynasty of Ur.\" p.16: \"Archaeological excavation ... does not of itself offer an absolute chronology in years B.C./A.D.\"",
           "id": "p0j5frxvrwg",
           "label": "Early Dynastic period",
+          "note": "These are approximate dates.",
           "originalLabel": {
             "eng-latn": "Early Dynastic period"
           },
-          "note": "These are approximate dates.",
           "source": {
             "locator": "pages 15-16",
             "partOf": "http://www.worldcat.org/oclc/8800122"
@@ -42858,10 +42858,10 @@
           "editorialNote": "unsure why GeoDia dates are 2130-2055 B.C.",
           "id": "p0j5frxvzk8",
           "label": "Isin-Larsa",
+          "note": "Robins' chronology is being used in preference to Freeman's, since it seems to represent the general textbook situation more accurately.",
           "originalLabel": {
             "eng-latn": "Isin-Larsa"
           },
-          "note": "Robins' chronology is being used in preference to Freeman's, since it seems to represent the general textbook situation more accurately.",
           "source": {
             "locator": "page 180",
             "partOf": "http://www.worldcat.org/oclc/8800122"
@@ -44503,10 +44503,10 @@
         "p0kh9ds2pnp": {
           "id": "p0kh9ds2pnp",
           "label": "Late 20th Century",
+          "note": "The final third of the 20th century.",
           "originalLabel": {
             "eng-latn": "Late 20th Century"
           },
-          "note": "The final third of the 20th century.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/L20",
           "spatialCoverage": [
             {
@@ -44532,10 +44532,10 @@
         "p0kh9ds3566": {
           "id": "p0kh9ds3566",
           "label": "First World War",
+          "note": "Used to record buildings, defensive monuments and sites dating to, and associated with, the First World War. For other types of building, such as houses, built during this period use EARLY 20TH CENTURY.",
           "originalLabel": {
             "eng-latn": "First World War"
           },
-          "note": "Used to record buildings, defensive monuments and sites dating to, and associated with, the First World War. For other types of building, such as houses, built during this period use EARLY 20TH CENTURY.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/WW1",
           "spatialCoverage": [
             {
@@ -44561,10 +44561,10 @@
         "p0kh9ds3whd": {
           "id": "p0kh9ds3whd",
           "label": "Jacobean",
+          "note": "Dating to the reign of James I of England (VI of Scotland)",
           "originalLabel": {
             "eng-latn": "Jacobean"
           },
-          "note": "Dating to the reign of James I of England (VI of Scotland)",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/JAC",
           "spatialCoverage": [
             {
@@ -44590,10 +44590,10 @@
         "p0kh9ds4hjq": {
           "id": "p0kh9ds4hjq",
           "label": "Late Neolithic",
+          "note": "The third and latest subdivision of the Neolithic, or New Stone Age.",
           "originalLabel": {
             "eng-latn": "Late Neolithic"
           },
-          "note": "The third and latest subdivision of the Neolithic, or New Stone Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/LNE",
           "spatialCoverage": [
             {
@@ -44619,10 +44619,10 @@
         "p0kh9ds5x8v": {
           "id": "p0kh9ds5x8v",
           "label": "Second World War",
+          "note": "Used to record buildings, defensive monuments and sites dating to, and associated with, the Second World War. For other types of building, such as houses, built during this period use MID 20TH CENTURY.",
           "originalLabel": {
             "eng-latn": "Second World War"
           },
-          "note": "Used to record buildings, defensive monuments and sites dating to, and associated with, the Second World War. For other types of building, such as houses, built during this period use MID 20TH CENTURY.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/WW2",
           "spatialCoverage": [
             {
@@ -44648,10 +44648,10 @@
         "p0kh9ds6f4n": {
           "id": "p0kh9ds6f4n",
           "label": "Stuart",
+          "note": "Dating to the reign of the Stuart kings of England (including the Commonwealth inter-regnum)",
           "originalLabel": {
             "eng-latn": "Stuart"
           },
-          "note": "Dating to the reign of the Stuart kings of England (including the Commonwealth inter-regnum)",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/STU",
           "spatialCoverage": [
             {
@@ -44677,10 +44677,10 @@
         "p0kh9ds6t9k": {
           "id": "p0kh9ds6t9k",
           "label": "Early Mesolithic",
+          "note": "The earliest subdivision of the Mesolithic, or Middle Stone Age.",
           "originalLabel": {
             "eng-latn": "Early Mesolithic"
           },
-          "note": "The earliest subdivision of the Mesolithic, or Middle Stone Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/EME",
           "spatialCoverage": [
             {
@@ -44706,10 +44706,10 @@
         "p0kh9ds785r": {
           "id": "p0kh9ds785r",
           "label": "Later Prehistoric",
+          "note": "For monuments that can be identifed only to a date range from Neolithic to Iron Age.",
           "originalLabel": {
             "eng-latn": "Later Prehistoric"
           },
-          "note": "For monuments that can be identifed only to a date range from Neolithic to Iron Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/LPR",
           "spatialCoverage": [
             {
@@ -44735,10 +44735,10 @@
         "p0kh9ds7jvs": {
           "id": "p0kh9ds7jvs",
           "label": "Tudor",
+          "note": "Dating to the reign of the Tudor monarchs",
           "originalLabel": {
             "eng-latn": "Tudor"
           },
-          "note": "Dating to the reign of the Tudor monarchs",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/TUD",
           "spatialCoverage": [
             {
@@ -44764,10 +44764,10 @@
         "p0kh9ds7q8m": {
           "id": "p0kh9ds7q8m",
           "label": "Bronze Age",
+          "note": "This period follows on from the Neolithic and is characterized by the increasing use of Bronzework. It is subdivided in the Early,Middle and Late Bronze Age.",
           "originalLabel": {
             "eng-latn": "Bronze Age"
           },
-          "note": "This period follows on from the Neolithic and is characterized by the increasing use of Bronzework. It is subdivided in the Early,Middle and Late Bronze Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/BA",
           "spatialCoverage": [
             {
@@ -44793,10 +44793,10 @@
         "p0kh9ds8p8k": {
           "id": "p0kh9ds8p8k",
           "label": "Late Iron Age",
+          "note": "The third and latest subdivision of the Iron Age.",
           "originalLabel": {
             "eng-latn": "Late Iron Age"
           },
-          "note": "The third and latest subdivision of the Iron Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/LIA",
           "spatialCoverage": [
             {
@@ -44822,10 +44822,10 @@
         "p0kh9ds9nsj": {
           "id": "p0kh9ds9nsj",
           "label": "Roman",
+          "note": "Traditionally begins with the Roman invasion in 43AD and ends with the emperor Honorius directing Britain to see to its own defence in 410AD.",
           "originalLabel": {
             "eng-latn": "Roman"
           },
-          "note": "Traditionally begins with the Roman invasion in 43AD and ends with the emperor Honorius directing Britain to see to its own defence in 410AD.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/RO",
           "spatialCoverage": [
             {
@@ -44851,10 +44851,10 @@
         "p0kh9dsbd33": {
           "id": "p0kh9dsbd33",
           "label": "Cold War",
+          "note": "The period of political and military opposition betwen the major Superpowers (USA and USSR) and their allies. Known as the Cold War as there were no direct military conflicts between the two main protagonists.",
           "originalLabel": {
             "eng-latn": "Cold War"
           },
-          "note": "The period of political and military opposition betwen the major Superpowers (USA and USSR) and their allies. Known as the Cold War as there were no direct military conflicts between the two main protagonists.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/WW3",
           "spatialCoverage": [
             {
@@ -44880,10 +44880,10 @@
         "p0kh9dsbm2h": {
           "id": "p0kh9dsbm2h",
           "label": "Middle Neolithic",
+          "note": "The second subdivision of the Neolithic, or New Stone Age.",
           "originalLabel": {
             "eng-latn": "Middle Neolithic"
           },
-          "note": "The second subdivision of the Neolithic, or New Stone Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/MNE",
           "spatialCoverage": [
             {
@@ -44909,10 +44909,10 @@
         "p0kh9dsbnzg": {
           "id": "p0kh9dsbnzg",
           "label": "Early Neolithic",
+          "note": "The earliest subdivision of the Neolithic, or New Stone Age.",
           "originalLabel": {
             "eng-latn": "Early Neolithic"
           },
-          "note": "The earliest subdivision of the Neolithic, or New Stone Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/ENE",
           "spatialCoverage": [
             {
@@ -44938,10 +44938,10 @@
         "p0kh9dsbz2g": {
           "id": "p0kh9dsbz2g",
           "label": "Neolithic",
+          "note": "The New Stone Age, this period follows on from the Palaeolithic and the Mesolithc and is itself suceeded by the Bronze Age. This period is characterized by the practice of a farming ecomony and extensive monumental constructions.",
           "originalLabel": {
             "eng-latn": "Neolithic"
           },
-          "note": "The New Stone Age, this period follows on from the Palaeolithic and the Mesolithc and is itself suceeded by the Bronze Age. This period is characterized by the practice of a farming ecomony and extensive monumental constructions.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/NE",
           "spatialCoverage": [
             {
@@ -44967,10 +44967,10 @@
         "p0kh9dscbkd": {
           "id": "p0kh9dscbkd",
           "label": "Medieval",
+          "note": "The Medieval period or Middle Ages begins with the Norman invasion and ends with the dissolution of the monasteries.",
           "originalLabel": {
             "eng-latn": "Medieval"
           },
-          "note": "The Medieval period or Middle Ages begins with the Norman invasion and ends with the dissolution of the monasteries.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/MD",
           "spatialCoverage": [
             {
@@ -44996,10 +44996,10 @@
         "p0kh9dscmjf": {
           "id": "p0kh9dscmjf",
           "label": "Late Mesolithic",
+          "note": "The latest subdivision of the Mesolithic, or Middle Stone Age.",
           "originalLabel": {
             "eng-latn": "Late Mesolithic"
           },
-          "note": "The latest subdivision of the Mesolithic, or Middle Stone Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/LME",
           "spatialCoverage": [
             {
@@ -45025,10 +45025,10 @@
         "p0kh9dsctsj": {
           "id": "p0kh9dsctsj",
           "label": "Post Medieval",
+          "note": "Begins with the dissolution of the monasteries and ends with the death of Queen Victoria. Use more specific period where known.",
           "originalLabel": {
             "eng-latn": "Post Medieval"
           },
-          "note": "Begins with the dissolution of the monasteries and ends with the death of Queen Victoria. Use more specific period where known.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/PM",
           "spatialCoverage": [
             {
@@ -45054,10 +45054,10 @@
         "p0kh9dsdf5j": {
           "id": "p0kh9dsdf5j",
           "label": "Early Prehistoric",
+          "note": "For monuments which are characteristic of the Paleolithic to Mesolithic but cannot be specifically assigned.",
           "originalLabel": {
             "eng-latn": "Early Prehistoric"
           },
-          "note": "For monuments which are characteristic of the Paleolithic to Mesolithic but cannot be specifically assigned.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/EPR",
           "spatialCoverage": [
             {
@@ -45083,10 +45083,10 @@
         "p0kh9dshs59": {
           "id": "p0kh9dshs59",
           "label": "Early Bronze Age",
+          "note": "The earliest subdivision of the Bronze Age.",
           "originalLabel": {
             "eng-latn": "Early Bronze Age"
           },
-          "note": "The earliest subdivision of the Bronze Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/EBA",
           "spatialCoverage": [
             {
@@ -45112,10 +45112,10 @@
         "p0kh9dsj33x": {
           "id": "p0kh9dsj33x",
           "label": "Iron Age",
+          "note": "This period follows on from the Bronze Age and is characterized by the use of iron for making tools and monuments such as hillforts and oppida. The Iron Age is taken to end with the Roman invasion.",
           "originalLabel": {
             "eng-latn": "Iron Age"
           },
-          "note": "This period follows on from the Bronze Age and is characterized by the use of iron for making tools and monuments such as hillforts and oppida. The Iron Age is taken to end with the Roman invasion.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/IA",
           "spatialCoverage": [
             {
@@ -45141,10 +45141,10 @@
         "p0kh9dsk4zt": {
           "id": "p0kh9dsk4zt",
           "label": "Mid 20th Century",
+          "note": "The mid third of the 20th Century",
           "originalLabel": {
             "eng-latn": "Mid 20th Century"
           },
-          "note": "The mid third of the 20th Century",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/M20",
           "spatialCoverage": [
             {
@@ -45170,10 +45170,10 @@
         "p0kh9dskb4m": {
           "id": "p0kh9dskb4m",
           "label": "Mesolithic",
+          "note": "The Middle Stone Age, falling between the Palaeolithic and the Neolithic; marks the beginning of a move from a hunter gatherer society towards food producing society.",
           "originalLabel": {
             "eng-latn": "Mesolithic"
           },
-          "note": "The Middle Stone Age, falling between the Palaeolithic and the Neolithic; marks the beginning of a move from a hunter gatherer society towards food producing society.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/ME",
           "spatialCoverage": [
             {
@@ -45199,10 +45199,10 @@
         "p0kh9dsmf3f": {
           "id": "p0kh9dsmf3f",
           "label": "Early Medieval",
+          "note": "This dates from the breakdown of Roman rule in Britain to the Norman invasion in 1066 and is to be used for monuments of post Roman, Saxon and Viking date.",
           "originalLabel": {
             "eng-latn": "Early Medieval"
           },
-          "note": "This dates from the breakdown of Roman rule in Britain to the Norman invasion in 1066 and is to be used for monuments of post Roman, Saxon and Viking date.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/EM",
           "spatialCoverage": [
             {
@@ -45228,10 +45228,10 @@
         "p0kh9dsnrhc": {
           "id": "p0kh9dsnrhc",
           "label": "Middle Palaeolithic",
+          "note": "The second subdivision of the Paleolithic or Old Stone Age. Characterized by the fine flake tools of the Mousterian tradition and economically by a hunter gatherer society.",
           "originalLabel": {
             "eng-latn": "Middle Palaeolithic"
           },
-          "note": "The second subdivision of the Paleolithic or Old Stone Age. Characterized by the fine flake tools of the Mousterian tradition and economically by a hunter gatherer society.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/MPA",
           "spatialCoverage": [
             {
@@ -45257,10 +45257,10 @@
         "p0kh9dsqfgv": {
           "id": "p0kh9dsqfgv",
           "label": "Palaeolithic",
+          "note": "The Old Stone Age defined by the practice of hunting and gathering and the use of chipped flint tools. This period is usually divided up into the Lower, Middle and Upper Palaeolithic.",
           "originalLabel": {
             "eng-latn": "Palaeolithic"
           },
-          "note": "The Old Stone Age defined by the practice of hunting and gathering and the use of chipped flint tools. This period is usually divided up into the Lower, Middle and Upper Palaeolithic.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/PA",
           "spatialCoverage": [
             {
@@ -45286,10 +45286,10 @@
         "p0kh9dsqkbq": {
           "id": "p0kh9dsqkbq",
           "label": "Late Bronze Age",
+          "note": "The third and latest subdivision of the Bronze Age.",
           "originalLabel": {
             "eng-latn": "Late Bronze Age"
           },
-          "note": "The third and latest subdivision of the Bronze Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/LBA",
           "spatialCoverage": [
             {
@@ -45315,10 +45315,10 @@
         "p0kh9dsqpzm": {
           "id": "p0kh9dsqpzm",
           "label": "Middle Bronze Age",
+          "note": "The second subdivision of the Bronze Age.",
           "originalLabel": {
             "eng-latn": "Middle Bronze Age"
           },
-          "note": "The second subdivision of the Bronze Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/MBA",
           "spatialCoverage": [
             {
@@ -45344,10 +45344,10 @@
         "p0kh9dsqx6c": {
           "id": "p0kh9dsqx6c",
           "label": "Middle Iron Age",
+          "note": "The second subdivision of the Iron Age.",
           "originalLabel": {
             "eng-latn": "Middle Iron Age"
           },
-          "note": "The second subdivision of the Iron Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/MIA",
           "spatialCoverage": [
             {
@@ -45373,10 +45373,10 @@
         "p0kh9dst3vc": {
           "id": "p0kh9dst3vc",
           "label": "Georgian",
+          "note": "Dating to or characteristic of the reigns of any of the first four kings of Great Britain called George",
           "originalLabel": {
             "eng-latn": "Georgian"
           },
-          "note": "Dating to or characteristic of the reigns of any of the first four kings of Great Britain called George",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/GEO",
           "spatialCoverage": [
             {
@@ -45402,10 +45402,10 @@
         "p0kh9dst7t7": {
           "id": "p0kh9dst7t7",
           "label": "Prehistoric",
+          "note": "For monuments that can be identifed only to a date range from Palaeolithic to Iron Age.",
           "originalLabel": {
             "eng-latn": "Prehistoric"
           },
-          "note": "For monuments that can be identifed only to a date range from Palaeolithic to Iron Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/PR",
           "spatialCoverage": [
             {
@@ -45431,10 +45431,10 @@
         "p0kh9dstffb": {
           "id": "p0kh9dstffb",
           "label": "Early 20th Century",
+          "note": "The first third of the 20th century.",
           "originalLabel": {
             "eng-latn": "Early 20th Century"
           },
-          "note": "The first third of the 20th century.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/E20",
           "spatialCoverage": [
             {
@@ -45460,10 +45460,10 @@
         "p0kh9dstg2x": {
           "id": "p0kh9dstg2x",
           "label": "20th Century",
+          "note": "Previously recorded as 'Modern'",
           "originalLabel": {
             "eng-latn": "20th Century"
           },
-          "note": "Previously recorded as 'Modern'",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/C20",
           "spatialCoverage": [
             {
@@ -45489,10 +45489,10 @@
         "p0kh9dstmtg": {
           "id": "p0kh9dstmtg",
           "label": "Lower Palaeolithic",
+          "note": "The earliest subdivision of the Palaeolithic, or Old Stone Age; when the earliest use of flint tools appears in the current archaeological record. A hunter gatherer society is a defining characteristic.",
           "originalLabel": {
             "eng-latn": "Lower Palaeolithic"
           },
-          "note": "The earliest subdivision of the Palaeolithic, or Old Stone Age; when the earliest use of flint tools appears in the current archaeological record. A hunter gatherer society is a defining characteristic.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/LPA",
           "spatialCoverage": [
             {
@@ -45518,10 +45518,10 @@
         "p0kh9dstr3n": {
           "id": "p0kh9dstr3n",
           "label": "Elizabethan",
+          "note": "Dating to the reign of Elizabeth 1st of England.",
           "originalLabel": {
             "eng-latn": "Elizabethan"
           },
-          "note": "Dating to the reign of Elizabeth 1st of England.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/LIZ",
           "spatialCoverage": [
             {
@@ -45547,10 +45547,10 @@
         "p0kh9dsts5m": {
           "id": "p0kh9dsts5m",
           "label": "Upper Palaeolithic",
+          "note": "The third and last subdivision of the Paleolithic or Old Stone Age; characterized by the development of projectile points made from bony materials and the development of fine blade flint tools.",
           "originalLabel": {
             "eng-latn": "Upper Palaeolithic"
           },
-          "note": "The third and last subdivision of the Paleolithic or Old Stone Age; characterized by the development of projectile points made from bony materials and the development of fine blade flint tools.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/UPA",
           "spatialCoverage": [
             {
@@ -45576,10 +45576,10 @@
         "p0kh9dsvcdn": {
           "id": "p0kh9dsvcdn",
           "label": "Hanoverian",
+          "note": "Dating to the reign of the Hanoverian kings.",
           "originalLabel": {
             "eng-latn": "Hanoverian"
           },
-          "note": "Dating to the reign of the Hanoverian kings.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/HAN",
           "spatialCoverage": [
             {
@@ -45605,10 +45605,10 @@
         "p0kh9dsw3zv": {
           "id": "p0kh9dsw3zv",
           "label": "Edwardian",
+          "note": "The period covering the reign of Edward VII. Do not use for the reigns of Edwards I-VI.",
           "originalLabel": {
             "eng-latn": "Edwardian"
           },
-          "note": "The period covering the reign of Edward VII. Do not use for the reigns of Edwards I-VI.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/EDW",
           "spatialCoverage": [
             {
@@ -45634,10 +45634,10 @@
         "p0kh9dsxp46": {
           "id": "p0kh9dsxp46",
           "label": "Victorian",
+          "note": "Dating to the reign of Queen Victoria",
           "originalLabel": {
             "eng-latn": "Victorian"
           },
-          "note": "Dating to the reign of Queen Victoria",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/VIC",
           "spatialCoverage": [
             {
@@ -45663,10 +45663,10 @@
         "p0kh9dszj78": {
           "id": "p0kh9dszj78",
           "label": "21st Century",
+          "note": "Twenty first century phases and events.",
           "originalLabel": {
             "eng-latn": "21st Century"
           },
-          "note": "Twenty first century phases and events.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/C21",
           "spatialCoverage": [
             {
@@ -45692,10 +45692,10 @@
         "p0kh9dszskn": {
           "id": "p0kh9dszskn",
           "label": "Early Iron Age",
+          "note": "The earliest subdivision of the Iron Age.",
           "originalLabel": {
             "eng-latn": "Early Iron Age"
           },
-          "note": "The earliest subdivision of the Iron Age.",
           "sameAs": "http://purl.org/heritagedata/schemes/eh_period/concepts/EIA",
           "spatialCoverage": [
             {
@@ -45920,10 +45920,10 @@
           "editorialNote": "Deleted Kingdom of Commagene (163 B.C.-72 A.D.) on 10/20/14 due to problem with this end-date. Found these from the index entry for Armenia.",
           "id": "p0kj6dj7pzf",
           "label": "proto-Armenian Satrapy of Greater Armenia",
+          "note": "Kingdom was ruled by Romans between 17 A.D.-43 A.D.",
           "originalLabel": {
             "eng-latn": "proto-Armenian Satrapy of Greater Armenia"
           },
-          "note": "Kingdom was ruled by Romans between 17 A.D.-43 A.D.",
           "source": {
             "locator": "pages 52, 67",
             "partOf": "http://www.worldcat.org/oclc/398120"
@@ -50097,10 +50097,10 @@
           },
           "id": "p0ms2ch58wg",
           "label": "DAIII",
+          "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
           "originalLabel": {
             "eng-latn": "DAIII"
           },
-          "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Greece",
@@ -50129,10 +50129,10 @@
           },
           "id": "p0ms2ch6k6q",
           "label": "DAI",
+          "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
           "originalLabel": {
             "eng-latn": "DAI"
           },
-          "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Greece",
@@ -50187,10 +50187,10 @@
         "p0ms2chk8gk": {
           "id": "p0ms2chk8gk",
           "label": "Late Geometric",
+          "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
           "originalLabel": {
             "eng-latn": "Late Geometric"
           },
-          "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Greece",
@@ -50219,10 +50219,10 @@
           },
           "id": "p0ms2chvhsq",
           "label": "DAII",
+          "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton; note that this period subsumes a separate period \"Dark Age II/III\" that Conlin and Newton drew from McDonald and Coulson, and date 850-800 B.C.",
           "originalLabel": {
             "eng-latn": "DAII"
           },
-          "note": "CC307C, Spring 2011, group 3: Tyler Conlin and Morgan Newton; note that this period subsumes a separate period \"Dark Age II/III\" that Conlin and Newton drew from McDonald and Coulson, and date 850-800 B.C.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Greece",
@@ -50625,10 +50625,10 @@
         "p0njrb4zdmh": {
           "id": "p0njrb4zdmh",
           "label": "Second Dynasty of Isin",
+          "note": "Dynasty IV from Isin",
           "originalLabel": {
             "eng-latn": "Second Dynasty of Isin"
           },
-          "note": "Dynasty IV from Isin",
           "source": {
             "locator": "page 357",
             "partOf": "http://www.worldcat.org/oclc/869670586"
@@ -50678,10 +50678,10 @@
         "p0pk6scfcf7": {
           "id": "p0pk6scfcf7",
           "label": "Archaic",
+          "note": "See also Dominguez in C. Sanchez & G.R. Tsetskhladze, 2001. Greek Pottery from the Iberian Peninsula.",
           "originalLabel": {
             "eng-latn": "Archaic"
           },
-          "note": "See also Dominguez in C. Sanchez & G.R. Tsetskhladze, 2001. Greek Pottery from the Iberian Peninsula.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Spain",
@@ -55787,10 +55787,10 @@
           "editorialNote": "no date type shown, but context indicates BC",
           "id": "p0rqpwq4prr",
           "label": "Deuxième époque",
+          "note": "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)",
           "originalLabel": {
             "fra-latn": "Deuxième époque"
           },
-          "note": "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Tunisia",
@@ -55823,10 +55823,10 @@
           "editorialNote": "no date type shown, but context indicates BC",
           "id": "p0rqpwqb48w",
           "label": "Première époque",
+          "note": "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)",
           "originalLabel": {
             "fra-latn": "Première époque"
           },
-          "note": "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Tunisia",
@@ -55893,10 +55893,10 @@
           "editorialNote": "no date type shown, but context indicates BC",
           "id": "p0rqpwqwxnj",
           "label": "Troisième époque",
+          "note": "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)",
           "originalLabel": {
             "fra-latn": "Troisième époque"
           },
-          "note": "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Tunisia",
@@ -55969,10 +55969,10 @@
         "p0s7jn8xtgc": {
           "id": "p0s7jn8xtgc",
           "label": "Hellenistic",
+          "note": "Period ends with Roman annexation of Sicily, 241 B.C.",
           "originalLabel": {
             "eng-latn": "Hellenistic"
           },
-          "note": "Period ends with Roman annexation of Sicily, 241 B.C.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Sicily",
@@ -56150,10 +56150,10 @@
           },
           "id": "p0tns5v4kdf",
           "label": "Iron Age II (Middle Iron Age)",
+          "note": "This period is used to designate the moment of Phoenician colonization in the West before the development of a distinctive Punic identity.",
           "originalLabel": {
             "eng-latn": "Iron Age II (Middle Iron Age)"
           },
-          "note": "This period is used to designate the moment of Phoenician colonization in the West before the development of a distinctive Punic identity.",
           "source": {
             "locator": "page 25",
             "partOf": "http://www.worldcat.org/oclc/63807908"
@@ -58276,10 +58276,10 @@
         "p0vpm8v8c6p": {
           "id": "p0vpm8v8c6p",
           "label": "Cassabile",
+          "note": "Table 1 lists more phase names by sites",
           "originalLabel": {
             "eng-latn": "Cassabile"
           },
-          "note": "Table 1 lists more phase names by sites",
           "source": {
             "locator": "page 269",
             "partOf": "http://www.worldcat.org/oclc/39695441"
@@ -58626,10 +58626,10 @@
           },
           "id": "p0wf3wd8m8j",
           "label": "Phoenician",
+          "note": "Also known as Nuragic IV (cf. Sardinian)",
           "originalLabel": {
             "eng-latn": "Phoenician"
           },
-          "note": "Also known as Nuragic IV (cf. Sardinian)",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Sardinia",
@@ -58685,10 +58685,10 @@
         "p0wf3wdjmdx": {
           "id": "p0wf3wdjmdx",
           "label": "Bronze Age",
+          "note": "See also G. Lilliu, 2003. La civiltÃ dei Sardi dal paleolitico all'etÃ dei nuraghi; G.S. Webster, 1996. A Prehistory of Sardinia 2300-500BC. Also known as Nuragic III (following Nuragic I = Early Bronze Age, 1800-1500 B.C.; & Nuragic II = Middle Bronze Age, 1500-1200 B.C.)",
           "originalLabel": {
             "eng-latn": "Bronze Age"
           },
-          "note": "See also G. Lilliu, 2003. La civiltÃ dei Sardi dal paleolitico all'etÃ dei nuraghi; G.S. Webster, 1996. A Prehistory of Sardinia 2300-500BC. Also known as Nuragic III (following Nuragic I = Early Bronze Age, 1800-1500 B.C.; & Nuragic II = Middle Bronze Age, 1500-1200 B.C.)",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Sardinia",
@@ -58777,10 +58777,10 @@
         "p0wf3wdnm6q": {
           "id": "p0wf3wdnm6q",
           "label": "Late Iron Age",
+          "note": "Also known as Nuragic V, or final Nuragic (cf. Late Iron Age & Iron Age Sardinian) = period of Carthaginian hegemony, ending in Roman annexation of Sardinia, 238 B.C.",
           "originalLabel": {
             "eng-latn": "Late Iron Age"
           },
-          "note": "Also known as Nuragic V, or final Nuragic (cf. Late Iron Age & Iron Age Sardinian) = period of Carthaginian hegemony, ending in Roman annexation of Sardinia, 238 B.C.",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Sardinia",
@@ -58958,10 +58958,10 @@
         "p0wnvm4rqg9": {
           "id": "p0wnvm4rqg9",
           "label": "Archaic",
+          "note": "See also van Dommelen et al. (2008)",
           "originalLabel": {
             "eng-latn": "Archaic"
           },
-          "note": "See also van Dommelen et al. (2008)",
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Spain",

--- a/data.ttl
+++ b/data.ttl
@@ -722,7 +722,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/mesolithic-middle-east> ;
-    skos:altLabel "Mesolithic"@eng-latn ;
+    skos:altLabel "Mesolithic"@eng-latn, "Mesolithic Middle East (18000-9000 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Epipaleolithic-Protoneolithic ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Mesolithic Middle East (18000-9000 BC)" ;
@@ -745,7 +745,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/mongol-middle-east> ;
-    skos:altLabel "Mongol"@eng-latn ;
+    skos:altLabel "Mongol"@eng-latn, "Mongol Middle East (AD 1258-1501)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME, Central Asia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Mongol Middle East (AD 1258-1501)" ;
@@ -768,7 +768,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Armenia>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/urartian-eastern-anatolia> ;
-    skos:altLabel "Urartian"@eng-latn ;
+    skos:altLabel "Urartian"@eng-latn, "Urartian Eastern Anatolia (900-600 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "eastern Anatolia" ;
     skos:prefLabel "Urartian Eastern Anatolia (900-600 BC)" ;
@@ -790,7 +790,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ottoman-rise> ;
-    skos:altLabel "Ottoman Rise"@eng-latn ;
+    skos:altLabel "Ottoman Rise"@eng-latn, "Ottoman Rise (AD 1300-1453)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "ends with the conquest of Constantinople" ;
     skos:prefLabel "Ottoman Rise (AD 1300-1453)" ;
@@ -813,7 +813,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Saudi_Arabia> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/khwarezmian-middle-east> ;
-    skos:altLabel "Khwarezmian"@eng-latn ;
+    skos:altLabel "Khwarezmian"@eng-latn, "Khwarezmian Middle East (AD 1077-1258)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Khwarezmid", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Khwarezmian Middle East (AD 1077-1258)" ;
@@ -835,7 +835,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Albania>, <http://dbpedia.org/resource/Algeria>, <http://dbpedia.org/resource/Armenia>, <http://dbpedia.org/resource/Austria>, <http://dbpedia.org/resource/Azerbaijan>, <http://dbpedia.org/resource/Bosnia_and_Herzegovina>, <http://dbpedia.org/resource/Bulgaria>, <http://dbpedia.org/resource/Croatia>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Czech_Republic>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Gibraltar>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Hungary>, <http://dbpedia.org/resource/India>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Kenya>, <http://dbpedia.org/resource/Kosovo>, <http://dbpedia.org/resource/Kuwait>, <http://dbpedia.org/resource/Kyrgyzstan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Libya>, <http://dbpedia.org/resource/Malta>, <http://dbpedia.org/resource/Moldova>, <http://dbpedia.org/resource/Monaco>, <http://dbpedia.org/resource/Montenegro>, <http://dbpedia.org/resource/Morocco>, <http://dbpedia.org/resource/Oman>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Portugal>, <http://dbpedia.org/resource/Republic_of_Macedonia>, <http://dbpedia.org/resource/Romania>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Serbia>, <http://dbpedia.org/resource/Slovenia>, <http://dbpedia.org/resource/Somalia>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Switzerland>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Tajikistan>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Turkmenistan>, <http://dbpedia.org/resource/Ukraine>, <http://dbpedia.org/resource/United_Kingdom>, <http://dbpedia.org/resource/Uzbekistan>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/classical> ;
-    skos:altLabel "Classical"@eng-latn ;
+    skos:altLabel "Classical"@eng-latn, "Classical (Greco-Roman; 550 BC-330 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Classical period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 550 and end in the year 330 before the birth of Christ." ;
     skos:prefLabel "Classical (Greco-Roman; 550 BC-330 BC)" ;
@@ -858,7 +858,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-period-egypt> ;
-    skos:altLabel "Late Period"@eng-latn ;
+    skos:altLabel "Late Period"@eng-latn, "Late Period Egypt (664-332)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Late Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Late Period Egypt (664-332)" ;
@@ -880,7 +880,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Ireland>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/United_Kingdom>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/2nd-millenium-bce> ;
-    skos:altLabel "2nd Millennium BCE"@eng-latn ;
+    skos:altLabel "2nd Millenium BCE"@eng-latn, "2nd Millennium BCE"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The second millenium BCE as defined at http://en.wikipedia.org/wiki/2nd_millennium_BC" ;
     skos:prefLabel "2nd Millenium BCE" ;
@@ -903,7 +903,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/samanid-ghaznavid-iran> ;
-    skos:altLabel "Samanid-Ghaznavid"@eng-latn ;
+    skos:altLabel "Samanid-Ghaznavid"@eng-latn, "Samanid-Ghaznavid Iran (AD 819-1186)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Iran", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Samanid-Ghaznavid Iran (AD 819-1186)" ;
@@ -926,7 +926,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-middle-east> ;
-    skos:altLabel "Hellenistic"@eng-latn ;
+    skos:altLabel "Hellenistic"@eng-latn, "Hellenistic Middle East (330-140 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Macedonian-Seleucid/Ptolemaic/Attalid/Greco-Bactrian", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Hellenistic Middle East (330-140 BC)" ;
@@ -949,7 +949,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/crusader-ottoman-levant> ;
-    skos:altLabel "Crusader-Ottoman"@eng-latn ;
+    skos:altLabel "Crusader-Ottoman"@eng-latn, "Crusader-Ottoman Levant (AD 1099-1750)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Crusader-Seljuq-Ayyubid-Mamluk-Ottoman Levant", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Crusader-Ottoman Levant (AD 1099-1750)" ;
@@ -971,7 +971,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Albania>, <http://dbpedia.org/resource/Algeria>, <http://dbpedia.org/resource/Andorra>, <http://dbpedia.org/resource/Armenia>, <http://dbpedia.org/resource/Austria>, <http://dbpedia.org/resource/Azerbaijan>, <http://dbpedia.org/resource/Bahrain>, <http://dbpedia.org/resource/Bangladesh>, <http://dbpedia.org/resource/Belgium>, <http://dbpedia.org/resource/Bosnia_and_Herzegovina>, <http://dbpedia.org/resource/Bulgaria>, <http://dbpedia.org/resource/China>, <http://dbpedia.org/resource/Croatia>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Czech_Republic>, <http://dbpedia.org/resource/Denmark>, <http://dbpedia.org/resource/Djibouti>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Eritrea>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Gibraltar>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Guernsey>, <http://dbpedia.org/resource/Hungary>, <http://dbpedia.org/resource/India>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Ireland>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Kazakhstan>, <http://dbpedia.org/resource/Kenya>, <http://dbpedia.org/resource/Kosovo>, <http://dbpedia.org/resource/Kuwait>, <http://dbpedia.org/resource/Kyrgyzstan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Libya>, <http://dbpedia.org/resource/Liechtenstein>, <http://dbpedia.org/resource/Luxembourg>, <http://dbpedia.org/resource/Malta>, <http://dbpedia.org/resource/Moldova>, <http://dbpedia.org/resource/Monaco>, <http://dbpedia.org/resource/Montenegro>, <http://dbpedia.org/resource/Morocco>, <http://dbpedia.org/resource/Nepal>, <http://dbpedia.org/resource/Netherlands>, <http://dbpedia.org/resource/Oman>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Poland>, <http://dbpedia.org/resource/Portugal>, <http://dbpedia.org/resource/Republic_of_Macedonia>, <http://dbpedia.org/resource/Romania>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Serbia>, <http://dbpedia.org/resource/Slovakia>, <http://dbpedia.org/resource/Slovenia>, <http://dbpedia.org/resource/Somalia>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Sri_Lanka>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Switzerland>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Tajikistan>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Turkmenistan> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-republican> ;
-    skos:altLabel " Roman Republic"@eng-latn, "Hellenistic Greek"@eng-latn, "Hellenistic Greek, Roman Republic"@eng-latn ;
+    skos:altLabel " Roman Republic"@eng-latn, "Hellenistic Greek"@eng-latn, "Hellenistic Greek, Roman Republic"@eng-latn, "Hellenistic Greek, Roman Republic (330 BC-30 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Hellenistic period in Greek history and the middle-to-late Republican period in Roman history. For the purposes of Pleiades, this period is said to begin in the year 330 and end in the year 30 before the birth of Christ." ;
     skos:prefLabel "Hellenistic Greek, Roman Republic (330 BC-30 BC)" ;
@@ -994,7 +994,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Palestine> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-bronze-age-southern-levant> ;
-    skos:altLabel "Late Bronze Age"@eng-latn ;
+    skos:altLabel "Late Bronze Age"@eng-latn, "Late Bronze Age Southern Levant (1400-1200 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "southern Levant" ;
     skos:prefLabel "Late Bronze Age Southern Levant (1400-1200 BC)" ;
@@ -1017,7 +1017,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Palestine> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/transition-early-middle-bronze-age-southern-levant> ;
-    skos:altLabel "Transition Early-Middle Bronze Age"@eng-latn ;
+    skos:altLabel "Transition Early-Middle Bronze Age"@eng-latn, "Transition Early-Middle Bronze Age Southern Levant (2100-1900 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "southern Levant" ;
     skos:prefLabel "Transition Early-Middle Bronze Age Southern Levant (2100-1900 BC)" ;
@@ -1039,7 +1039,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Kenya>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/transition-roman-early-empire-late-antique> ;
-    skos:altLabel "Transition Roman Early Empire-Late Antique"@eng-latn ;
+    skos:altLabel "Transition Roman Early Empire-Late Antique"@eng-latn, "Transition Roman Early Empire-Late Antique (AD 284-337)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Mediterranean", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Transition Roman Early Empire-Late Antique (AD 284-337)" ;
@@ -1062,7 +1062,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Djibouti>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/khedivate-egypt> ;
-    skos:altLabel "Khedivate"@eng-latn ;
+    skos:altLabel "Khedivate"@eng-latn, "Khedivate Egypt (AD 1800-1922)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Muhammed Ali-Khedivate Egypt, Alawiyya Egypt, Anglo-Egyptian", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Khedivate Egypt (AD 1800-1922)" ;
@@ -1085,7 +1085,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/egyptian-hittite-levant> ;
-    skos:altLabel "Egyptian/Hittite"@eng-latn ;
+    skos:altLabel "Egyptian/Hittite"@eng-latn, "Egyptian/Hittite Levant (1344-1212 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Levant", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Egyptian/Hittite Levant (1344-1212 BC)" ;
@@ -1108,7 +1108,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Ireland>, <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/iron-age-britain> ;
-    skos:altLabel "Iron Age"@eng-latn ;
+    skos:altLabel "Iron Age"@eng-latn, "Iron Age Britain (ca. 800 BC/BCE - ca. 100 AD/CE)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "A long time period associated with Iron Age Britain.", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Iron Age Britain (ca. 800 BC/BCE - ca. 100 AD/CE)" ;
@@ -1130,7 +1130,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Albania>, <http://dbpedia.org/resource/Algeria>, <http://dbpedia.org/resource/Andorra>, <http://dbpedia.org/resource/Armenia>, <http://dbpedia.org/resource/Austria>, <http://dbpedia.org/resource/Azerbaijan>, <http://dbpedia.org/resource/Bahrain>, <http://dbpedia.org/resource/Bangladesh>, <http://dbpedia.org/resource/Belgium>, <http://dbpedia.org/resource/Bosnia_and_Herzegovina>, <http://dbpedia.org/resource/Bulgaria>, <http://dbpedia.org/resource/China>, <http://dbpedia.org/resource/Croatia>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Czech_Republic>, <http://dbpedia.org/resource/Democratic_Republic_of_the_Congo>, <http://dbpedia.org/resource/Denmark>, <http://dbpedia.org/resource/Djibouti>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Ethiopia>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Gibraltar>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Guernsey>, <http://dbpedia.org/resource/Hungary>, <http://dbpedia.org/resource/India>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Ireland>, <http://dbpedia.org/resource/Isle_of_Man>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Kazakhstan>, <http://dbpedia.org/resource/Kenya>, <http://dbpedia.org/resource/Kosovo>, <http://dbpedia.org/resource/Kuwait>, <http://dbpedia.org/resource/Kyrgyzstan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Libya>, <http://dbpedia.org/resource/Liechtenstein>, <http://dbpedia.org/resource/Luxembourg>, <http://dbpedia.org/resource/Malta>, <http://dbpedia.org/resource/Moldova>, <http://dbpedia.org/resource/Monaco>, <http://dbpedia.org/resource/Montenegro>, <http://dbpedia.org/resource/Morocco>, <http://dbpedia.org/resource/Nepal>, <http://dbpedia.org/resource/Netherlands>, <http://dbpedia.org/resource/Norway>, <http://dbpedia.org/resource/Oman>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Poland>, <http://dbpedia.org/resource/Portugal>, <http://dbpedia.org/resource/Republic_of_Macedonia>, <http://dbpedia.org/resource/Republic_of_the_Congo>, <http://dbpedia.org/resource/Romania>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Serbia>, <http://dbpedia.org/resource/Slovakia>, <http://dbpedia.org/resource/Slovenia>, <http://dbpedia.org/resource/Somalia>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Sri_Lanka>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Sweden>, <http://dbpedia.org/resource/Switzerland>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Tajikistan>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Turkmenistan>, <http://dbpedia.org/resource/Uganda>, <http://dbpedia.org/resource/Ukraine>, <http://dbpedia.org/resource/United_Arab_Emirates>, <http://dbpedia.org/resource/United_Kingdom>, <http://dbpedia.org/resource/Uzbekistan>, <http://dbpedia.org/resource/Vatican_City>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-antique> ;
-    skos:altLabel "Late Antique"@eng-latn ;
+    skos:altLabel "Late Antique"@eng-latn, "Late Antique (AD 300-AD 640)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Late Antique period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 300 and to end in the year 640 after the birth of Christ." ;
     skos:prefLabel "Late Antique (AD 300-AD 640)" ;
@@ -1152,7 +1152,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Albania>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Kenya>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Luxembourg>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Ukraine> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-byzantine> ;
-    skos:altLabel "Middle Byzantine"@eng-latn ;
+    skos:altLabel "Middle Byzantine"@eng-latn, "Middle Byzantine (AD 850-1200)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Middle Byzantine period in areas where such designations are appropriate.", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Middle Byzantine (AD 850-1200)" ;
@@ -1175,7 +1175,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/perso-ottoman-russian-caucasus> ;
-    skos:altLabel "Perso-Ottoman-Russian"@eng-latn ;
+    skos:altLabel "Perso-Ottoman-Russian"@eng-latn, "Perso-Ottoman-Russian Caucasus (AD 1500-1918)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Safavid-Qajar-Ottoman Empire-Russian Empire Caucasus", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Perso-Ottoman-Russian Caucasus (AD 1500-1918)" ;
@@ -1197,7 +1197,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Albania>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Libya>, <http://dbpedia.org/resource/Luxembourg>, <http://dbpedia.org/resource/Morocco>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-roman-early-empire> ;
-    skos:altLabel "Hellenistic-Roman Early Empire"@eng-latn ;
+    skos:altLabel "Hellenistic-Roman Early Empire"@eng-latn, "Hellenistic-Roman Early Empire (330 BC - AD 300)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Mediterranean", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Hellenistic-Roman Early Empire (330 BC - AD 300)" ;
@@ -1220,7 +1220,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-age-anatolia> ;
-    skos:altLabel "Middle Bronze Age"@eng-latn ;
+    skos:altLabel "Middle Bronze Age"@eng-latn, "Middle Bronze Age Anatolia (1750-1450 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Anatolia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Middle Bronze Age Anatolia (1750-1450 BC)" ;
@@ -1243,7 +1243,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Turkmenistan> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-antique-sasanian-middle-east> ;
-    skos:altLabel "Late Antique/Sasanian"@eng-latn ;
+    skos:altLabel "Late Antique/Sasanian"@eng-latn, "Late Antique/Sasanian Middle East (AD 300-640)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Late Antique/Sasanian Middle East (AD 300-640)" ;
@@ -1266,7 +1266,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/parthian-middle-east> ;
-    skos:altLabel "Parthian"@eng-latn ;
+    skos:altLabel "Parthian"@eng-latn, "Parthian Middle East (140 BC - AD 226)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Arsacid ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Parthian Middle East (140 BC - AD 226)" ;
@@ -1289,7 +1289,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ptolemaic-egypt> ;
-    skos:altLabel "Ptolemaic"@eng-latn ;
+    skos:altLabel "Ptolemaic"@eng-latn, "Ptolemaic Egypt (304-30 BCE/BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Ptolemaic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Ptolemaic Egypt (304-30 BCE/BC)" ;
@@ -1311,7 +1311,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Djibouti>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ottoman-empire> ;
-    skos:altLabel "Ottoman Empire"@eng-latn ;
+    skos:altLabel "Ottoman Empire"@eng-latn, "Ottoman Empire (AD 1513-1918)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME, Balkan, Northern Africa", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Ottoman Empire (AD 1513-1918)" ;
@@ -1334,7 +1334,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Azerbaijan>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-medieval-caucasus> ;
-    skos:altLabel "Early Medieval"@eng-latn ;
+    skos:altLabel "Early Medieval"@eng-latn, "Early Medieval Caucasus (AD 850-1200)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Bagratid, Kingdom of Armenia/Kingdom of Georgia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Early Medieval Caucasus (AD 850-1200)" ;
@@ -1357,7 +1357,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Djibouti>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/United_Arab_Emirates>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/1500-ad-middle-east> ;
-    skos:altLabel "1500 AD"@eng-latn ;
+    skos:altLabel "1500 AD"@eng-latn, "1500 AD Middle East (AD 1500-1500)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME, Greece, Indus", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "1500 AD Middle East (AD 1500-1500)" ;
@@ -1380,7 +1380,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/chalcolithic-iran> ;
-    skos:altLabel "Chalcolithic"@eng-latn ;
+    skos:altLabel "Chalcolithic"@eng-latn, "Chalcolithic Iran (5000-2500 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Iran", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Chalcolithic Iran (5000-2500 BC)" ;
@@ -1403,7 +1403,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/safavid-middle-east> ;
-    skos:altLabel "Safavid"@eng-latn ;
+    skos:altLabel "Safavid"@eng-latn, "Safavid Middle East (AD 1501-1725)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Eastern ME, Central Asia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Safavid Middle East (AD 1501-1725)" ;
@@ -1425,7 +1425,7 @@
     dcterms:spatial <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Ireland>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/United_Kingdom>, <http://dbpedia.org/resource/Uzbekistan> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/4th-millenium-bce> ;
-    skos:altLabel "4th millennium BCE"@eng-latn ;
+    skos:altLabel "4th millenium BCE"@eng-latn, "4th millennium BCE"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The fourth millenium BCE as defined at http://en.wikipedia.org/wiki/4th_millennium_BC" ;
     skos:prefLabel "4th millenium BCE" ;
@@ -1448,7 +1448,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/akkadian-ur-iii-mesopotamia> ;
-    skos:altLabel "Akkadian-Ur III"@eng-latn ;
+    skos:altLabel "Akkadian-Ur III"@eng-latn, "Akkadian-Ur III Mesopotamia (2335-2000 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Akkadian-Neo-Sumerian Mesopotamia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Akkadian-Ur III Mesopotamia (2335-2000 BC)" ;
@@ -1470,7 +1470,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-nubian> ;
-    skos:altLabel "Middle Nubian"@eng-latn ;
+    skos:altLabel "Middle Nubian"@eng-latn, "Middle Nubian (2300-1600 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "C-Group-Kerma-Middle Nubian-Pan-Grave-MK", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Middle Nubian (2300-1600 BC)" ;
@@ -1493,7 +1493,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-early-iron-age-iran> ;
-    skos:altLabel "Middle Bronze-Early Iron Age"@eng-latn ;
+    skos:altLabel "Middle Bronze-Early Iron Age"@eng-latn, "Middle Bronze-Early Iron Age Iran (2000-650 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Iran", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Middle Bronze-Early Iron Age Iran (2000-650 BC)" ;
@@ -1516,7 +1516,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Djibouti>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/colonial-modern-middle-east> ;
-    skos:altLabel "Colonial-Modern"@eng-latn ;
+    skos:altLabel "Colonial-Modern"@eng-latn, "Colonial-Modern Middle East (AD 1800-2000)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Late Ottoman-Colonial-Mandate Modern Middle east", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Colonial-Modern Middle East (AD 1800-2000)" ;
@@ -1538,7 +1538,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Albania>, <http://dbpedia.org/resource/Algeria>, <http://dbpedia.org/resource/Croatia>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Hungary>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Libya>, <http://dbpedia.org/resource/Morocco>, <http://dbpedia.org/resource/Netherlands>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Portugal>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/roman-early-empire-late-antique> ;
-    skos:altLabel "Roman Early Empire-Late Antique"@eng-latn ;
+    skos:altLabel "Roman Early Empire-Late Antique"@eng-latn, "Roman Early Empire-Late Antique (30 BC - AD 640)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Mediterranean", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Roman Early Empire-Late Antique (30 BC - AD 640)" ;
@@ -1560,7 +1560,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Algeria>, <http://dbpedia.org/resource/Armenia>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Kenya>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Romania>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Slovakia>, <http://dbpedia.org/resource/Somalia>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Sri_Lanka>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Turkmenistan>, <http://dbpedia.org/resource/Ukraine>, <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/mediaeval-byzantine> ;
-    skos:altLabel "Mediaeval/Byzantine"@eng-latn ;
+    skos:altLabel "Mediaeval/Byzantine"@eng-latn, "Mediaeval/Byzantine (AD 641-AD 1453)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Mediaeval period in the West, or the period from the end of Late Antiquity (640) to the fall of Constantinople in the East (1453)." ;
     skos:prefLabel "Mediaeval/Byzantine (AD 641-AD 1453)" ;
@@ -1583,7 +1583,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-hittite-anatolia> ;
-    skos:altLabel "Middle Hittite"@eng-latn ;
+    skos:altLabel "Middle Hittite"@eng-latn, "Middle Hittite Anatolia (1450-1200 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "New Kingdom Hittite", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Middle Hittite Anatolia (1450-1200 BC)" ;
@@ -1605,7 +1605,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/proto-byzantine> ;
-    skos:altLabel "Proto-Byzantine"@eng-latn ;
+    skos:altLabel "Proto-Byzantine"@eng-latn, "Proto-Byzantine (AD 500-650)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Early Byzantine; includes Justinian I", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Proto-Byzantine (AD 500-650)" ;
@@ -1628,7 +1628,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Sudan> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neolithic-egypt> ;
-    skos:altLabel "Neolithic"@eng-latn ;
+    skos:altLabel "Neolithic"@eng-latn, "Neolithic Egypt (6000-4500 BCE/BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Neolithic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Neolithic Egypt (6000-4500 BCE/BC)" ;
@@ -1651,7 +1651,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Sudan> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/new-kingdom-egypt> ;
-    skos:altLabel "New Kingdom"@eng-latn ;
+    skos:altLabel "New Kingdom"@eng-latn, "New Kingdom Egypt (1548-1086)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The New Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "New Kingdom Egypt (1548-1086)" ;
@@ -1674,7 +1674,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/elamite-western-iran> ;
-    skos:altLabel "Elamite"@eng-latn ;
+    skos:altLabel "Elamite"@eng-latn, "Elamite Western Iran (3200-540 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Proto-Old-Middle-Neo-Elamite", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Elamite Western Iran (3200-540 BC)" ;
@@ -1697,7 +1697,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Malta> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neolithic-malta> ;
-    skos:altLabel "Neolithic"@eng-latn ;
+    skos:altLabel "Neolithic"@eng-latn, "Neolithic Period on Malta (ca. 5,000-2,500BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The neolithic or so-called \"New Stone Age\" as expressed in remains of physical culture on the island of Malta, where it appears to have lasted from around 5,000 to 2,500 BC" ;
     skos:prefLabel "Neolithic Period on Malta (ca. 5,000-2,500BC)" ;
@@ -1720,7 +1720,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Turkmenistan>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/achaemenid-roman-republic-middle-east> ;
-    skos:altLabel "Achaemenid-Roman Republic"@eng-latn ;
+    skos:altLabel "Achaemenid-Roman Republic"@eng-latn, "Achaemenid-Roman Republic Middle East (540-30 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Achaemenid-Roman Republic Middle East (540-30 BC)" ;
@@ -1743,7 +1743,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-parthian-middle-east> ;
-    skos:altLabel "Hellenistic-Parthian"@eng-latn ;
+    skos:altLabel "Hellenistic-Parthian"@eng-latn, "Hellenistic-Parthian Middle East (330 BC - AD 226)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Seleucid-Early Roman-Arsacid Middle East", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Hellenistic-Parthian Middle East (330 BC - AD 226)" ;
@@ -1765,7 +1765,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-ottoman-empire> ;
-    skos:altLabel "Early Ottoman Empire"@eng-latn ;
+    skos:altLabel "Early Ottoman Empire"@eng-latn, "Early Ottoman Empire (AD 1453-1683)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "ends with the siege of Vienna" ;
     skos:prefLabel "Early Ottoman Empire (AD 1453-1683)" ;
@@ -1787,7 +1787,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Djibouti>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Kuwait>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Netherlands>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-ottoman-empire> ;
-    skos:altLabel "Late Ottoman Empire"@eng-latn ;
+    skos:altLabel "Late Ottoman Empire"@eng-latn, "Late Ottoman Empire (AD 1683-1918)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME, Balkan, Northern Africa", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Late Ottoman Empire (AD 1683-1918)" ;
@@ -1810,7 +1810,7 @@
     dcterms:spatial <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/bronze-age-britain> ;
-    skos:altLabel "Bronze Age"@eng-latn ;
+    skos:altLabel "Bronze Age"@eng-latn, "Bronze Age Britain (ca. 2500 - ca. 800 BC/BCE)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "A long time period associated with Bronze Age Britain.", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Bronze Age Britain (ca. 2500 - ca. 800 BC/BCE)" ;
@@ -1832,7 +1832,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-nubian> ;
-    skos:altLabel "Late Nubian"@eng-latn ;
+    skos:altLabel "Late Nubian"@eng-latn, "Late Nubian (1600-350 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "NK-Kushite-Meroitic", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Late Nubian (1600-350 BC)" ;
@@ -1855,7 +1855,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/later-2nd-millennium-bc-mesopotamia> ;
-    skos:altLabel "Later 2nd Millennium BC"@eng-latn ;
+    skos:altLabel "Later 2nd Millennium BC"@eng-latn, "Later 2nd Millennium BC Mesopotamia (1600-1000 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Middle Assyrian/Middle Babylonian/Kassite Mesopotamia, LBA-Early Iron Age Mesopotamia, incl. Sea Peoples", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Later 2nd Millennium BC Mesopotamia (1600-1000 BC)" ;
@@ -1878,7 +1878,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Palestine> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/mesolithic-levant> ;
-    skos:altLabel "Mesolithic"@eng-latn ;
+    skos:altLabel "Mesolithic"@eng-latn, "Mesolithic Levant (18000-9500 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Epipaleolithic-Protoneolithic Levant, Kebaran-Natufian", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Mesolithic Levant (18000-9500 BC)" ;
@@ -1901,7 +1901,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Sudan> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ptolemaic-roman-egypt> ;
-    skos:altLabel "Ptolemaic-Roman"@eng-latn ;
+    skos:altLabel "Ptolemaic-Roman"@eng-latn, "Ptolemaic-Roman Egypt (304 BC - AD 640)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Egypt", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Ptolemaic-Roman Egypt (304 BC - AD 640)" ;
@@ -1924,7 +1924,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/crusader-seljuq-ayyubid-levant> ;
-    skos:altLabel "Crusader/Seljuq-Ayyubid"@eng-latn ;
+    skos:altLabel "Crusader/Seljuq-Ayyubid"@eng-latn, "Crusader/Seljuq-Ayyubid Levant (AD 1099-1291)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Latin", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Crusader/Seljuq-Ayyubid Levant (AD 1099-1291)" ;
@@ -1946,7 +1946,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Albania>, <http://dbpedia.org/resource/Algeria>, <http://dbpedia.org/resource/Armenia>, <http://dbpedia.org/resource/Austria>, <http://dbpedia.org/resource/Azerbaijan>, <http://dbpedia.org/resource/Bahrain>, <http://dbpedia.org/resource/Bangladesh>, <http://dbpedia.org/resource/Belgium>, <http://dbpedia.org/resource/Bosnia_and_Herzegovina>, <http://dbpedia.org/resource/Bulgaria>, <http://dbpedia.org/resource/Burma>, <http://dbpedia.org/resource/China>, <http://dbpedia.org/resource/Croatia>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Czech_Republic>, <http://dbpedia.org/resource/Democratic_Republic_of_the_Congo>, <http://dbpedia.org/resource/Djibouti>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Eritrea>, <http://dbpedia.org/resource/Ethiopia>, <http://dbpedia.org/resource/Faroe_Islands>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Gibraltar>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Guernsey>, <http://dbpedia.org/resource/Hungary>, <http://dbpedia.org/resource/India>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Ireland>, <http://dbpedia.org/resource/Isle_of_Man>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jersey>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Kazakhstan>, <http://dbpedia.org/resource/Kenya>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Libya>, <http://dbpedia.org/resource/Lithuania>, <http://dbpedia.org/resource/Luxembourg>, <http://dbpedia.org/resource/Malta>, <http://dbpedia.org/resource/Montenegro>, <http://dbpedia.org/resource/Morocco>, <http://dbpedia.org/resource/Netherlands>, <http://dbpedia.org/resource/Oman>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Poland>, <http://dbpedia.org/resource/Portugal>, <http://dbpedia.org/resource/Republic_of_Macedonia>, <http://dbpedia.org/resource/Republic_of_the_Congo>, <http://dbpedia.org/resource/Romania>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/San_Marino>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Serbia>, <http://dbpedia.org/resource/Slovakia>, <http://dbpedia.org/resource/Slovenia>, <http://dbpedia.org/resource/Somalia>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Switzerland>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Tajikistan>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Ukraine>, <http://dbpedia.org/resource/United_Kingdom>, <http://dbpedia.org/resource/Uzbekistan>, <http://dbpedia.org/resource/Vatican_City>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/modern> ;
-    skos:altLabel "Modern"@eng-latn ;
+    skos:altLabel "Modern"@eng-latn, "Modern (AD 1700-Present)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Our present, modern era.", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Modern (AD 1700-Present)" ;
@@ -1969,7 +1969,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/old-kingdom-egypt> ;
-    skos:altLabel "Old Kingdom"@eng-latn ;
+    skos:altLabel "Old Kingdom"@eng-latn, "Old Kingdom Egypt (2670-2168 BCE/BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Old Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Old Kingdom Egypt (2670-2168 BCE/BC)" ;
@@ -1992,7 +1992,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/pre-pottery-neolithic-middle-east> ;
-    skos:altLabel "Pre-Pottery Neolithic"@eng-latn ;
+    skos:altLabel "Pre-Pottery Neolithic"@eng-latn, "Pre-Pottery Neolithic Middle East (9000-6000 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Aceramic Neolithic ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Pre-Pottery Neolithic Middle East (9000-6000 BC)" ;
@@ -2015,7 +2015,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/timurid-middle-east> ;
-    skos:altLabel "Timurid"@eng-latn ;
+    skos:altLabel "Timurid"@eng-latn, "Timurid Middle East (AD 1370-1501)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Eastern ME, Central Asia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Timurid Middle East (AD 1370-1501)" ;
@@ -2038,7 +2038,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Sudan> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-kingdom-egypt> ;
-    skos:altLabel "Middle Kingdom"@eng-latn ;
+    skos:altLabel "Middle Kingdom"@eng-latn, "Middle Kingdom Egypt (2010-1640 BCE/BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Middle Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Middle Kingdom Egypt (2010-1640 BCE/BC)" ;
@@ -2061,7 +2061,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ubaid-early-dynastic-ii-mesopotamia> ;
-    skos:altLabel "Ubaid-Early Dynastic II"@eng-latn ;
+    skos:altLabel "Ubaid-Early Dynastic II"@eng-latn, "Ubaid-Early Dynastic II Mesopotamia (5500-2600 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Late Chalcolithic-ED II Mesopotamia, Ubaid-Uruk-Jemdet Nasr-ED Mesopotamia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Ubaid-Early Dynastic II Mesopotamia (5500-2600 BC)" ;
@@ -2084,7 +2084,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Palestine> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-bronze-age-southern-levant> ;
-    skos:altLabel "Early Bronze Age"@eng-latn ;
+    skos:altLabel "Early Bronze Age"@eng-latn, "Early Bronze Age Southern Levant (3300-2000 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "southern Levant" ;
     skos:prefLabel "Early Bronze Age Southern Levant (3300-2000 BC)" ;
@@ -2107,7 +2107,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/roman-middle-east> ;
-    skos:altLabel "Roman"@eng-latn ;
+    skos:altLabel "Roman"@eng-latn, "Roman Middle East (140 BC - AD 640)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Roman Middle East (140 BC - AD 640)" ;
@@ -2130,7 +2130,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/caliphate-umayyad-middle-east> ;
-    skos:altLabel "Caliphate-Umayyad"@eng-latn ;
+    skos:altLabel "Caliphate-Umayyad"@eng-latn, "Caliphate-Umayyad Middle East (AD 632-750)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Early Islamic, Rashidun-Umayyad (starts with death of Muhammed who only controlled Arabia)", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Caliphate-Umayyad Middle East (AD 632-750)" ;
@@ -2153,7 +2153,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/seljuq-khwarezmian-middle-east> ;
-    skos:altLabel "Seljuq-Khwarezmian"@eng-latn ;
+    skos:altLabel "Seljuq-Khwarezmian"@eng-latn, "Seljuq-Khwarezmian Middle East (AD 1037-1258)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Seljuq-Khwarezmian Middle East (AD 1037-1258)" ;
@@ -2175,7 +2175,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Albania>, <http://dbpedia.org/resource/Croatia>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Luxembourg>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-byzantine> ;
-    skos:altLabel "Early Byzantine"@eng-latn ;
+    skos:altLabel "Early Byzantine"@eng-latn, "Early Byzantine (AD 650-850)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Early Byzantine Period in areas where such designations are appropriate.", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Early Byzantine (AD 650-850)" ;
@@ -2197,7 +2197,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-geometric> ;
-    skos:altLabel "Middle Geometric"@eng-latn ;
+    skos:altLabel "Middle Geometric"@eng-latn, "Middle Geometric (Greek; 850-750 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Middle Geometric period in ancient Greece, from 850-750 before the birth of Christ." ;
     skos:prefLabel "Middle Geometric (Greek; 850-750 BC)" ;
@@ -2220,7 +2220,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/pottery-neolithic-middle-east> ;
-    skos:altLabel "Pottery Neolithic"@eng-latn ;
+    skos:altLabel "Pottery Neolithic"@eng-latn, "Pottery Neolithic Middle East (6000-4500 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Pottery Neolithic Middle East (6000-4500 BC)" ;
@@ -2243,7 +2243,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Malta> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/bronze-age-malta> ;
-    skos:altLabel "Bronze Age"@eng-latn ;
+    skos:altLabel "Bronze Age"@eng-latn, "Bronze Age Malta (ca. 2,500-700 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Bronze age as represented in the remains of physical culture from the island of Malta." ;
     skos:prefLabel "Bronze Age Malta (ca. 2,500-700 BC)" ;
@@ -2266,7 +2266,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-late-iron-age-anatolia> ;
-    skos:altLabel "Middle-Late Iron Age"@eng-latn ;
+    skos:altLabel "Middle-Late Iron Age"@eng-latn, "Middle-Late Iron Age Anatolia (700-500 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Anatolia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Middle-Late Iron Age Anatolia (700-500 BC)" ;
@@ -2289,7 +2289,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neolithic-middle-east> ;
-    skos:altLabel "Neolithic"@eng-latn ;
+    skos:altLabel "Neolithic"@eng-latn, "Neolithic Middle East (9000-4500 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Neolithic Middle East (9000-4500 BC)" ;
@@ -2312,7 +2312,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Italy> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/iron-age-italy-latial-culture-i-1000-900-bc> ;
-    skos:altLabel "Iron Age"@eng-latn ;
+    skos:altLabel "Iron Age"@eng-latn, "Iron Age Italy (Latial Culture I, 1000-900 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Latial I is concentrated around Rome, the Alban Hills, and the Monti della Tolfa.", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Iron Age Italy (Latial Culture I, 1000-900 BC)" ;
@@ -2335,7 +2335,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ilkhanate-middle-east> ;
-    skos:altLabel "Ilkhanate"@eng-latn ;
+    skos:altLabel "Ilkhanate"@eng-latn, "Ilkhanate Middle East (AD 1258-1335)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Ilkhanid, Hulagu, Early Mongol", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Ilkhanate Middle East (AD 1258-1335)" ;
@@ -2358,7 +2358,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-iron-age-anatolia> ;
-    skos:altLabel "Early Iron Age"@eng-latn ;
+    skos:altLabel "Early Iron Age"@eng-latn, "Early Iron Age Anatolia (1200-700 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "incl. Mitanni" ;
     skos:prefLabel "Early Iron Age Anatolia (1200-700 BC)" ;
@@ -2380,7 +2380,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/old-nubian> ;
-    skos:altLabel "Old Nubian"@eng-latn ;
+    skos:altLabel "Old Nubian"@eng-latn, "Old Nubian (3800-2300 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "A-Group/Old Nubian-Middle Nubian-OK", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Old Nubian (3800-2300 BC)" ;
@@ -2403,7 +2403,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Sudan> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/third-intermediate-period-egypt> ;
-    skos:altLabel "Third Intermediate"@eng-latn ;
+    skos:altLabel "Third Intermediate"@eng-latn, "Third Intermediate Period Egypt (1086-664)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Third Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Third Intermediate Period Egypt (1086-664)" ;
@@ -2426,7 +2426,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Djibouti>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/1200-bc-middle-east> ;
-    skos:altLabel "1200 BC"@eng-latn ;
+    skos:altLabel "1200 BC"@eng-latn, "1200 BC Middle East"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME, Greece", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "1200 BC Middle East" ;
@@ -2448,7 +2448,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ummayad> ;
-    skos:altLabel "Ummayad"@eng-latn ;
+    skos:altLabel "Ummayad"@eng-latn, "Ummayad Period (661-750CE)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The period of the Umayyad Caliphate as defined by http://en.wikipedia.org/wiki/Umayyad_Caliphate" ;
     skos:prefLabel "Ummayad Period (661-750CE)" ;
@@ -2470,7 +2470,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Albania>, <http://dbpedia.org/resource/Algeria>, <http://dbpedia.org/resource/Armenia>, <http://dbpedia.org/resource/Bulgaria>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Kosovo>, <http://dbpedia.org/resource/Kuwait>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Libya>, <http://dbpedia.org/resource/Moldova>, <http://dbpedia.org/resource/Monaco>, <http://dbpedia.org/resource/Morocco>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Poland>, <http://dbpedia.org/resource/Portugal>, <http://dbpedia.org/resource/Republic_of_Macedonia>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Tajikistan>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Turkmenistan>, <http://dbpedia.org/resource/Ukraine>, <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/archaic> ;
-    skos:altLabel "Archaic"@eng-latn ;
+    skos:altLabel "Archaic"@eng-latn, "Archaic (Greco-Roman; 750-550 BCE/BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Archaic period in Greek and Roman history. For the purposes of Pleiades, this period is seen to begin in the year 750 and end in the year 550 before the birth of Christ." ;
     skos:prefLabel "Archaic (Greco-Roman; 750-550 BCE/BC)" ;
@@ -2493,7 +2493,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Sudan> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/2nd-millennium-bc-egypt> ;
-    skos:altLabel "2nd Millennium BC"@eng-latn ;
+    skos:altLabel "2nd Millennium BC"@eng-latn, "2nd Millennium BC Egypt (2000-1000 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Egypt", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "2nd Millennium BC Egypt (2000-1000 BC)" ;
@@ -2516,7 +2516,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-bronze-age-anatolia> ;
-    skos:altLabel "Early Bronze Age"@eng-latn ;
+    skos:altLabel "Early Bronze Age"@eng-latn, "Early Bronze Age Anatolia (2000-1750 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Karum Anatolia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Early Bronze Age Anatolia (2000-1750 BC)" ;
@@ -2539,7 +2539,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/mamluk-middle-east> ;
-    skos:altLabel "Mamluk"@eng-latn ;
+    skos:altLabel "Mamluk"@eng-latn, "Mamluk Middle East (AD 1258-1516)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "Western ME" ;
     skos:prefLabel "Mamluk Middle East (AD 1258-1516)" ;
@@ -2562,7 +2562,7 @@
     dcterms:spatial <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neolithic-british> ;
-    skos:altLabel "Neolithic"@eng-latn ;
+    skos:altLabel "Neolithic"@eng-latn, "Neolithic Period (British Isles; 4,000-2,500 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Neolithic period in the British Isles, after Wikipedia, Neolithic British Isles, http://en.wikipedia.org/wiki/Neolithic_British_Isles." ;
     skos:prefLabel "Neolithic Period (British Isles; 4,000-2,500 BC)" ;
@@ -2584,7 +2584,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-antique-late-byzantine> ;
-    skos:altLabel "Late Antique-Late Byzantine"@eng-latn ;
+    skos:altLabel "Late Antique-Late Byzantine"@eng-latn, "Late Antique-Late Byzantine (AD 300-1450)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Late Antique-Late Byzantine (AD 300-1450)" ;
@@ -2607,7 +2607,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/2nd-millennium-bc-levant> ;
-    skos:altLabel "2nd Millennium BC"@eng-latn ;
+    skos:altLabel "2nd Millennium BC"@eng-latn, "2nd Millennium BC Levant (2000-1000 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "MBA Levant-LBA Levant-Iron Age I Levant (not sure as these are all taken from southern Levant periodisation)", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "2nd Millennium BC Levant (2000-1000 BC)" ;
@@ -2630,7 +2630,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/abassid-middle-east> ;
-    skos:altLabel "Abassid"@eng-latn ;
+    skos:altLabel "Abassid"@eng-latn, "Abassid Middle East (AD 750-940)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME, northern Africa", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Abassid Middle East (AD 750-940)" ;
@@ -2653,7 +2653,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/roman-early-byzantine-middle-east> ;
-    skos:altLabel "Roman-Early Byzantine"@eng-latn ;
+    skos:altLabel "Roman-Early Byzantine"@eng-latn, "Roman-Early Byzantine Middle East (140 BC - AD 850)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Roman-Early Byzantine Middle East (140 BC - AD 850)" ;
@@ -2675,7 +2675,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Albania>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Kenya>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-byzantine-ottoman-rise> ;
-    skos:altLabel "Late Byzantine/Ottoman Rise"@eng-latn ;
+    skos:altLabel "Late Byzantine/Ottoman Rise"@eng-latn, "Late Byzantine/Ottoman Rise (AD 1200-1453)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Aegean, Balkan & Anatolia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Late Byzantine/Ottoman Rise (AD 1200-1453)" ;
@@ -2698,7 +2698,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/crusader-byzantine-seljuq-middle-east> ;
-    skos:altLabel "Crusader/Byzantine/Seljuq"@eng-latn ;
+    skos:altLabel "Crusader/Byzantine/Seljuq"@eng-latn, "Crusader/Byzantine/Seljuq Middle East (AD 1081-1204)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Latin/1st-4th Crusades-end of Middle Byzantine-Rum/Seljuq", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Crusader/Byzantine/Seljuq Middle East (AD 1081-1204)" ;
@@ -2721,7 +2721,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Palestine> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-age-southern-levant> ;
-    skos:altLabel "Middle Bronze Age"@eng-latn ;
+    skos:altLabel "Middle Bronze Age"@eng-latn, "Middle Bronze Age Southern Levant (2000-1400 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "southern Levant" ;
     skos:prefLabel "Middle Bronze Age Southern Levant (2000-1400 BC)" ;
@@ -2743,7 +2743,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-geometric> ;
-    skos:altLabel "Early Geometric"@eng-latn ;
+    skos:altLabel "Early Geometric"@eng-latn, "Early Geometric (Greek; 900-850 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Early Geometric period in ancient Greece, from 900-850 before the birth of Christ." ;
     skos:prefLabel "Early Geometric (Greek; 900-850 BC)" ;
@@ -2766,7 +2766,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/old-babylonian-assyrian-mesopotamia> ;
-    skos:altLabel "Old Babylonian/Assyrian"@eng-latn ;
+    skos:altLabel "Old Babylonian/Assyrian"@eng-latn, "Old Babylonian/Assyrian Mesopotamia (2000-1600 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Mesopotamia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Old Babylonian/Assyrian Mesopotamia (2000-1600 BC)" ;
@@ -2789,7 +2789,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Kuwait>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ottoman-decline-mandate-middle-east> ;
-    skos:altLabel "Ottoman Decline-Mandate"@eng-latn ;
+    skos:altLabel "Ottoman Decline-Mandate"@eng-latn, "Ottoman Decline-Mandate Middle East (AD 1900-1950)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Ottoman Decline-Mandate Middle East (AD 1900-1950)" ;
@@ -2812,7 +2812,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ubaid> ;
-    skos:altLabel "Ubaid"@eng-latn ;
+    skos:altLabel "Ubaid"@eng-latn, "Ubaid period in Mesopotamia (ca. 6500 to 3800 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The prehistoric Ubaid period of Mesopotamia, as defined by Wikipedia following Carter, Robert A. and Philip, Graham Beyond the Ubaid: Transformation and Integration in the Late Prehistoric Societies of the Middle East (Studies in Ancient Oriental Civilization, Number 63) The Oriental Institute of the University of Chicago (2010) ISBN 978-1-885923-66-0 p.2, at http://oi.uchicago.edu/research/pubs/catalog/saoc/saoc63.html" ;
     skos:prefLabel "Ubaid period in Mesopotamia (ca. 6500 to 3800 BC)" ;
@@ -2835,7 +2835,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/rum-crusader-anatolia> ;
-    skos:altLabel "Rum/Crusader"@eng-latn ;
+    skos:altLabel "Rum/Crusader"@eng-latn, "Rum/Crusader Anatolia (AD 1077-1307)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Seljuk-Latin States/Francocracy", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Rum/Crusader Anatolia (AD 1077-1307)" ;
@@ -2858,7 +2858,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Lebanon> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/13th-century-ad-eastern-mediterranean> ;
-    skos:altLabel "13th Century AD"@eng-latn ;
+    skos:altLabel "13th Century AD"@eng-latn, "13th Century AD Eastern Mediterranean (AD 1200-1300)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Late Byzantine-Ayyubid-Mamluk Western Middle East", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "13th Century AD Eastern Mediterranean (AD 1200-1300)" ;
@@ -2881,7 +2881,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-helladic> ;
-    skos:altLabel "Late Helladic"@eng-latn ;
+    skos:altLabel "Late Helladic"@eng-latn, "Late Helladic (Mainland Greece; 1600-1200 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Late Helladic period in the Greek mainland, after Preziosi and Hitchcock, Aegean Art and Architecture, Oxford History of Art, 1998." ;
     skos:prefLabel "Late Helladic (Mainland Greece; 1600-1200 BC)" ;
@@ -2904,7 +2904,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Azerbaijan>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Djibouti>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Kuwait>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/modern-middle-east> ;
-    skos:altLabel "Modern"@eng-latn ;
+    skos:altLabel "Modern"@eng-latn, "Modern Middle East (AD 1918-2000)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Modern Middle East (AD 1918-2000)" ;
@@ -2927,7 +2927,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/sassanian-middle-east> ;
-    skos:altLabel "Sassanian"@eng-latn ;
+    skos:altLabel "Sassanian"@eng-latn, "Sassanian Middle East (AD 262-700)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Sassanid", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Sassanian Middle East (AD 262-700)" ;
@@ -2950,7 +2950,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-dynastic-mesopotamia> ;
-    skos:altLabel "Early Dynastic"@eng-latn ;
+    skos:altLabel "Early Dynastic"@eng-latn, "Early Dynastic Mesopotamia (2950-2350 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Mesopotamia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Early Dynastic Mesopotamia (2950-2350 BC)" ;
@@ -2973,7 +2973,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middleminoan> ;
-    skos:altLabel "Middle Minoan"@eng-latn ;
+    skos:altLabel "Middle Minoan"@eng-latn, "Middle Minoan (Crete; 2000-1600 BC/BCE)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Middle Minoan period on Crete, as defined in C. Shelmerdine, The Cambridge Companion to the Aegean Bronze Age (2008), p. 4, figure 1.1." ;
     skos:prefLabel "Middle Minoan (Crete; 2000-1600 BC/BCE)" ;
@@ -2996,7 +2996,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/fatimid-middle-east> ;
-    skos:altLabel "Fatimid"@eng-latn ;
+    skos:altLabel "Fatimid"@eng-latn, "Fatimid Middle East (AD 950-1150)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "Western ME, northern Africa" ;
     skos:prefLabel "Fatimid Middle East (AD 950-1150)" ;
@@ -3019,7 +3019,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/chalcolithic-mesopotamia> ;
-    skos:altLabel "Chalcolithic"@eng-latn ;
+    skos:altLabel "Chalcolithic"@eng-latn, "Chalcolithic Mesopotamia (6200-3750 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Copper Age Mesopotamia, Halaf-Ubaid-Early Uruk Mesopotamia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Chalcolithic Mesopotamia (6200-3750 BC)" ;
@@ -3042,7 +3042,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neo-hittite-northern-levant> ;
-    skos:altLabel "Neo-Hittite"@eng-latn ;
+    skos:altLabel "Neo-Hittite"@eng-latn, "Neo-Hittite Northern Levant (1200-700 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "Syro-Hittite Northern Levant" ;
     skos:prefLabel "Neo-Hittite Northern Levant (1200-700 BC)" ;
@@ -3065,7 +3065,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/persian-medieval-caucasus> ;
-    skos:altLabel "Persian-Medieval"@eng-latn ;
+    skos:altLabel "Persian-Medieval"@eng-latn, "Persian-Medieval Caucasus (AD 600-1500)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Persian-Arabic-Early Medieval-Middle Medieval-Turco-Mongol/Late Medieval Caucasus", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Persian-Medieval Caucasus (AD 600-1500)" ;
@@ -3110,7 +3110,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neolithic-eastern-med> ;
-    skos:altLabel "Neolithic"@eng-latn ;
+    skos:altLabel "Neolithic"@eng-latn, "Neolithic Period in the Eastern Mediterranean (ca. 10,000-3,300 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The so-called \"Neolithic\" or \"New Stone Age\" period as defined in the Eastern portion of the Mediterranean basin, lasting roughly from 10,000 - 3,300 BC. See further: http://ancienthistory.about.com/od/artarchaeologyarchitect/g/neolithic.htm" ;
     skos:prefLabel "Neolithic Period in the Eastern Mediterranean (ca. 10,000-3,300 BC)" ;
@@ -3133,7 +3133,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Palestine> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-middle-bronze-age-iran> ;
-    skos:altLabel "Early-Middle Bronze Age"@eng-latn ;
+    skos:altLabel "Early-Middle Bronze Age"@eng-latn, "Early-Middle Bronze Age Iran (2500-1500 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Iran", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Early-Middle Bronze Age Iran (2500-1500 BC)" ;
@@ -3156,7 +3156,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neo-assyrian-babylonian-middle-east> ;
-    skos:altLabel "Neo-Assyrian/Babylonian"@eng-latn ;
+    skos:altLabel "Neo-Assyrian/Babylonian"@eng-latn, "Neo-Assyrian/Babylonian Middle East (720-540 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Neo-Assyrian/Babylonian Middle East (720-540 BC)" ;
@@ -3179,7 +3179,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/first-intermediate-period-egypt> ;
-    skos:altLabel "First Intermediate Period"@eng-latn ;
+    skos:altLabel "First Intermediate Period"@eng-latn, "First Intermediate Period Egypt (2168-2010 BCE/BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The First Intermediate Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "First Intermediate Period Egypt (2168-2010 BCE/BC)" ;
@@ -3202,7 +3202,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/macedonian-egypt> ;
-    skos:altLabel "Macedonian"@eng-latn ;
+    skos:altLabel "Macedonian"@eng-latn, "Macedonian Egypt (332-304 BCE/BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Macedonian period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Macedonian Egypt (332-304 BCE/BC)" ;
@@ -3224,7 +3224,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Albania>, <http://dbpedia.org/resource/Algeria>, <http://dbpedia.org/resource/Andorra>, <http://dbpedia.org/resource/Armenia>, <http://dbpedia.org/resource/Austria>, <http://dbpedia.org/resource/Azerbaijan>, <http://dbpedia.org/resource/Bahrain>, <http://dbpedia.org/resource/Bangladesh>, <http://dbpedia.org/resource/Belgium>, <http://dbpedia.org/resource/Bosnia_and_Herzegovina>, <http://dbpedia.org/resource/Bulgaria>, <http://dbpedia.org/resource/Burma>, <http://dbpedia.org/resource/China>, <http://dbpedia.org/resource/Croatia>, <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Czech_Republic>, <http://dbpedia.org/resource/Democratic_Republic_of_the_Congo>, <http://dbpedia.org/resource/Denmark>, <http://dbpedia.org/resource/Djibouti>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Eritrea>, <http://dbpedia.org/resource/Ethiopia>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Gibraltar>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Guernsey>, <http://dbpedia.org/resource/Hungary>, <http://dbpedia.org/resource/India>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Ireland>, <http://dbpedia.org/resource/Isle_of_Man>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Kazakhstan>, <http://dbpedia.org/resource/Kenya>, <http://dbpedia.org/resource/Kosovo>, <http://dbpedia.org/resource/Kuwait>, <http://dbpedia.org/resource/Kyrgyzstan>, <http://dbpedia.org/resource/Latvia>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Libya>, <http://dbpedia.org/resource/Liechtenstein>, <http://dbpedia.org/resource/Lithuania>, <http://dbpedia.org/resource/Luxembourg>, <http://dbpedia.org/resource/Malta>, <http://dbpedia.org/resource/Moldova>, <http://dbpedia.org/resource/Monaco>, <http://dbpedia.org/resource/Montenegro>, <http://dbpedia.org/resource/Morocco>, <http://dbpedia.org/resource/Nepal>, <http://dbpedia.org/resource/Netherlands>, <http://dbpedia.org/resource/Norway>, <http://dbpedia.org/resource/Oman>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Poland>, <http://dbpedia.org/resource/Portugal>, <http://dbpedia.org/resource/Republic_of_Macedonia>, <http://dbpedia.org/resource/Republic_of_the_Congo>, <http://dbpedia.org/resource/Romania>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Serbia>, <http://dbpedia.org/resource/Slovakia>, <http://dbpedia.org/resource/Slovenia>, <http://dbpedia.org/resource/Somalia>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Sri_Lanka>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Sweden>, <http://dbpedia.org/resource/Switzerland>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Tajikistan>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Turkmenistan>, <http://dbpedia.org/resource/Uganda>, <http://dbpedia.org/resource/Ukraine>, <http://dbpedia.org/resource/United_Arab_Emirates>, <http://dbpedia.org/resource/United_Kingdom>, <http://dbpedia.org/resource/Uzbekistan>, <http://dbpedia.org/resource/Vatican_City>, <http://dbpedia.org/resource/Yemen> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/roman> ;
-    skos:altLabel " early Empire"@eng-latn, "Roman"@eng-latn, "Roman, early Empire"@eng-latn ;
+    skos:altLabel " early Empire"@eng-latn, "Roman"@eng-latn, "Roman, early Empire"@eng-latn, "Roman, early Empire (30 BC-AD 300)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Roman period (i.e., the early Roman Empire) in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 30 before the birth of Christ and to end in the year 300 after the birth of Christ." ;
     skos:prefLabel "Roman, early Empire (30 BC-AD 300)" ;
@@ -3247,7 +3247,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/iron-age-southern-levant> ;
-    skos:altLabel "Iron Age"@eng-latn ;
+    skos:altLabel "Iron Age"@eng-latn, "Iron Age Southern Levant"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Iron Age Southern Levant" ;
@@ -3270,7 +3270,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Palestine>, <http://dbpedia.org/resource/Saudi_Arabia>, <http://dbpedia.org/resource/Sudan>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/roman-early-empire-parthian-middle-east> ;
-    skos:altLabel "Roman Early Empire/Parthian"@eng-latn ;
+    skos:altLabel "Roman Early Empire/Parthian"@eng-latn, "Roman Early Empire/Parthian Middle East (30 BC - AD 226)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Early Roman/Parthian", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Roman Early Empire/Parthian Middle East (30 BC - AD 226)" ;
@@ -3293,7 +3293,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/paleolithic-middle-east> ;
-    skos:altLabel "Paleolithic"@eng-latn ;
+    skos:altLabel "Paleolithic"@eng-latn, "Paleolithic Middle East (2600000-18000 BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Paleolithic Middle East (2600000-18000 BC)" ;
@@ -3316,7 +3316,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/predynastic-egypt> ;
-    skos:altLabel "Predynastic"@eng-latn ;
+    skos:altLabel "Predynastic"@eng-latn, "Predynastic Egypt (4500-2950 BCE/BC)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The predynastic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Predynastic Egypt (4500-2950 BCE/BC)" ;
@@ -3339,7 +3339,7 @@
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Sudan> ;
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/second-intermediate-period-egypt> ;
-    skos:altLabel "Second Intermediate"@eng-latn ;
+    skos:altLabel "Second Intermediate"@eng-latn, "Second Intermediate Period Egypt (1640-1548)"@eng-latn ;
     skos:inScheme <p03wskd> ;
     skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Second Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Second Intermediate Period Egypt (1640-1548)" ;
@@ -3466,7 +3466,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Susa II"@eng-latn ;
+    skos:altLabel "Susa II"@eng-latn, "Susa II archaeological period"@eng-latn ;
     skos:inScheme <p047fhm> ;
     skos:note "Prehistoric Susa II, corresponds to Mesopotamian Ubaid period.", "unsure why listed in GeoDia with dates 3700-3500 B.C." ;
     skos:prefLabel "Susa II archaeological period" ;
@@ -3539,7 +3539,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Susa I"@eng-latn ;
+    skos:altLabel "Susa I"@eng-latn, "Susa I archaeological period"@eng-latn ;
     skos:inScheme <p047fhm> ;
     skos:note "GeoDia listed the two archaeological periods of Susa I (4200-3700 B.C.) and Susa II (3700-3500 B.C.).", "This period designates prehistoric Susa and corresponds to Ubaid period in Mesopotamia." ;
     skos:prefLabel "Susa I archaeological period" ;
@@ -3948,7 +3948,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Proto-Elamite"@eng-latn, "Protoliterate"@eng-latn ;
+    skos:altLabel "Proto-Elamite"@eng-latn, "Protoliterate"@eng-latn, "Protoliterate: Proto-Elamite"@eng-latn ;
     skos:inScheme <p047fhm> ;
     skos:note "Listed as historic period, not archaeological period.", "This period corresponds to Proto-Literate period in Mesopotamia." ;
     skos:prefLabel "Protoliterate: Proto-Elamite" ;
@@ -4025,7 +4025,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "Geometric"@eng-latn ;
+    skos:altLabel "Geometric"@eng-latn, "Geometric Period"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "Geometric Period" ;
     time:intervalFinishedBy [
@@ -4098,7 +4098,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "Hellenistic"@eng-latn ;
+    skos:altLabel "Hellenistic"@eng-latn, "Hellenistic Period"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "Hellenistic Period" ;
     time:intervalFinishedBy [
@@ -4146,7 +4146,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "Archaic"@eng-latn ;
+    skos:altLabel "Archaic"@eng-latn, "Archaic Period"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "Archaic Period" ;
     time:intervalFinishedBy [
@@ -4170,7 +4170,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "Frankish"@eng-latn ;
+    skos:altLabel "Frankish"@eng-latn, "Frankish Period"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "Frankish Period" ;
     time:intervalFinishedBy [
@@ -4266,7 +4266,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "Dark Age"@eng-latn, "Submycenaean and Early Iron Age"@eng-latn ;
+    skos:altLabel "Dark Age"@eng-latn, "Submycenaean and Early Iron Age"@eng-latn, "Submycenaean and Early Iron Age or Dark Age"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "Submycenaean and Early Iron Age or Dark Age" ;
     time:intervalFinishedBy [
@@ -4363,7 +4363,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "Late Roman"@eng-latn ;
+    skos:altLabel "Late Roman"@eng-latn, "Late Roman Period"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "Late Roman Period" ;
     time:intervalFinishedBy [
@@ -4411,7 +4411,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "Classical"@eng-latn ;
+    skos:altLabel "Classical"@eng-latn, "Classical Period"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "Classical Period" ;
     time:intervalFinishedBy [
@@ -4435,7 +4435,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "Second Ottoman"@eng-latn ;
+    skos:altLabel "Second Ottoman"@eng-latn, "Second Ottoman Period"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "Second Ottoman Period" ;
     time:intervalFinishedBy [
@@ -4557,7 +4557,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "Late Byzantine"@eng-latn ;
+    skos:altLabel "Late Byzantine"@eng-latn, "Late Byzantine Period"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "Late Byzantine Period" ;
     time:intervalFinishedBy [
@@ -4581,7 +4581,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "Early Byzantine"@eng-latn ;
+    skos:altLabel "Early Byzantine"@eng-latn, "Early Byzantine Period"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "Early Byzantine Period" ;
     time:intervalFinishedBy [
@@ -4605,7 +4605,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "First Ottoman"@eng-latn, "Turkish Messenia"@eng-latn ;
+    skos:altLabel "First Ottoman"@eng-latn, "First Ottoman Period"@eng-latn, "Turkish Messenia"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "First Ottoman Period" ;
     time:intervalFinishedBy [
@@ -4653,7 +4653,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "Roman"@eng-latn ;
+    skos:altLabel "Roman"@eng-latn, "Roman Period"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "Roman Period" ;
     time:intervalFinishedBy [
@@ -4725,7 +4725,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Messenia> ;
     a skos:Concept ;
-    skos:altLabel "Upper Palaeolithic"@eng-latn ;
+    skos:altLabel "Upper Palaeolithic"@eng-latn, "Upper Paleolithic"@eng-latn ;
     skos:inScheme <p05krdx> ;
     skos:prefLabel "Upper Paleolithic" ;
     time:intervalFinishedBy [
@@ -4777,7 +4777,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Italy> ;
     a skos:Concept ;
-    skos:altLabel "Flavians"@eng-latn ;
+    skos:altLabel "Flavians"@eng-latn, "The Flavians"@eng-latn ;
     skos:inScheme <p05xnzq> ;
     skos:prefLabel "The Flavians" ;
     time:intervalFinishedBy [
@@ -4801,7 +4801,7 @@
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Italy> ;
     a skos:Concept ;
-    skos:altLabel "Severans"@eng-latn ;
+    skos:altLabel "Severans"@eng-latn, "The Severans"@eng-latn ;
     skos:inScheme <p05xnzq> ;
     skos:prefLabel "The Severans" ;
     time:intervalFinishedBy [
@@ -5206,7 +5206,7 @@
 <p06v8w44bj2>
     dcterms:spatial <http://dbpedia.org/resource/Kosovo> ;
     a skos:Concept ;
-    skos:altLabel "Classic illyrian"@eng-latn, "Urban illyrian"@eng-latn ;
+    skos:altLabel "Classic illyrian"@eng-latn, "Classic/Urban illyrian"@eng-latn, "Urban illyrian"@eng-latn ;
     skos:inScheme <p06v8w4> ;
     skos:prefLabel "Classic/Urban illyrian" ;
     time:intervalFinishedBy [
@@ -5226,7 +5226,7 @@
 <p06v8w44ckn>
     dcterms:spatial <http://dbpedia.org/resource/Slovenia> ;
     a skos:Concept ;
-    skos:altLabel "Contemporary"@eng-latn ;
+    skos:altLabel "Contemporary"@eng-latn, "Contermporary"@eng-latn ;
     skos:inScheme <p06v8w4> ;
     skos:prefLabel "Contermporary" ;
     time:intervalFinishedBy [
@@ -5761,7 +5761,7 @@
 <p06v8w47m8h>
     dcterms:spatial <http://dbpedia.org/resource/Kosovo> ;
     a skos:Concept ;
-    skos:altLabel "Archaic illyrian"@eng-latn, "Protourban illyrian"@eng-latn ;
+    skos:altLabel "Archaic illyrian"@eng-latn, "Archaic/Protourban illyrian"@eng-latn, "Protourban illyrian"@eng-latn ;
     skos:inScheme <p06v8w4> ;
     skos:prefLabel "Archaic/Protourban illyrian" ;
     time:intervalFinishedBy [
@@ -6041,7 +6041,7 @@
 <p06v8w4b3x6>
     dcterms:spatial <http://dbpedia.org/resource/Serbia> ;
     a skos:Concept ;
-    skos:altLabel "Classic illyrian"@eng-latn, "Urban illyrian"@eng-latn ;
+    skos:altLabel "Classic illyrian"@eng-latn, "Classic/Urban illyrian"@eng-latn, "Urban illyrian"@eng-latn ;
     skos:inScheme <p06v8w4> ;
     skos:prefLabel "Classic/Urban illyrian" ;
     time:intervalFinishedBy [
@@ -6969,7 +6969,7 @@
 <p06v8w4j9dh>
     dcterms:spatial <http://dbpedia.org/resource/Serbia> ;
     a skos:Concept ;
-    skos:altLabel "Archaic illyrian"@eng-latn, "Protourban illyrian"@eng-latn ;
+    skos:altLabel "Archaic illyrian"@eng-latn, "Archaic/Protourban illyrian"@eng-latn, "Protourban illyrian"@eng-latn ;
     skos:inScheme <p06v8w4> ;
     skos:prefLabel "Archaic/Protourban illyrian" ;
     time:intervalFinishedBy [
@@ -8836,7 +8836,7 @@
 <p06v8w4xdt8>
     dcterms:spatial <http://dbpedia.org/resource/Serbia> ;
     a skos:Concept ;
-    skos:altLabel "Byzantine"@eng-latn, "Medieval"@eng-latn ;
+    skos:altLabel "Byzantine"@eng-latn, "Medieval"@eng-latn, "Medieval/Byzantine"@eng-latn ;
     skos:inScheme <p06v8w4> ;
     skos:prefLabel "Medieval/Byzantine" ;
     time:intervalFinishedBy [
@@ -9103,7 +9103,7 @@
     periodo:spatialCoverageDescription "Catalan area" ;
     dcterms:spatial <http://dbpedia.org/resource/Spain> ;
     a skos:Concept ;
-    skos:altLabel "Early Iberian"@eng-latn ;
+    skos:altLabel "Early Iberian"@eng-latn, "Early Iberian Period"@eng-latn ;
     skos:inScheme <p06xc6m> ;
     skos:prefLabel "Early Iberian Period" ;
     time:intervalFinishedBy [
@@ -9123,7 +9123,7 @@
     periodo:spatialCoverageDescription "Catalan area" ;
     dcterms:spatial <http://dbpedia.org/resource/Spain> ;
     a skos:Concept ;
-    skos:altLabel "Classical Iberian"@eng-latn ;
+    skos:altLabel "Classical Iberian"@eng-latn, "Classical Iberian Period"@eng-latn ;
     skos:inScheme <p06xc6m> ;
     skos:note "Equivalent to Iberian III (450-350 B.C.) and IV (350-200 B.C.) - cf. M. Diaz-Andreu & S. Keay, 1997. The Archaeology of Iberia; Dominguez in C. Sanchez & G.R. Tsetskhladze, 2001. Greek Pottery from the Iberian Peninsula." ;
     skos:prefLabel "Classical Iberian Period" ;
@@ -10490,7 +10490,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Crete> ;
     a skos:Concept ;
-    skos:altLabel "Old Palace"@eng-latn, "Protopalatial"@eng-latn ;
+    skos:altLabel "Old Palace"@eng-latn, "Old Palace (Protopalatial)"@eng-latn, "Protopalatial"@eng-latn ;
     skos:inScheme <p083p5r> ;
     skos:note "\"(= Middle Minoan IB)\"" ;
     skos:prefLabel "Old Palace (Protopalatial)" ;
@@ -10588,7 +10588,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Iran> ;
     a skos:Concept ;
-    skos:altLabel "Archaemenid"@eng-latn ;
+    skos:altLabel "Achaemenids"@eng-latn, "Archaemenid"@eng-latn ;
     skos:inScheme <p083p5r> ;
     skos:note "Gates discusses only the Achaemenids in Persia proper in this chapter." ;
     skos:prefLabel "Achaemenids" ;
@@ -10929,7 +10929,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Lazio> ;
     a skos:Concept ;
-    skos:altLabel "Etruscan"@eng-latn ;
+    skos:altLabel "Etruscan"@eng-latn, "Etruscan rule"@eng-latn ;
     skos:inScheme <p083p5r> ;
     skos:prefLabel "Etruscan rule" ;
     time:intervalFinishedBy [
@@ -11217,7 +11217,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Late Bronze Age"@eng-latn, "Late Cypriot"@eng-latn ;
+    skos:altLabel "Late Bronze Age"@eng-latn, "Late Bronze Age (= Late Cypriot)"@eng-latn, "Late Cypriot"@eng-latn ;
     skos:inScheme <p083p5r> ;
     skos:prefLabel "Late Bronze Age (= Late Cypriot)" ;
     time:intervalFinishedBy [
@@ -11387,7 +11387,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Crete> ;
     a skos:Concept ;
-    skos:altLabel "Neopalatial"@eng-latn, "New Palace"@eng-latn ;
+    skos:altLabel "Neopalatial"@eng-latn, "New Palace"@eng-latn, "New Palace (Neopalatial)"@eng-latn ;
     skos:inScheme <p083p5r> ;
     skos:note "\"(= Middle Minoan III, Late Minoan IA and B)\"" ;
     skos:prefLabel "New Palace (Neopalatial)" ;
@@ -11557,7 +11557,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel "Protoliterate"@eng-latn, "Uruk"@eng-latn ;
+    skos:altLabel "Protoliterate"@eng-latn, "Protoliterate (Uruk)"@eng-latn, "Uruk"@eng-latn ;
     skos:inScheme <p083p5r> ;
     skos:prefLabel "Protoliterate (Uruk)" ;
     time:intervalFinishedBy [
@@ -11581,7 +11581,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
-    skos:altLabel "Archaic"@eng-latn, "Early Dynastic"@eng-latn ;
+    skos:altLabel "Archaic"@eng-latn, "Early Dynastic"@eng-latn, "Early Dynastic (Archaic)"@eng-latn ;
     skos:inScheme <p083p5r> ;
     skos:prefLabel "Early Dynastic (Archaic)" ;
     time:intervalFinishedBy [
@@ -11629,7 +11629,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Early Archaic"@eng-latn, "Orientalizing"@eng-latn ;
+    skos:altLabel "Early Archaic"@eng-latn, "Orientalizing"@eng-latn, "Orientalizing (Early Archaic)"@eng-latn ;
     skos:inScheme <p083p5r> ;
     skos:note "Gates discusses Greek cities that are now in the territory of Turkey, although he does not refer to Anatolia specifically." ;
     skos:prefLabel "Orientalizing (Early Archaic)" ;
@@ -11654,7 +11654,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/India>, <http://dbpedia.org/resource/Pakistan> ;
     a skos:Concept ;
-    skos:altLabel "Harappan"@eng-latn ;
+    skos:altLabel "Harappan"@eng-latn, "Harappan, or Mature"@eng-latn ;
     skos:inScheme <p083p5r> ;
     skos:note "Indus Valley is defined as \"a region now situated in modern Pakistan and north-west India\"" ;
     skos:prefLabel "Harappan, or Mature" ;
@@ -11773,7 +11773,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9235v>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "British"@eng-latn ;
+    skos:altLabel "British"@eng-latn, "British 1763-1783"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "British 1763-1783" ;
@@ -11794,7 +11794,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj924nt>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "18th Century::3rd quarter"@eng-latn ;
+    skos:altLabel "18th Century::3rd quarter"@eng-latn, "18th Century::3rd quarter (1750 - 1774)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "18th Century::3rd quarter (1750 - 1774)" ;
@@ -11941,7 +11941,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj92hb4>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Glades II"@eng-latn ;
+    skos:altLabel "Glades II"@eng-latn, "Glades II, A.D. 750-1200"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Glades II, A.D. 750-1200" ;
@@ -12088,7 +12088,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj92szg>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Glades III"@eng-latn ;
+    skos:altLabel "Glades III"@eng-latn, "Glades III, A.D. 1000-1700"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Glades III, A.D. 1000-1700" ;
@@ -12214,7 +12214,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj932pt>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Indian Pond"@eng-latn ;
+    skos:altLabel "Indian Pond"@eng-latn, "Indian Pond A.D. 950-contact"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Indian Pond A.D. 950-contact" ;
@@ -12361,7 +12361,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj93btj>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "18th Century::1st half"@eng-latn ;
+    skos:altLabel "18th Century::1st half"@eng-latn, "18th Century::1st half (1700 - 1749)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "18th Century::1st half (1700 - 1749)" ;
@@ -12382,7 +12382,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj93gmq>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Paleoindian"@eng-latn ;
+    skos:altLabel "Paleoindian"@eng-latn, "Paleoindian, 10000 B.C.-8500 B.C."@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Paleoindian, 10000 B.C.-8500 B.C." ;
@@ -12424,7 +12424,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj93hq2>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "WW I & Aftermath"@eng-latn ;
+    skos:altLabel "WW I & Aftermath"@eng-latn, "WW I & Aftermath 1917-1920"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "WW I & Aftermath 1917-1920" ;
@@ -12697,7 +12697,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj946k9>
     dcterms:spatial <http://www.geonames.org/4398678> ;
     a skos:Concept ;
-    skos:altLabel "Antebellum"@eng-latn ;
+    skos:altLabel "Antebellum"@eng-latn, "Antebellum (1821-1861)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA34" ;
     skos:prefLabel "Antebellum (1821-1861)" ;
@@ -12760,7 +12760,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj948gv>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "18th Century::2nd quarter"@eng-latn ;
+    skos:altLabel "18th Century::2nd quarter"@eng-latn, "18th Century::2nd quarter (1725 - 1749)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "18th Century::2nd quarter (1725 - 1749)" ;
@@ -12823,7 +12823,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj94c64>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "19th Century::4th quarter"@eng-latn ;
+    skos:altLabel "19th Century::4th quarter"@eng-latn, "19th Century::4th quarter (1875 - 1899)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "19th Century::4th quarter (1875 - 1899)" ;
@@ -12865,7 +12865,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj94dk3>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "19th Century::1st half"@eng-latn ;
+    skos:altLabel "19th Century::1st half"@eng-latn, "19th Century::1st half (1800 - 1849)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "19th Century::1st half (1800 - 1849)" ;
@@ -12907,7 +12907,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj94mbh>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "20th Century::2nd half"@eng-latn ;
+    skos:altLabel "20th Century::2nd half"@eng-latn, "20th Century::2nd half (1950 - 1999)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "20th Century::2nd half (1950 - 1999)" ;
@@ -12928,7 +12928,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj94nmg>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "20th Century::1st quarter"@eng-latn ;
+    skos:altLabel "20th Century::1st quarter"@eng-latn, "20th Century::1st quarter (1900 - 1924)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "20th Century::1st quarter (1900 - 1924)" ;
@@ -12949,7 +12949,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj94pwf>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Post-Reconstruction"@eng-latn ;
+    skos:altLabel "Post-Reconstruction"@eng-latn, "Post-Reconstruction 1880-1897"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Post-Reconstruction 1880-1897" ;
@@ -13180,7 +13180,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj95c6c>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Statehood & Antebellum"@eng-latn ;
+    skos:altLabel "Statehood & Antebellum"@eng-latn, "Statehood & Antebellum 1845-1860"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Statehood & Antebellum 1845-1860" ;
@@ -13222,7 +13222,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj95kss>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "17th Century::2nd quarter"@eng-latn ;
+    skos:altLabel "17th Century::2nd quarter"@eng-latn, "17th Century::2nd quarter (1625 - 1649)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "17th Century::2nd quarter (1625 - 1649)" ;
@@ -13783,7 +13783,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj96z3n>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Early Woodland"@eng-latn ;
+    skos:altLabel "Early Woodland"@eng-latn, "Early Woodland (1200 B.C. - 299 A.D.)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Early Woodland (1200 B.C. - 299 A.D.)" ;
@@ -14098,7 +14098,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj97wnn>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "19th Century::3rd quarter"@eng-latn ;
+    skos:altLabel "19th Century::3rd quarter"@eng-latn, "19th Century::3rd quarter (1850 - 1874)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "19th Century::3rd quarter (1850 - 1874)" ;
@@ -14182,7 +14182,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj983gf>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "The New Dominion"@eng-latn ;
+    skos:altLabel "The New Dominion"@eng-latn, "The New Dominion (1946 - 1988)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "The New Dominion (1946 - 1988)" ;
@@ -14308,7 +14308,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj98d84>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "St. Johns"@eng-latn ;
+    skos:altLabel "St. Johns"@eng-latn, "St. Johns, 700 B.C.-A.D. 1500"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "St. Johns, 700 B.C.-A.D. 1500" ;
@@ -14350,7 +14350,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj98fpd>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Woodland"@eng-latn ;
+    skos:altLabel "Woodland"@eng-latn, "Woodland (1200 B.C. - 1606 A.D.)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Woodland (1200 B.C. - 1606 A.D.)" ;
@@ -14392,7 +14392,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj98jxm>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Reconstruction"@eng-latn ;
+    skos:altLabel "Reconstruction"@eng-latn, "Reconstruction 1866-1879"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Reconstruction 1866-1879" ;
@@ -14602,7 +14602,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj98vgx>
     dcterms:spatial <http://www.geonames.org/4398678> ;
     a skos:Concept ;
-    skos:altLabel "Territorial"@eng-latn ;
+    skos:altLabel "Territorial"@eng-latn, "Territorial (1804-1820)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA17" ;
     skos:prefLabel "Territorial (1804-1820)" ;
@@ -14623,7 +14623,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj98vq9>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel " 2nd War to 3rd"@eng-latn, "Seminole"@eng-latn, "Seminole, 2nd War to 3rd"@eng-latn ;
+    skos:altLabel " 2nd War to 3rd"@eng-latn, "Seminole"@eng-latn, "Seminole, 2nd War to 3rd"@eng-latn, "Seminole, 2nd War to 3rd 1835-1855"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Seminole, 2nd War to 3rd 1835-1855" ;
@@ -14707,7 +14707,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9947n>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "17th Century::4th quarter"@eng-latn ;
+    skos:altLabel "17th Century::4th quarter"@eng-latn, "17th Century::4th quarter (1675 - 1699)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "17th Century::4th quarter (1675 - 1699)" ;
@@ -14749,7 +14749,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj996ck>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "WW II & Aftermath"@eng-latn ;
+    skos:altLabel "WW II & Aftermath"@eng-latn, "WW II & Aftermath 1941-1950"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "WW II & Aftermath 1941-1950" ;
@@ -14770,7 +14770,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj997fj>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Belle Glade"@eng-latn ;
+    skos:altLabel "Belle Glade"@eng-latn, "Belle Glade, 700 B.C.-A.D. 1700"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Belle Glade, 700 B.C.-A.D. 1700" ;
@@ -14791,7 +14791,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj997h7>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "17th Century::1st half"@eng-latn ;
+    skos:altLabel "17th Century::1st half"@eng-latn, "17th Century::1st half (1600 - 1649)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "17th Century::1st half (1600 - 1649)" ;
@@ -14812,7 +14812,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj998dh>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel " 1st War to 2nd"@eng-latn, "Seminole"@eng-latn, "Seminole, 1st War to 2nd"@eng-latn ;
+    skos:altLabel " 1st War to 2nd"@eng-latn, "Seminole"@eng-latn, "Seminole, 1st War to 2nd"@eng-latn, "Seminole, 1st War to 2nd 1817-1834"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Seminole, 1st War to 2nd 1817-1834" ;
@@ -14938,7 +14938,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj99m9g>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "American Acquisition & Development"@eng-latn ;
+    skos:altLabel "American Acquisition & Development"@eng-latn, "American Acquisition & Development 1821-45"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "American Acquisition & Development 1821-45" ;
@@ -15085,7 +15085,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj99vs7>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "18th Century::2nd/3rd quarter"@eng-latn ;
+    skos:altLabel "18th Century::2nd/3rd quarter"@eng-latn, "18th Century::2nd/3rd quarter (1725 - 1774)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "18th Century::2nd/3rd quarter (1725 - 1774)" ;
@@ -15190,7 +15190,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9b399>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "19th Century::2nd/3rd quarter"@eng-latn ;
+    skos:altLabel "19th Century::2nd/3rd quarter"@eng-latn, "19th Century::2nd/3rd quarter (1825 - 1874)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "19th Century::2nd/3rd quarter (1825 - 1874)" ;
@@ -15274,7 +15274,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9b8z4>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Swift Creek"@eng-latn ;
+    skos:altLabel "Swift Creek"@eng-latn, "Swift Creek, 300 B.C.-A.D. 450"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Swift Creek, 300 B.C.-A.D. 450" ;
@@ -15295,7 +15295,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9b92q>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "20th Century::2nd/3rd quarter"@eng-latn ;
+    skos:altLabel "20th Century::2nd/3rd quarter"@eng-latn, "20th Century::2nd/3rd quarter (1925 - 1974)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "20th Century::2nd/3rd quarter (1925 - 1974)" ;
@@ -15337,7 +15337,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9bcrz>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Cades Pond"@eng-latn ;
+    skos:altLabel "Cades Pond"@eng-latn, "Cades Pond 300 B.C.-A.D. 800"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Cades Pond 300 B.C.-A.D. 800" ;
@@ -15400,7 +15400,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9bj2s>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Manasota"@eng-latn ;
+    skos:altLabel "Manasota"@eng-latn, "Manasota, 700 B.C.-A.D. 700"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Manasota, 700 B.C.-A.D. 700" ;
@@ -15631,7 +15631,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9bzz2>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "18th Century::1st quarter"@eng-latn ;
+    skos:altLabel "18th Century::1st quarter"@eng-latn, "18th Century::1st quarter (1700 - 1724)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "18th Century::1st quarter (1700 - 1724)" ;
@@ -15652,7 +15652,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9c327>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Seminole"@eng-latn ;
+    skos:altLabel "Seminole"@eng-latn, "Seminole 1716-present"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Seminole 1716-present" ;
@@ -15757,7 +15757,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9c9vn>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Spanish-American War"@eng-latn ;
+    skos:altLabel "Spanish-American War"@eng-latn, "Spanish-American War 1898-1916"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Spanish-American War 1898-1916" ;
@@ -15820,7 +15820,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9ccn8>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel " 3rd War onward"@eng-latn, "Seminole"@eng-latn, "Seminole, 3rd War onward"@eng-latn ;
+    skos:altLabel " 3rd War onward"@eng-latn, "Seminole"@eng-latn, "Seminole, 3rd War onward"@eng-latn, "Seminole, 3rd War onward, 1856-"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Seminole, 3rd War onward, 1856-" ;
@@ -15967,7 +15967,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9cm7b>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "World War I to World War II"@eng-latn ;
+    skos:altLabel "World War I to World War II"@eng-latn, "World War I to World War II (1917 - 1945)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "World War I to World War II (1917 - 1945)" ;
@@ -16114,7 +16114,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9ctdr>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Contact Period"@eng-latn ;
+    skos:altLabel "Contact Period"@eng-latn, "Contact Period (1607 - 1750)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Contact Period (1607 - 1750)" ;
@@ -16345,7 +16345,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9d84m>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "20th Century"@eng-latn ;
+    skos:altLabel "20th Century"@eng-latn, "20th Century (1900 - 1999)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "20th Century (1900 - 1999)" ;
@@ -16492,7 +16492,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9dfv4>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Safety Harbor"@eng-latn ;
+    skos:altLabel "Safety Harbor"@eng-latn, "Safety Harbor, A.D. 1000-1500"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Safety Harbor, A.D. 1000-1500" ;
@@ -16807,7 +16807,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9fcmf>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Middle Archaic"@eng-latn ;
+    skos:altLabel "Middle Archaic"@eng-latn, "Middle Archaic (6500 - 3001 B.C.)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Middle Archaic (6500 - 3001 B.C.)" ;
@@ -16912,7 +16912,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9fnds>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "17th Century::1st quarter"@eng-latn ;
+    skos:altLabel "17th Century::1st quarter"@eng-latn, "17th Century::1st quarter (1600 - 1624)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "17th Century::1st quarter (1600 - 1624)" ;
@@ -16933,7 +16933,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9frv2>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "17th Century::2nd half"@eng-latn ;
+    skos:altLabel "17th Century::2nd half"@eng-latn, "17th Century::2nd half (1650 - 1699)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "17th Century::2nd half (1650 - 1699)" ;
@@ -17059,7 +17059,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9g4c9>
     dcterms:spatial <http://www.geonames.org/4398678> ;
     a skos:Concept ;
-    skos:altLabel "Colonial"@eng-latn ;
+    skos:altLabel "Colonial"@eng-latn, "Colonial (1700-1803)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA8" ;
     skos:prefLabel "Colonial (1700-1803)" ;
@@ -17185,7 +17185,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9gbmd>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "18th Century"@eng-latn ;
+    skos:altLabel "18th Century"@eng-latn, "18th Century (1700 - 1799)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "18th Century (1700 - 1799)" ;
@@ -17563,7 +17563,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9h55t>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "19th c. American"@eng-latn ;
+    skos:altLabel "19th c. American"@eng-latn, "Nineteenth C. American 1821-1899"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Nineteenth C. American 1821-1899" ;
@@ -17647,7 +17647,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9hk3q>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "17th Century"@eng-latn ;
+    skos:altLabel "17th Century"@eng-latn, "17th Century (1600 - 1699)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "17th Century (1600 - 1699)" ;
@@ -17710,7 +17710,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9hqsk>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Post Cold War"@eng-latn ;
+    skos:altLabel "Post Cold War"@eng-latn, "Post Cold War (1989 - Present)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Post Cold War (1989 - Present)" ;
@@ -17836,7 +17836,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9j3tt>
     dcterms:spatial <http://www.geonames.org/4398678> ;
     a skos:Concept ;
-    skos:altLabel "Emergent Miss."@eng-latn, "Terminal Late Woodland"@eng-latn ;
+    skos:altLabel "Emergent Miss."@eng-latn, "Terminal Late Woodland"@eng-latn, "Terminal Late Woodland (Emergent Miss.)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA16" ;
     skos:prefLabel "Terminal Late Woodland (Emergent Miss.)" ;
@@ -17899,7 +17899,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9j8fn>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Antebellum Period"@eng-latn ;
+    skos:altLabel "Antebellum Period"@eng-latn, "Antebellum Period (1830 - 1860)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Antebellum Period (1830 - 1860)" ;
@@ -17920,7 +17920,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9j8wz>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "20th c. American"@eng-latn ;
+    skos:altLabel "20th c. American"@eng-latn, "Twentieth C American"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Twentieth C American" ;
@@ -18109,7 +18109,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9jkgn>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Late Archaic"@eng-latn ;
+    skos:altLabel "Late Archaic"@eng-latn, "Late Archaic (3000 - 1201 B.C.)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Late Archaic (3000 - 1201 B.C.)" ;
@@ -18151,7 +18151,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9jn9k>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Civil War"@eng-latn ;
+    skos:altLabel "Civil War"@eng-latn, "Civil War (1861 - 1865)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Civil War (1861 - 1865)" ;
@@ -18172,7 +18172,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9jndk>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Seminole-Colonization Period"@eng-latn ;
+    skos:altLabel "Seminole-Colonization Period"@eng-latn, "Seminole-Colonization Period 1750-1816"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Seminole-Colonization Period 1750-1816" ;
@@ -18214,7 +18214,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9jqnh>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Early National Period"@eng-latn ;
+    skos:altLabel "Early National Period"@eng-latn, "Early National Period (1790 - 1829)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Early National Period (1790 - 1829)" ;
@@ -18298,7 +18298,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9jvw2>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Late Woodland"@eng-latn ;
+    skos:altLabel "Late Woodland"@eng-latn, "Late Woodland (1000 - 1606)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Late Woodland (1000 - 1606)" ;
@@ -18382,7 +18382,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9kft3>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "17th Century::3rd quarter"@eng-latn ;
+    skos:altLabel "17th Century::3rd quarter"@eng-latn, "17th Century::3rd quarter (1650 - 1674)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "17th Century::3rd quarter (1650 - 1674)" ;
@@ -18424,7 +18424,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9kh9n>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Glades I"@eng-latn ;
+    skos:altLabel "Glades I"@eng-latn, "Glades I, 1000 B.C.-A.D. 750"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Glades I, 1000 B.C.-A.D. 750" ;
@@ -18466,7 +18466,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9kkzk>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Transitional"@eng-latn ;
+    skos:altLabel "Transitional"@eng-latn, "Transitional, 1000 B.C.-700 B.C."@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Transitional, 1000 B.C.-700 B.C." ;
@@ -18592,7 +18592,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9kvs9>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Colony to Nation"@eng-latn ;
+    skos:altLabel "Colony to Nation"@eng-latn, "Colony to Nation (1751 - 1789)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Colony to Nation (1751 - 1789)" ;
@@ -18613,7 +18613,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9kwkk>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Ft. Walton"@eng-latn ;
+    skos:altLabel "Ft. Walton"@eng-latn, "Ft. Walton A.D. 1000-1500"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Ft. Walton A.D. 1000-1500" ;
@@ -18676,7 +18676,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9kxzj>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "20th Century::1st half"@eng-latn ;
+    skos:altLabel "20th Century::1st half"@eng-latn, "20th Century::1st half (1900 - 1949)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "20th Century::1st half (1900 - 1949)" ;
@@ -18739,7 +18739,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9m2fd>
     dcterms:spatial <http://www.geonames.org/4398678> ;
     a skos:Concept ;
-    skos:altLabel "Urban/Industrial"@eng-latn ;
+    skos:altLabel "Urban / Industrial (1900-1960)"@eng-latn, "Urban/Industrial"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA18" ;
     skos:prefLabel "Urban / Industrial (1900-1960)" ;
@@ -18802,7 +18802,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9m6nk>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "18th Century::2nd half"@eng-latn ;
+    skos:altLabel "18th Century::2nd half"@eng-latn, "18th Century::2nd half (1750 - 1799)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "18th Century::2nd half (1750 - 1799)" ;
@@ -19054,7 +19054,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9n5x7>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Boom Times"@eng-latn ;
+    skos:altLabel "Boom Times"@eng-latn, "Boom Times 1921-1929"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Boom Times 1921-1929" ;
@@ -19201,7 +19201,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9np4z>
     dcterms:spatial <http://www.geonames.org/4862182> ;
     a skos:Concept ;
-    skos:altLabel "1870-1930"@eng-latn ;
+    skos:altLabel "1870 - 1930"@eng-latn, "1870-1930"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/NW4KIRR95" ;
     skos:prefLabel "1870 - 1930" ;
@@ -19705,7 +19705,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9pr6h>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Modern"@eng-latn ;
+    skos:altLabel "Modern"@eng-latn, "Modern (Post 1950)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Modern (Post 1950)" ;
@@ -19789,7 +19789,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9pv4q>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "19th Century::1st quarter"@eng-latn ;
+    skos:altLabel "19th Century::1st quarter"@eng-latn, "19th Century::1st quarter (1800 - 1825)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "19th Century::1st quarter (1800 - 1825)" ;
@@ -19810,7 +19810,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9pxcn>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "19th Century::2nd half"@eng-latn ;
+    skos:altLabel "19th Century::2nd half"@eng-latn, "19th Century::2nd half (1850 - 1899)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "19th Century::2nd half (1850 - 1899)" ;
@@ -19831,7 +19831,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9q8fx>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "St. Johns II"@eng-latn ;
+    skos:altLabel "St. Johns II"@eng-latn, "St. Johns II, A.D. 800-1500"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "St. Johns II, A.D. 800-1500" ;
@@ -19978,7 +19978,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9qq6g>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Spanish-Second Period"@eng-latn ;
+    skos:altLabel "Spanish-Second Period"@eng-latn, "Spanish-Second Period 1783-1821"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Spanish-Second Period 1783-1821" ;
@@ -20062,7 +20062,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9qtfp>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Spanish-First Period"@eng-latn ;
+    skos:altLabel "Spanish-First Period"@eng-latn, "Spanish-First Period 1513-1763"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Spanish-First Period 1513-1763" ;
@@ -20104,7 +20104,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9qztj>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Prehistoric/Unknown"@eng-latn ;
+    skos:altLabel "Prehistoric/Unknown"@eng-latn, "Prehistoric/Unknown (15000 B.C. - 1606 A.D.)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Prehistoric/Unknown (15000 B.C. - 1606 A.D.)" ;
@@ -20293,7 +20293,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9rn4g>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "American"@eng-latn ;
+    skos:altLabel "American"@eng-latn, "American 1821-present"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "American 1821-present" ;
@@ -20377,7 +20377,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9rxqh>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Civil War"@eng-latn ;
+    skos:altLabel "Civil War"@eng-latn, "Civil War 1861-1865"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Civil War 1861-1865" ;
@@ -20566,7 +20566,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9sf59>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "18th Century::4th quarter"@eng-latn ;
+    skos:altLabel "18th Century::4th quarter"@eng-latn, "18th Century::4th quarter (1775 - 1799)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "18th Century::4th quarter (1775 - 1799)" ;
@@ -20587,7 +20587,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9sfdm>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "20th Century::4th quarter"@eng-latn ;
+    skos:altLabel "20th Century::4th quarter"@eng-latn, "20th Century::4th quarter (1975 - 1999)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "20th Century::4th quarter (1975 - 1999)" ;
@@ -20692,7 +20692,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9srkx>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Glades"@eng-latn ;
+    skos:altLabel "Glades"@eng-latn, "Glades, 1000 B.C.-A.D. 1700"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Glades, 1000 B.C.-A.D. 1700" ;
@@ -20713,7 +20713,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9srm9>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Paleo-Indian"@eng-latn ;
+    skos:altLabel "Paleo-Indian"@eng-latn, "Paleo-Indian (15000 - 8501 B.C.)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Paleo-Indian (15000 - 8501 B.C.)" ;
@@ -20839,7 +20839,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9sxn4>
     dcterms:spatial <http://www.geonames.org/4398678> ;
     a skos:Concept ;
-    skos:altLabel "Early Industrial"@eng-latn ;
+    skos:altLabel "Early Industrial"@eng-latn, "Early Industrial (1866-1899)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA32" ;
     skos:prefLabel "Early Industrial (1866-1899)" ;
@@ -21007,7 +21007,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9t9hp>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Early Archaic"@eng-latn ;
+    skos:altLabel "Early Archaic"@eng-latn, "Early Archaic (8500 - 6501 B.C.)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Early Archaic (8500 - 6501 B.C.)" ;
@@ -21112,7 +21112,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9tj9r>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Archaic"@eng-latn ;
+    skos:altLabel "Archaic"@eng-latn, "Archaic (8500 - 1201 B.C.)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Archaic (8500 - 1201 B.C.)" ;
@@ -21217,7 +21217,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9tr4v>
     dcterms:spatial <http://www.geonames.org/4398678> ;
     a skos:Concept ;
-    skos:altLabel "Civil War"@eng-latn ;
+    skos:altLabel "Civil War"@eng-latn, "Civil War (1861-1865)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/77WZXEA33" ;
     skos:prefLabel "Civil War (1861-1865)" ;
@@ -21259,7 +21259,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9ttng>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Early/Middle Woodland"@eng-latn ;
+    skos:altLabel "Early/Middle Woodland"@eng-latn, "Early/Middle Woodland (1200 B.C. - 999 A.D.)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Early/Middle Woodland (1200 B.C. - 999 A.D.)" ;
@@ -21280,7 +21280,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9twsd>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Depression/New Deal"@eng-latn ;
+    skos:altLabel "Depression/New Deal"@eng-latn, "Depression/New Deal 1930-1940"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Depression/New Deal 1930-1940" ;
@@ -21301,7 +21301,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9v37h>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Caloosahatchee"@eng-latn ;
+    skos:altLabel "Caloosahatchee"@eng-latn, "Caloosahatchee 500 B.C.-1700 A.D."@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Caloosahatchee 500 B.C.-1700 A.D." ;
@@ -21322,7 +21322,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9v6zd>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Hickory Pond"@eng-latn ;
+    skos:altLabel "Hickory Pond"@eng-latn, "Hickory Pond, A.D. 800-1250"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Hickory Pond, A.D. 800-1250" ;
@@ -21343,7 +21343,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9v8jz>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Deptford"@eng-latn ;
+    skos:altLabel "Deptford"@eng-latn, "Deptford 700 B.C.-300 B.C."@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Deptford 700 B.C.-300 B.C." ;
@@ -21553,7 +21553,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9vzjw>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "Weeden Island"@eng-latn ;
+    skos:altLabel "Weeden Island"@eng-latn, "Weeden Island A.D. 450-1000"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "Weeden Island A.D. 450-1000" ;
@@ -21658,7 +21658,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9w9vj>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "Reconstruction and Growth"@eng-latn ;
+    skos:altLabel "Reconstruction and Growth"@eng-latn, "Reconstruction and Growth (1866 - 1916)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "Reconstruction and Growth (1866 - 1916)" ;
@@ -21700,7 +21700,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9wbvt>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "19th Century"@eng-latn ;
+    skos:altLabel "19th Century"@eng-latn, "19th Century (1800 - 1899)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "19th Century (1800 - 1899)" ;
@@ -21826,7 +21826,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9wzb6>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "20th Century::2nd quarter"@eng-latn ;
+    skos:altLabel "20th Century::2nd quarter"@eng-latn, "20th Century::2nd quarter (1925 - 1949)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "20th Century::2nd quarter (1925 - 1949)" ;
@@ -21847,7 +21847,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9x24q>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "17th Century::2nd/3rd quarter"@eng-latn ;
+    skos:altLabel "17th Century::2nd/3rd quarter"@eng-latn, "17th Century::2nd/3rd quarter (1625 - 1674)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "17th Century::2nd/3rd quarter (1625 - 1674)" ;
@@ -21952,7 +21952,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9xd3c>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "20th Century::3rd quarter"@eng-latn ;
+    skos:altLabel "20th Century::3rd quarter"@eng-latn, "20th Century::3rd quarter (1950 - 1974)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "20th Century::3rd quarter (1950 - 1974)" ;
@@ -22141,7 +22141,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9xtn8>
     dcterms:spatial <http://www.geonames.org/4155751> ;
     a skos:Concept ;
-    skos:altLabel "First Spanish Period"@eng-latn ;
+    skos:altLabel "First Spanish Period"@eng-latn, "First Spanish Period 1513-1599"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/collectionKey/IE6SWQKE" ;
     skos:prefLabel "First Spanish Period 1513-1599" ;
@@ -22624,7 +22624,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p086kj9zswj>
     dcterms:spatial <http://www.geonames.org/6254928> ;
     a skos:Concept ;
-    skos:altLabel "19th Century::2nd quarter"@eng-latn ;
+    skos:altLabel "19th Century::2nd quarter"@eng-latn, "19th Century::2nd quarter (1825 - 1849)"@eng-latn ;
     skos:inScheme <p086kj9> ;
     skos:note "Period based on publications identified in the following Zotero collections: http://zotero.org/groups/dinaa_resources/items/itemKey/IIFD95TN; http://zotero.org/groups/dinaa_resources/items/itemKey/WP9H545G; http://zotero.org/groups/dinaa_resources/items/itemKey/QCXUNKRP; http://zotero.org/groups/dinaa_resources/items/itemKey/DRZKP7DP; http://zotero.org/groups/dinaa_resources/items/itemKey/ZD4UBM6E; http://zotero.org/groups/dinaa_resources/items/itemKey/9PVBS3WC" ;
     skos:prefLabel "19th Century::2nd quarter (1825 - 1849)" ;
@@ -23033,7 +23033,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Neo-Assyrian"@eng-latn ;
+    skos:altLabel "Neo Assyrian"@eng-latn, "Neo-Assyrian"@eng-latn ;
     skos:inScheme <p08tf6p> ;
     skos:prefLabel "Neo Assyrian" ;
     time:intervalFinishedBy [
@@ -23493,7 +23493,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
-    skos:altLabel "Third Intermediate Period"@eng-latn ;
+    skos:altLabel "Third Intermediate Period"@eng-latn, "Third Intermediate period"@eng-latn ;
     skos:inScheme <p0bd664> ;
     skos:prefLabel "Third Intermediate period" ;
     time:intervalFinishedBy [
@@ -24316,7 +24316,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
-    skos:altLabel "Old Syrian"@eng-latn ;
+    skos:altLabel "Old Syrian"@eng-latn, "Old Syrian Period"@eng-latn ;
     skos:inScheme <p0cfv7g> ;
     skos:prefLabel "Old Syrian Period" ;
     time:intervalFinishedBy [
@@ -24460,7 +24460,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
-    skos:altLabel "New Syrian"@eng-latn ;
+    skos:altLabel "New Syrian"@eng-latn, "New Syrian Period"@eng-latn ;
     skos:inScheme <p0cfv7g> ;
     skos:prefLabel "New Syrian Period" ;
     time:intervalFinishedBy [
@@ -24508,7 +24508,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
-    skos:altLabel "Monarchic"@eng-latn ;
+    skos:altLabel "Monarchic"@eng-latn, "monarchic period"@eng-latn ;
     skos:inScheme <p0cfv7g> ;
     skos:prefLabel "monarchic period" ;
     time:intervalFinishedBy [
@@ -24556,7 +24556,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
-    skos:altLabel "Early Canaanite"@eng-latn ;
+    skos:altLabel "Early Canaanite"@eng-latn, "Early Canaanite Period"@eng-latn ;
     skos:inScheme <p0cfv7g> ;
     skos:note "see also Mazar, 1992" ;
     skos:prefLabel "Early Canaanite Period" ;
@@ -25586,7 +25586,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Ireland>, <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
-    skos:altLabel "Early Christian"@eng-latn ;
+    skos:altLabel "Early Christian"@eng-latn, "Early Christian (Britain, Ireland)"@eng-latn ;
     skos:inScheme <p0ff3dt> ;
     skos:note "Maps pages 116, 119." ;
     skos:prefLabel "Early Christian (Britain, Ireland)" ;
@@ -25660,7 +25660,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
-    skos:altLabel "Anglo-Saxon"@eng-latn ;
+    skos:altLabel "Anglo-Saxon"@eng-latn, "Anglo-Saxon (East Britain)"@eng-latn ;
     skos:inScheme <p0ff3dt> ;
     skos:note "Maps pages 110-111." ;
     skos:prefLabel "Anglo-Saxon (East Britain)" ;
@@ -26393,7 +26393,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0gjgrsn5zn>
     dcterms:spatial <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
-    skos:altLabel "Early Palaeolithic"@eng-latn, "Lower Palaeolithic"@eng-latn ;
+    skos:altLabel "Early Palaeolithic"@eng-latn, "Lower (Early) Palaeolithic"@eng-latn, "Lower Palaeolithic"@eng-latn ;
     skos:inScheme <p0gjgrs> ;
     skos:prefLabel "Lower (Early) Palaeolithic" ;
     time:intervalFinishedBy [
@@ -26533,7 +26533,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0gjgrswcr8>
     dcterms:spatial <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
-    skos:altLabel "Late Palaeolithic"@eng-latn, "Upper Palaeolithic"@eng-latn ;
+    skos:altLabel "Late Palaeolithic"@eng-latn, "Upper (Late) Palaeolithic"@eng-latn, "Upper Palaeolithic"@eng-latn ;
     skos:inScheme <p0gjgrs> ;
     skos:prefLabel "Upper (Late) Palaeolithic" ;
     time:intervalFinishedBy [
@@ -26709,7 +26709,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
-    skos:altLabel "Early Dynastic"@eng-latn ;
+    skos:altLabel "Early Dynastic"@eng-latn, "Early Dynastic period"@eng-latn ;
     skos:inScheme <p0j5frx> ;
     skos:note "Removed due to inferences in GeoDia: al-'Ubaid (5500-4000 B.C.), Uruk (4000-3250 B.C.), Jamdat Nasr periods (3250-3000 B.C.), and Ur of the Chaldees (1150-800 B.C.). Note this quote p.15: \"At an archaeological congress of excavators held at Baghdad in 1929 it was agreed that the early stages of human settlement in south Mesopotamia could be classified n successive phases which should be called, after the places where the evidence for each was first discovered, the al-'Ubaid period, the Uruk period, the Jamdat Nasr period, and then the Early Dynastic period, towards the end of which (in IIIb) comes the First Dynasty of Ur.\" p.16: \"Archaeological excavation ... does not of itself offer an absolute chronology in years B.C./A.D.\"", "These are approximate dates." ;
     skos:prefLabel "Early Dynastic period" ;
@@ -26764,7 +26764,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzw33x8>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Late Bronze Age IB"@eng-latn, "Late Cypriot IB"@eng-latn ;
+    skos:altLabel "Late Bronze Age (Late Cypriot) IB"@eng-latn, "Late Bronze Age IB"@eng-latn, "Late Cypriot IB"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Late Bronze Age (Late Cypriot) IB" ;
     time:intervalFinishedBy [
@@ -26783,7 +26783,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzw3p99>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Middle Bronze Age I"@eng-latn, "Middle Cypriot I"@eng-latn ;
+    skos:altLabel "Middle Bronze Age (Middle Cypriot) I"@eng-latn, "Middle Bronze Age I"@eng-latn, "Middle Cypriot I"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Middle Bronze Age (Middle Cypriot) I" ;
     time:intervalFinishedBy [
@@ -26802,7 +26802,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzw6f7b>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Late Bronze Age IIA"@eng-latn, "Late Cypriot IIA"@eng-latn ;
+    skos:altLabel "Late Bronze Age (Late Cypriot) IIA"@eng-latn, "Late Bronze Age IIA"@eng-latn, "Late Cypriot IIA"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Late Bronze Age (Late Cypriot) IIA" ;
     time:intervalFinishedBy [
@@ -26821,7 +26821,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzw727b>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Middle Bronze Age III"@eng-latn, "Middle Cypriot III"@eng-latn ;
+    skos:altLabel "Middle Bronze Age (Middle Cypriot) III"@eng-latn, "Middle Bronze Age III"@eng-latn, "Middle Cypriot III"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Middle Bronze Age (Middle Cypriot) III" ;
     time:intervalFinishedBy [
@@ -26840,7 +26840,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzw8gr5>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Cypro-Geometric I"@eng-latn, "Geometric I"@eng-latn ;
+    skos:altLabel "Cypro-Geometric I"@eng-latn, "Geometric (Cypro-Geometric) I"@eng-latn, "Geometric I"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Geometric (Cypro-Geometric) I" ;
     time:intervalFinishedBy [
@@ -26859,7 +26859,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzw8xcb>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Archaic II"@eng-latn, "Cypro-Archaic II"@eng-latn ;
+    skos:altLabel "Archaic (Cypro-Archaic) II"@eng-latn, "Archaic II"@eng-latn, "Cypro-Archaic II"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Archaic (Cypro-Archaic) II" ;
     time:intervalFinishedBy [
@@ -26878,7 +26878,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzw932g>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Cypro-Geometric III"@eng-latn, "Geometric III"@eng-latn ;
+    skos:altLabel "Cypro-Geometric III"@eng-latn, "Geometric (Cypro-Geometric) III"@eng-latn, "Geometric III"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Geometric (Cypro-Geometric) III" ;
     time:intervalFinishedBy [
@@ -26916,7 +26916,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwcs2w>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Middle Bronze Age II"@eng-latn, "Middle Cypriot II"@eng-latn ;
+    skos:altLabel "Middle Bronze Age (Middle Cypriot) II"@eng-latn, "Middle Bronze Age II"@eng-latn, "Middle Cypriot II"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Middle Bronze Age (Middle Cypriot) II" ;
     time:intervalFinishedBy [
@@ -26954,7 +26954,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwfmq9>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Late Bronze Age IIB"@eng-latn, "Late Cypriot IIB"@eng-latn ;
+    skos:altLabel "Late Bronze Age (Late Cypriot) IIB"@eng-latn, "Late Bronze Age IIB"@eng-latn, "Late Cypriot IIB"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Late Bronze Age (Late Cypriot) IIB" ;
     time:intervalFinishedBy [
@@ -26973,7 +26973,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwfv22>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Late Bronze Age IIIB"@eng-latn, "Late Cypriot IIIB"@eng-latn ;
+    skos:altLabel "Late Bronze Age (Late Cypriot) IIIB"@eng-latn, "Late Bronze Age IIIB"@eng-latn, "Late Cypriot IIIB"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Late Bronze Age (Late Cypriot) IIIB" ;
     time:intervalFinishedBy [
@@ -26992,7 +26992,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwg63z>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Archaic I"@eng-latn, "Cypro-Archaic I"@eng-latn ;
+    skos:altLabel "Archaic (Cypro-Archaic) I"@eng-latn, "Archaic I"@eng-latn, "Cypro-Archaic I"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Archaic (Cypro-Archaic) I" ;
     time:intervalFinishedBy [
@@ -27011,7 +27011,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwgxd7>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Classical I"@eng-latn, "Cypro-Classical I"@eng-latn ;
+    skos:altLabel "Classical (Cypro-Classical) I"@eng-latn, "Classical I"@eng-latn, "Cypro-Classical I"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Classical (Cypro-Classical) I" ;
     time:intervalFinishedBy [
@@ -27030,7 +27030,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwhwbh>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Philia Culture"@eng-latn, "Transitional"@eng-latn ;
+    skos:altLabel "Philia Culture"@eng-latn, "Transitional"@eng-latn, "Transitional (Philia Culture)"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Transitional (Philia Culture)" ;
     time:intervalFinishedBy [
@@ -27069,7 +27069,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwkp48>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Late Bronze Age IA"@eng-latn, "Late Cypriot IA"@eng-latn ;
+    skos:altLabel "Late Bronze Age (Late Cypriot) IA"@eng-latn, "Late Bronze Age IA"@eng-latn, "Late Cypriot IA"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Late Bronze Age (Late Cypriot) IA" ;
     time:intervalFinishedBy [
@@ -27107,7 +27107,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwnc5f>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Early Bronze Age III"@eng-latn, "Early Cypriot III"@eng-latn ;
+    skos:altLabel "Early Bronze Age (Early Cypriot) III"@eng-latn, "Early Bronze Age III"@eng-latn, "Early Cypriot III"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Early Bronze Age (Early Cypriot) III" ;
     time:intervalFinishedBy [
@@ -27126,7 +27126,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwp3dn>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Cypro-Geometric II"@eng-latn, "Geometric II"@eng-latn ;
+    skos:altLabel "Cypro-Geometric II"@eng-latn, "Geometric (Cypro-Geometric) II"@eng-latn, "Geometric II"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Geometric (Cypro-Geometric) II" ;
     time:intervalFinishedBy [
@@ -27145,7 +27145,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwr3rh>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Classical II"@eng-latn, "Cypro-Classical II"@eng-latn ;
+    skos:altLabel "Classical (Cypro-Classical) II"@eng-latn, "Classical II"@eng-latn, "Cypro-Classical II"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Classical (Cypro-Classical) II" ;
     time:intervalFinishedBy [
@@ -27164,7 +27164,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwr5gf>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Early Bronze Age I"@eng-latn, "Early Cypriot I"@eng-latn ;
+    skos:altLabel "Early Bronze Age (Early Cypriot) I"@eng-latn, "Early Bronze Age I"@eng-latn, "Early Cypriot I"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Early Bronze Age (Early Cypriot) I" ;
     time:intervalFinishedBy [
@@ -27242,7 +27242,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwt8d6>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Early Bronze Age II"@eng-latn, "Early Cypriot II"@eng-latn ;
+    skos:altLabel "Early Bronze Age (Early Cypriot) II"@eng-latn, "Early Bronze Age II"@eng-latn, "Early Cypriot II"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Early Bronze Age (Early Cypriot) II" ;
     time:intervalFinishedBy [
@@ -27261,7 +27261,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwtk9t>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Late Bronze Age IIIC"@eng-latn, "Late Cypriot IIIC"@eng-latn ;
+    skos:altLabel "Late Bronze Age (Late Cypriot) IIIC"@eng-latn, "Late Bronze Age IIIC"@eng-latn, "Late Cypriot IIIC"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Late Bronze Age (Late Cypriot) IIIC" ;
     time:intervalFinishedBy [
@@ -27299,7 +27299,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzww7hd>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Late Bronze Age IIIA"@eng-latn, "Late Cypriot IIIA"@eng-latn ;
+    skos:altLabel "Late Bronze Age (Late Cypriot) IIIA"@eng-latn, "Late Bronze Age IIIA"@eng-latn, "Late Cypriot IIIA"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Late Bronze Age (Late Cypriot) IIIA" ;
     time:intervalFinishedBy [
@@ -27318,7 +27318,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0jtbzwwmnz>
     dcterms:spatial <http://dbpedia.org/resource/Cyprus> ;
     a skos:Concept ;
-    skos:altLabel "Late Bronze Age IIC"@eng-latn, "Late Cypriot IIC"@eng-latn ;
+    skos:altLabel "Late Bronze Age (Late Cypriot) IIC"@eng-latn, "Late Bronze Age IIC"@eng-latn, "Late Cypriot IIC"@eng-latn ;
     skos:inScheme <p0jtbzw> ;
     skos:prefLabel "Late Bronze Age (Late Cypriot) IIC" ;
     time:intervalFinishedBy [
@@ -27467,7 +27467,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Ur" ;
     dcterms:spatial <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
-    skos:altLabel "Uruk Period"@eng-latn, "Warka Period"@eng-latn ;
+    skos:altLabel "Uruk (Warka) Period"@eng-latn, "Uruk Period"@eng-latn, "Warka Period"@eng-latn ;
     skos:inScheme <p0kc8t6> ;
     skos:prefLabel "Uruk (Warka) Period" ;
     time:intervalFinishedBy [
@@ -28646,7 +28646,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Armenia>, <http://dbpedia.org/resource/Azerbaijan>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Arsacid"@eng-latn ;
+    skos:altLabel "Arsacid"@eng-latn, "Arsacid period"@eng-latn ;
     skos:inScheme <p0kj6dj> ;
     skos:prefLabel "Arsacid period" ;
     time:intervalFinishedBy [
@@ -28743,7 +28743,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Armenia>, <http://dbpedia.org/resource/Azerbaijan>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "post-Arsacid"@eng-latn ;
+    skos:altLabel "post-Arsacid"@eng-latn, "post-Arsacid period"@eng-latn ;
     skos:inScheme <p0kj6dj> ;
     skos:prefLabel "post-Arsacid period" ;
     time:intervalFinishedBy [
@@ -28973,7 +28973,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Turkey" ;
     dcterms:spatial <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Late Hellenistic"@eng-latn ;
+    skos:altLabel "Late Hellenistic"@eng-latn, "Late Hellenistic Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Late Hellenistic Period" ;
     time:intervalFinishedBy [
@@ -29078,7 +29078,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel "Late Hellenistic"@eng-latn ;
+    skos:altLabel "Late Hellenistic"@eng-latn, "Late Hellenistic Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Late Hellenistic Period" ;
     time:intervalFinishedBy [
@@ -29099,7 +29099,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan, Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel "Neo Babylonian"@eng-latn ;
+    skos:altLabel "Neo Babylonian"@eng-latn, "Neo Babylonian Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Neo Babylonian Period" ;
     time:intervalFinishedBy [
@@ -29141,7 +29141,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Turkey" ;
     dcterms:spatial <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Early Roman"@eng-latn ;
+    skos:altLabel "Early Roman"@eng-latn, "Early Roman Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Early Roman Period" ;
     time:intervalFinishedBy [
@@ -29162,7 +29162,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Egypt" ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
-    skos:altLabel "Byzantine"@eng-latn ;
+    skos:altLabel "Byzantine"@eng-latn, "Byzantine Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Byzantine Period" ;
     time:intervalFinishedBy [
@@ -29183,7 +29183,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan, Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel "Ottoman"@eng-latn ;
+    skos:altLabel "Ottoman"@eng-latn, "Ottoman Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Ottoman Period" ;
     time:intervalFinishedBy [
@@ -29204,7 +29204,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan, Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel "Early Islamic"@eng-latn ;
+    skos:altLabel "Early Islamic"@eng-latn, "Early Islamic Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Early Islamic Period" ;
     time:intervalFinishedBy [
@@ -29288,7 +29288,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Turkey" ;
     dcterms:spatial <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Early Hellenistic"@eng-latn ;
+    skos:altLabel "Early Hellenistic"@eng-latn, "Early Hellenistic Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Early Hellenistic Period" ;
     time:intervalFinishedBy [
@@ -29309,7 +29309,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan, Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel "Fatimid/Mameluke"@eng-latn ;
+    skos:altLabel "Fatimid/Mameluke"@eng-latn, "Fatimid/Mameluke Periods"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Fatimid/Mameluke Periods" ;
     time:intervalFinishedBy [
@@ -29351,7 +29351,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Turkey" ;
     dcterms:spatial <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Middle Hellenistic"@eng-latn ;
+    skos:altLabel "Middle Hellenistic"@eng-latn, "Middle Hellenistic Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Middle Hellenistic Period" ;
     time:intervalFinishedBy [
@@ -29519,7 +29519,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
-    skos:altLabel "Early Roman"@eng-latn ;
+    skos:altLabel "Early Roman"@eng-latn, "Early Roman Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Early Roman Period" ;
     time:intervalFinishedBy [
@@ -29561,7 +29561,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel "Early Hellenistic"@eng-latn ;
+    skos:altLabel "Early Hellenistic"@eng-latn, "Early Hellenistic Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Early Hellenistic Period" ;
     time:intervalFinishedBy [
@@ -29666,7 +29666,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Egypt" ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
-    skos:altLabel "Hellenistic"@eng-latn ;
+    skos:altLabel "Hellenistic"@eng-latn, "Hellenistic Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Hellenistic Period" ;
     time:intervalFinishedBy [
@@ -29708,7 +29708,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Turkey, Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Late Roman"@eng-latn ;
+    skos:altLabel "Late Roman"@eng-latn, "Late Roman Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Late Roman Period" ;
     time:intervalFinishedBy [
@@ -29729,7 +29729,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Turkey" ;
     dcterms:spatial <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Ottoman"@eng-latn ;
+    skos:altLabel "Ottoman"@eng-latn, "Ottoman Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Ottoman Period" ;
     time:intervalFinishedBy [
@@ -29813,7 +29813,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Egypt" ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
-    skos:altLabel "Early Islamic"@eng-latn ;
+    skos:altLabel "Early Islamic"@eng-latn, "Early Islamic Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Early Islamic Period" ;
     time:intervalFinishedBy [
@@ -29876,7 +29876,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
-    skos:altLabel "Middle Roman"@eng-latn ;
+    skos:altLabel "Middle Roman"@eng-latn, "Middle Roman Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Middle Roman Period" ;
     time:intervalFinishedBy [
@@ -29897,7 +29897,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan, Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel "Later Islamic"@eng-latn ;
+    skos:altLabel "Later Islamic"@eng-latn, "Later Islamic Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Later Islamic Period" ;
     time:intervalFinishedBy [
@@ -29918,7 +29918,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Egypt" ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
-    skos:altLabel "Early Roman"@eng-latn ;
+    skos:altLabel "Early Roman"@eng-latn, "Early Roman Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Early Roman Period" ;
     time:intervalFinishedBy [
@@ -29939,7 +29939,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan, Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel "Frankish/Ayyubid"@eng-latn ;
+    skos:altLabel "Frankish/Ayyubid"@eng-latn, "Frankish/Ayyubid Periods"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Frankish/Ayyubid Periods" ;
     time:intervalFinishedBy [
@@ -29960,7 +29960,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
-    skos:altLabel "Late Hellenistic"@eng-latn ;
+    skos:altLabel "Late Hellenistic"@eng-latn, "Late Hellenistic Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Late Hellenistic Period" ;
     time:intervalFinishedBy [
@@ -30065,7 +30065,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan, Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel "Byzantine"@eng-latn ;
+    skos:altLabel "Byzantine"@eng-latn, "Byzantine Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Byzantine Period" ;
     time:intervalFinishedBy [
@@ -30128,7 +30128,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel "Early Roman"@eng-latn ;
+    skos:altLabel "Early Roman"@eng-latn, "Early Roman Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Early Roman Period" ;
     time:intervalFinishedBy [
@@ -30149,7 +30149,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Egypt" ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
-    skos:altLabel "Middle Roman"@eng-latn ;
+    skos:altLabel "Middle Roman"@eng-latn, "Middle Roman Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Middle Roman Period" ;
     time:intervalFinishedBy [
@@ -30359,7 +30359,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
-    skos:altLabel "Hasmonean"@eng-latn ;
+    skos:altLabel "Hasmonean"@eng-latn, "Hasmonean Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Hasmonean Period" ;
     time:intervalFinishedBy [
@@ -30569,7 +30569,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Egypt" ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
-    skos:altLabel "Late Roman"@eng-latn ;
+    skos:altLabel "Late Roman"@eng-latn, "Late Roman Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Late Roman Period" ;
     time:intervalFinishedBy [
@@ -30590,7 +30590,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan, Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel "Ummayyad/Abbasid"@eng-latn ;
+    skos:altLabel "Ummayyad/Abbasid"@eng-latn, "Ummayyad/Abbasid Periods"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Ummayyad/Abbasid Periods" ;
     time:intervalFinishedBy [
@@ -30674,7 +30674,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Turkey, Lebanon, Syria" ;
     dcterms:spatial <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Middle Roman"@eng-latn ;
+    skos:altLabel "Middle Roman"@eng-latn, "Middle Roman Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Middle Roman Period" ;
     time:intervalFinishedBy [
@@ -30737,7 +30737,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Turkey" ;
     dcterms:spatial <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Byzantine"@eng-latn ;
+    skos:altLabel "Byzantine"@eng-latn, "Byzantine Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Byzantine Period" ;
     time:intervalFinishedBy [
@@ -30758,7 +30758,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
-    skos:altLabel "Late Roman"@eng-latn ;
+    skos:altLabel "Late Roman"@eng-latn, "Late Roman Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Late Roman Period" ;
     time:intervalFinishedBy [
@@ -30884,7 +30884,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
-    skos:altLabel "Herodian"@eng-latn ;
+    skos:altLabel "Herodian"@eng-latn, "Herodian Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Herodian Period" ;
     time:intervalFinishedBy [
@@ -30926,7 +30926,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Israel, Jordan" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
-    skos:altLabel "Early Hellenistic"@eng-latn ;
+    skos:altLabel "Early Hellenistic"@eng-latn, "Early Hellenistic Period"@eng-latn ;
     skos:inScheme <p0m63nj> ;
     skos:prefLabel "Early Hellenistic Period" ;
     time:intervalFinishedBy [
@@ -31261,7 +31261,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
-    skos:altLabel "Old Babylonian"@eng-latn ;
+    skos:altLabel "Old Babylonian"@eng-latn, "Old Babylonian period"@eng-latn ;
     skos:inScheme <p0njrb4> ;
     skos:prefLabel "Old Babylonian period" ;
     time:intervalFinishedBy [
@@ -31285,7 +31285,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
-    skos:altLabel "Jemder Nasr"@eng-latn ;
+    skos:altLabel "Jemder Nasr"@eng-latn, "Jemdet Nasr period"@eng-latn ;
     skos:inScheme <p0njrb4> ;
     skos:prefLabel "Jemdet Nasr period" ;
     time:intervalFinishedBy [
@@ -31381,7 +31381,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
-    skos:altLabel "Early Uruk"@eng-latn ;
+    skos:altLabel "Early Uruk"@eng-latn, "Early Uruk period"@eng-latn ;
     skos:inScheme <p0njrb4> ;
     skos:prefLabel "Early Uruk period" ;
     time:intervalFinishedBy [
@@ -31405,7 +31405,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
-    skos:altLabel "Later Uruk"@eng-latn ;
+    skos:altLabel "Later Uruk"@eng-latn, "Later Uruk period"@eng-latn ;
     skos:inScheme <p0njrb4> ;
     skos:prefLabel "Later Uruk period" ;
     time:intervalFinishedBy [
@@ -31429,7 +31429,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
-    skos:altLabel "Neo-Assyrian"@eng-latn ;
+    skos:altLabel "Neo-Assyrian"@eng-latn, "Neo-Assyrian period"@eng-latn ;
     skos:inScheme <p0njrb4> ;
     skos:prefLabel "Neo-Assyrian period" ;
     time:intervalFinishedBy [
@@ -32684,7 +32684,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Middle Egypt" ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
-    skos:altLabel "Badarian"@eng-latn ;
+    skos:altLabel "Badarian"@eng-latn, "Badarian (Middle Egypt)"@eng-latn ;
     skos:inScheme <p0qk76z> ;
     skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Badarian (Middle Egypt)" ;
@@ -32941,7 +32941,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Lower Egypt" ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
-    skos:altLabel "Buto I"@eng-latn, "Maadi"@eng-latn ;
+    skos:altLabel "Buto I"@eng-latn, "Maadi"@eng-latn, "Maadi/Buto I"@eng-latn ;
     skos:inScheme <p0qk76z> ;
     skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Maadi/Buto I" ;
@@ -34702,7 +34702,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Palestine and Neighboring Areas (Mesopotamia), Southern Levant" ;
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
-    skos:altLabel " Old Assyrian"@eng-latn, "Middle Bronze I-II"@eng-latn, "Old Babylonian"@eng-latn ;
+    skos:altLabel " Old Assyrian"@eng-latn, "MB I-II"@eng-latn, "Middle Bronze I-II"@eng-latn, "Old Babylonian"@eng-latn ;
     skos:inScheme <p0qwcp6> ;
     skos:prefLabel "MB I-II" ;
     time:intervalFinishedBy [
@@ -35000,7 +35000,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Iron Age II"@eng-latn, "Middle Iron Age"@eng-latn ;
+    skos:altLabel "Iron Age II"@eng-latn, "Iron Age II (Middle Iron Age)"@eng-latn, "Middle Iron Age"@eng-latn ;
     skos:inScheme <p0tns5v> ;
     skos:note "This period is used to designate the moment of Phoenician colonization in the West before the development of a distinctive Punic identity." ;
     skos:prefLabel "Iron Age II (Middle Iron Age)" ;
@@ -35101,7 +35101,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Early Iron Age"@eng-latn, "Iron Age I"@eng-latn ;
+    skos:altLabel "Early Iron Age"@eng-latn, "Iron Age I"@eng-latn, "Iron Age I (Early Iron Age)"@eng-latn ;
     skos:inScheme <p0tns5v> ;
     skos:prefLabel "Iron Age I (Early Iron Age)" ;
     time:intervalFinishedBy [
@@ -35513,7 +35513,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0vm8tztmtk>
     dcterms:spatial <http://dbpedia.org/resource/Romania> ;
     a skos:Concept ;
-    skos:altLabel "Early Migrations"@eng-latn ;
+    skos:altLabel "Early Migrations"@eng-latn, "Early Migrations Period"@eng-latn ;
     skos:inScheme <p0vm8tz> ;
     skos:prefLabel "Early Migrations Period" ;
     time:intervalFinishedBy [
@@ -36367,7 +36367,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Sicily> ;
     a skos:Concept ;
-    skos:altLabel "Early Iron Age"@eng-latn, "Iron Age I"@eng-latn ;
+    skos:altLabel "Early Iron Age"@eng-latn, "Early Iron Age (I)"@eng-latn, "Iron Age I"@eng-latn ;
     skos:inScheme <p0vpm8v> ;
     skos:prefLabel "Early Iron Age (I)" ;
     time:intervalFinishedBy [
@@ -36699,7 +36699,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
 <p0wf3wdm797>
     dcterms:spatial <http://dbpedia.org/resource/Sardinia> ;
     a skos:Concept ;
-    skos:altLabel "Copper Age"@eng-latn, "Eneolithic"@eng-latn ;
+    skos:altLabel "Copper Age"@eng-latn, "Eneolithic"@eng-latn, "Eneolithic (Copper Age)"@eng-latn ;
     skos:inScheme <p0wf3wd> ;
     skos:note "added" ;
     skos:prefLabel "Eneolithic (Copper Age)" ;
@@ -37051,7 +37051,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
-    skos:altLabel "Phoenician"@eng-latn ;
+    skos:altLabel "Phoenician"@eng-latn, "Phoenician culture"@eng-latn ;
     skos:inScheme <p0z3skm> ;
     skos:note "removed Neo-Assyrian (722-586 B.C.) and Neo-Babylonian (586-539 B.C.) since not explicit, and added new sources Amitai, Barton, Savage, King/Stager, and Richard. " ;
     skos:prefLabel "Phoenician culture" ;
@@ -37452,7 +37452,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
-    skos:altLabel "Canaanite"@eng-latn ;
+    skos:altLabel "Canaanite"@eng-latn, "Canaanite culture"@eng-latn ;
     skos:inScheme <p0z3skm> ;
     skos:note "removed Neo-Assyrian (722-586 B.C.) and Neo-Babylonian (586-539 B.C.) since not explicit, and added new sources Amitai, Barton, Savage, King/Stager, and Richard. " ;
     skos:prefLabel "Canaanite culture" ;
@@ -37630,7 +37630,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "High Classical"@eng-latn ;
+    skos:altLabel "High Classical"@eng-latn, "High Classical Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "High Classical Period" ;
@@ -37654,7 +37654,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Ukraine> ;
     a skos:Concept ;
-    skos:altLabel "Early Byzantine"@eng-latn ;
+    skos:altLabel "Early Byzantine"@eng-latn, "Early Byzantine Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:note "For spatial coverage label, please see map on page 235." ;
     skos:prefLabel "Early Byzantine Period" ;
@@ -37704,7 +37704,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Bangladesh>, <http://dbpedia.org/resource/Bhutan>, <http://dbpedia.org/resource/India>, <http://dbpedia.org/resource/Nepal>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Sri_Lanka> ;
     a skos:Concept ;
-    skos:altLabel "Gupta"@eng-latn ;
+    skos:altLabel "Gupta"@eng-latn, "Gupta Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:prefLabel "Gupta Period" ;
     time:intervalFinishedBy [
@@ -37775,7 +37775,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Late Classical"@eng-latn ;
+    skos:altLabel "Late Classical"@eng-latn, "Late Classical Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Late Classical Period" ;
@@ -37872,7 +37872,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Hellenistic"@eng-latn ;
+    skos:altLabel "Hellenistic"@eng-latn, "Hellenistic Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:note "See also map on page 85." ;
     skos:prefLabel "Hellenistic Period" ;
@@ -37897,7 +37897,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/England>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Switzerland> ;
     a skos:Concept ;
-    skos:altLabel "Romanesque"@eng-latn ;
+    skos:altLabel "Romanesque"@eng-latn, "Romanesque period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:note "For spatial coverage label, please see map on page 475." ;
     skos:prefLabel "Romanesque period" ;
@@ -37921,7 +37921,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Proto-Geometric"@eng-latn ;
+    skos:altLabel "Proto-Geometric"@eng-latn, "Proto-Geometric Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Proto-Geometric Period" ;
@@ -37969,7 +37969,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Orientalizing"@eng-latn ;
+    skos:altLabel "Orientalizing"@eng-latn, "Orientalizing Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Orientalizing Period" ;
@@ -37993,7 +37993,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Geometric"@eng-latn ;
+    skos:altLabel "Geometric"@eng-latn, "Geometric Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Geometric Period" ;
@@ -38042,7 +38042,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
-    skos:altLabel "Minoan New Palace"@eng-latn ;
+    skos:altLabel "Minoan New Palace"@eng-latn, "Minoan New Palace period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:prefLabel "Minoan New Palace period" ;
     time:intervalFinishedBy [
@@ -38065,7 +38065,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Ukraine> ;
     a skos:Concept ;
-    skos:altLabel "Middle Byzantine"@eng-latn ;
+    skos:altLabel "Middle Byzantine"@eng-latn, "Middle Byzantine Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:note "For spatial coverage label, please see map on page 235." ;
     skos:prefLabel "Middle Byzantine Period" ;
@@ -38114,7 +38114,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
-    skos:altLabel "Helladic"@eng-latn, "Mycenaean culture"@eng-latn ;
+    skos:altLabel "Helladic"@eng-latn, "Helladic period"@eng-latn, "Mycenaean culture"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:prefLabel "Helladic period" ;
     time:intervalFinishedBy [
@@ -38210,7 +38210,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Bangladesh>, <http://dbpedia.org/resource/Bhutan>, <http://dbpedia.org/resource/India>, <http://dbpedia.org/resource/Nepal>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Sri_Lanka> ;
     a skos:Concept ;
-    skos:altLabel "Kushan and Later Andhra"@eng-latn ;
+    skos:altLabel "Kushan and Later Andhra"@eng-latn, "Kushan and Later Andhra Periods"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:prefLabel "Kushan and Later Andhra Periods" ;
     time:intervalFinishedBy [
@@ -38234,7 +38234,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Bangladesh>, <http://dbpedia.org/resource/Bhutan>, <http://dbpedia.org/resource/India>, <http://dbpedia.org/resource/Nepal>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Sri_Lanka> ;
     a skos:Concept ;
-    skos:altLabel "Maurya"@eng-latn ;
+    skos:altLabel "Maurya"@eng-latn, "Maurya Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:prefLabel "Maurya Period" ;
     time:intervalFinishedBy [
@@ -38257,7 +38257,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Early Classical"@eng-latn ;
+    skos:altLabel "Early Classical"@eng-latn, "Early Classical Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Early Classical Period" ;
@@ -38282,7 +38282,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
-    skos:altLabel "Minoan Old Palace"@eng-latn ;
+    skos:altLabel "Minoan Old Palace"@eng-latn, "Minoan Old Palace period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:prefLabel "Minoan Old Palace period" ;
     time:intervalFinishedBy [
@@ -38330,7 +38330,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Afghanistan>, <http://dbpedia.org/resource/Bangladesh>, <http://dbpedia.org/resource/Bhutan>, <http://dbpedia.org/resource/India>, <http://dbpedia.org/resource/Nepal>, <http://dbpedia.org/resource/Pakistan>, <http://dbpedia.org/resource/Sri_Lanka> ;
     a skos:Concept ;
-    skos:altLabel "Vedic"@eng-latn ;
+    skos:altLabel "Vedic"@eng-latn, "Vedic Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:prefLabel "Vedic Period" ;
     time:intervalFinishedBy [
@@ -38377,7 +38377,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Ukraine> ;
     a skos:Concept ;
-    skos:altLabel "Late Byzantine"@eng-latn ;
+    skos:altLabel "Late Byzantine"@eng-latn, "Late Byzantine Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:note "For spatial coverage label, please see map on page 235." ;
     skos:prefLabel "Late Byzantine Period" ;
@@ -38401,7 +38401,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     ] ;
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
-    skos:altLabel "Archaic"@eng-latn ;
+    skos:altLabel "Archaic"@eng-latn, "Archaic Period"@eng-latn ;
     skos:inScheme <p0z5nvh> ;
     skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Archaic Period" ;
@@ -39424,7 +39424,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Ras Shamra" ;
     dcterms:spatial <http://dbpedia.org/resource/Ugarit> ;
     a skos:Concept ;
-    skos:altLabel "Ubaid"@eng-latn ;
+    skos:altLabel "\"Ubaid\""@eng-latn, "Ubaid"@eng-latn ;
     skos:inScheme <p0zmdxz> ;
     skos:prefLabel "\"Ubaid\"" ;
     time:intervalFinishedBy [
@@ -39446,7 +39446,7 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     periodo:spatialCoverageDescription "Ras Shamra" ;
     dcterms:spatial <http://dbpedia.org/resource/Ugarit> ;
     a skos:Concept ;
-    skos:altLabel "Halaf Chalcolithic"@eng-latn ;
+    skos:altLabel "\"Halaf\" Chalcolithic"@eng-latn, "Halaf Chalcolithic"@eng-latn ;
     skos:inScheme <p0zmdxz> ;
     skos:prefLabel "\"Halaf\" Chalcolithic" ;
     time:intervalFinishedBy [


### PR DESCRIPTION
In the new format, label/localizedLabel/alternateLabel are distributed
differently.

  * `label` is the label found in the source, verbatim

  * `localizedLabel` should be an object with a single property and
    value. The property should be the language code for the label, and
    the value should be the label itself (repeated)

  * `alternateLabel` is any other labels derived from the verbatim text,
    whether in English or not. This is an object whose keys are language
    codes with values of an array of strings representing the period in
    that language.