### PR TITLE
Spatial coverage fixes

### DIFF
--- a/data.json
+++ b/data.json
@@ -1252,14 +1252,6 @@
               "label": "Egypt"
             },
             {
-              "id": "http://dbpedia.org/resource/Egypt",
-              "label": "Egypt"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Afghanistan",
-              "label": "Afghanistan"
-            },
-            {
               "id": "http://dbpedia.org/resource/Albania",
               "label": "Albania"
             },
@@ -1326,10 +1318,6 @@
             {
               "id": "http://dbpedia.org/resource/Djibouti",
               "label": "Djibouti"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Egypt",
-              "label": "Egypt"
             },
             {
               "id": "http://dbpedia.org/resource/Eritrea",
@@ -1534,10 +1522,6 @@
             {
               "id": "http://dbpedia.org/resource/Tunisia",
               "label": "Tunisia"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Turkey",
-              "label": "Turkey"
             },
             {
               "id": "http://dbpedia.org/resource/Turkmenistan",
@@ -3899,54 +3883,6 @@
             {
               "id": "http://dbpedia.org/resource/Turkmenistan",
               "label": "Turkmenistan"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Afghanistan",
-              "label": "Afghanistan"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Egypt",
-              "label": "Egypt"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Iran",
-              "label": "Iran"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Iraq",
-              "label": "Iraq"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Israel",
-              "label": "Israel"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Jordan",
-              "label": "Jordan"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Lebanon",
-              "label": "Lebanon"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Palestine",
-              "label": "Palestine"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Saudi_Arabia",
-              "label": "Saudi Arabia"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Sudan",
-              "label": "Sudan"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Syria",
-              "label": "Syria"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Turkey",
-              "label": "Turkey"
             },
             {
               "id": "http://dbpedia.org/resource/Yemen",
@@ -6649,10 +6585,6 @@
             {
               "id": "http://dbpedia.org/resource/Syria",
               "label": "Syria"
-            },
-            {
-              "id": "http://dbpedia.org/resource/Italy",
-              "label": "Italy"
             }
           ],
           "start": {

--- a/data.json
+++ b/data.json
@@ -40331,7 +40331,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Sicily",
-              "label": "Monte Casasia"
+              "label": "Sicily"
             }
           ],
           "start": {
@@ -40367,7 +40367,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Sicily",
-              "label": "Monte Casasia"
+              "label": "Sicily"
             }
           ],
           "start": {
@@ -40405,7 +40405,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/Sicily",
-              "label": "Monte Casasia"
+              "label": "Sicily"
             }
           ],
           "start": {
@@ -41062,7 +41062,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             },
             {
               "id": "http://dbpedia.org/resource/Ireland",
@@ -41198,7 +41198,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "spatialCoverageDescription": "East Britain",
@@ -41321,7 +41321,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             },
             {
               "id": "http://dbpedia.org/resource/Ireland",
@@ -41703,7 +41703,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -41730,7 +41730,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -41758,7 +41758,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -41785,7 +41785,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -41812,7 +41812,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -41840,7 +41840,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -41867,7 +41867,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -41895,7 +41895,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -41923,7 +41923,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -41950,7 +41950,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -41977,7 +41977,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42004,7 +42004,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42031,7 +42031,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42058,7 +42058,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42085,7 +42085,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42112,7 +42112,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42139,7 +42139,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42167,7 +42167,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42194,7 +42194,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42222,7 +42222,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42250,7 +42250,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42283,7 +42283,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42310,7 +42310,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42337,7 +42337,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42364,7 +42364,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42391,7 +42391,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42418,7 +42418,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42445,7 +42445,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42478,7 +42478,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42505,7 +42505,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -42533,7 +42533,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44443,7 +44443,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44472,7 +44472,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44501,7 +44501,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44530,7 +44530,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44559,7 +44559,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44588,7 +44588,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44617,7 +44617,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44646,7 +44646,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44675,7 +44675,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44704,7 +44704,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44733,7 +44733,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44762,7 +44762,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44791,7 +44791,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44820,7 +44820,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44849,7 +44849,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44878,7 +44878,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44907,7 +44907,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44936,7 +44936,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44965,7 +44965,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -44994,7 +44994,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45023,7 +45023,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45052,7 +45052,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45081,7 +45081,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45110,7 +45110,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45139,7 +45139,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45168,7 +45168,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45197,7 +45197,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45226,7 +45226,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45255,7 +45255,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45284,7 +45284,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45313,7 +45313,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45342,7 +45342,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45371,7 +45371,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45400,7 +45400,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45429,7 +45429,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45458,7 +45458,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45487,7 +45487,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45516,7 +45516,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45545,7 +45545,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45574,7 +45574,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45603,7 +45603,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -45632,7 +45632,7 @@
           "spatialCoverage": [
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -60294,7 +60294,7 @@
             },
             {
               "id": "http://dbpedia.org/resource/Afghanistan",
-              "label": "southeastern Afghanistan"
+              "label": "Afghanistan"
             },
             {
               "id": "http://dbpedia.org/resource/Pakistan",
@@ -60382,7 +60382,7 @@
             },
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -60429,7 +60429,7 @@
             },
             {
               "id": "http://dbpedia.org/resource/Netherlands",
-              "label": "Holland"
+              "label": "Netherlands"
             }
           ],
           "start": {
@@ -60598,7 +60598,7 @@
             },
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -61065,7 +61065,7 @@
             },
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {
@@ -61179,7 +61179,7 @@
             },
             {
               "id": "http://dbpedia.org/resource/Afghanistan",
-              "label": "southeastern Afghanistan"
+              "label": "Afghanistan"
             },
             {
               "id": "http://dbpedia.org/resource/Pakistan",
@@ -61270,7 +61270,7 @@
             },
             {
               "id": "http://dbpedia.org/resource/Afghanistan",
-              "label": "southeastern Afghanistan"
+              "label": "Afghanistan"
             },
             {
               "id": "http://dbpedia.org/resource/Pakistan",
@@ -61330,7 +61330,7 @@
             },
             {
               "id": "http://dbpedia.org/resource/Afghanistan",
-              "label": "southeastern Afghanistan"
+              "label": "Afghanistan"
             },
             {
               "id": "http://dbpedia.org/resource/Pakistan",
@@ -61474,7 +61474,7 @@
             },
             {
               "id": "http://dbpedia.org/resource/Netherlands",
-              "label": "Holland"
+              "label": "Netherlands"
             }
           ],
           "start": {
@@ -61513,7 +61513,7 @@
             },
             {
               "id": "http://dbpedia.org/resource/Afghanistan",
-              "label": "southeastern Afghanistan"
+              "label": "Afghanistan"
             },
             {
               "id": "http://dbpedia.org/resource/Pakistan",
@@ -61601,7 +61601,7 @@
             },
             {
               "id": "http://dbpedia.org/resource/United_Kingdom",
-              "label": "Britain"
+              "label": "United Kingdom"
             }
           ],
           "start": {

--- a/data.ttl
+++ b/data.ttl
@@ -11,7 +11,7 @@
 @prefix periodo: <p0v#> .
 
 <http://dbpedia.org/resource/Afghanistan>
-    skos:prefLabel "Afghanistan", "southeastern Afghanistan" .
+    skos:prefLabel "Afghanistan" .
 
 <http://dbpedia.org/resource/Albania>
     skos:prefLabel "Albania" .
@@ -221,7 +221,7 @@
     skos:prefLabel "Nepal" .
 
 <http://dbpedia.org/resource/Netherlands>
-    skos:prefLabel "Holland", "Netherlands" .
+    skos:prefLabel "Netherlands" .
 
 <http://dbpedia.org/resource/Norway>
     skos:prefLabel "Norway" .
@@ -275,7 +275,7 @@
     skos:prefLabel "Serbia" .
 
 <http://dbpedia.org/resource/Sicily>
-    skos:prefLabel "Monte Casasia", "Sicily" .
+    skos:prefLabel "Sicily" .
 
 <http://dbpedia.org/resource/Slovakia>
     skos:prefLabel "Slovakia" .
@@ -335,7 +335,7 @@
     skos:prefLabel "United Arab Emirates" .
 
 <http://dbpedia.org/resource/United_Kingdom>
-    skos:prefLabel "Britain", "United Kingdom" .
+    skos:prefLabel "United Kingdom" .
 
 <http://dbpedia.org/resource/Uzbekistan>
     skos:prefLabel "Uzbekistan" .


### PR DESCRIPTION
Two fixes: remove redundant coverages, and fix inconsistencies in labels from dbpedia.