### PR TITLE
editorialNote was incorrectly mapped

### DIFF
--- a/data.json
+++ b/data.json
@@ -19,7 +19,7 @@
       "@reverse": "http://www.w3.org/2004/02/skos/core#inScheme"
     },
     "earliestYear": "periodo:earliestYear",
-    "editorialNote": "http://www.w3.org/2004/02/skos/core#note",
+    "editorialNote": "http://www.w3.org/2004/02/skos/core#editorialNote",
     "id": "@id",
     "in": "http://www.w3.org/2006/time#hasDateTimeDescription",
     "inDataset": {

--- a/data.ttl
+++ b/data.ttl
@@ -515,8 +515,8 @@
     dcterms:spatial <http://dbpedia.org/resource/Italy> ;
     a skos:Concept ;
     skos:altLabel "Etruscan"@eng-latn ;
+    skos:editorialNote "\"Etruscans\" entry." ;
     skos:inScheme <p0244q7> ;
-    skos:note "\"Etruscans\" entry." ;
     skos:prefLabel "Etruscan" ;
     time:intervalFinishedBy [
         skos:prefLabel "509 B.C." ;
@@ -674,8 +674,8 @@
     dcterms:spatial <http://dbpedia.org/resource/Italy> ;
     a skos:Concept ;
     skos:altLabel "Hellenistic"@eng-latn ;
+    skos:editorialNote "added post-GeoDia" ;
     skos:inScheme <p03tqbz> ;
-    skos:note "added post-GeoDia" ;
     skos:prefLabel "Hellenistic" ;
     time:intervalFinishedBy [
         skos:prefLabel "331 BC"
@@ -723,8 +723,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/mesolithic-middle-east> ;
     skos:altLabel "Mesolithic"@eng-latn, "Mesolithic Middle East (18000-9000 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Epipaleolithic-Protoneolithic ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Epipaleolithic-Protoneolithic ME" ;
     skos:prefLabel "Mesolithic Middle East (18000-9000 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-9000" ;
@@ -746,8 +747,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/mongol-middle-east> ;
     skos:altLabel "Mongol"@eng-latn, "Mongol Middle East (AD 1258-1501)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME, Central Asia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME, Central Asia" ;
     skos:prefLabel "Mongol Middle East (AD 1258-1501)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1501" ;
@@ -769,8 +771,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/urartian-eastern-anatolia> ;
     skos:altLabel "Urartian"@eng-latn, "Urartian Eastern Anatolia (900-600 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "eastern Anatolia" ;
+    skos:note "eastern Anatolia" ;
     skos:prefLabel "Urartian Eastern Anatolia (900-600 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-600" ;
@@ -791,8 +794,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ottoman-rise> ;
     skos:altLabel "Ottoman Rise"@eng-latn, "Ottoman Rise (AD 1300-1453)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "ends with the conquest of Constantinople" ;
+    skos:note "ends with the conquest of Constantinople" ;
     skos:prefLabel "Ottoman Rise (AD 1300-1453)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1453" ;
@@ -814,8 +818,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/khwarezmian-middle-east> ;
     skos:altLabel "Khwarezmian"@eng-latn, "Khwarezmian Middle East (AD 1077-1258)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Khwarezmid", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Khwarezmid" ;
     skos:prefLabel "Khwarezmian Middle East (AD 1077-1258)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1258" ;
@@ -836,8 +841,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/classical> ;
     skos:altLabel "Classical"@eng-latn, "Classical (Greco-Roman; 550 BC-330 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Classical period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 550 and end in the year 330 before the birth of Christ." ;
+    skos:note "The Classical period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 550 and end in the year 330 before the birth of Christ." ;
     skos:prefLabel "Classical (Greco-Roman; 550 BC-330 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-330" ;
@@ -859,8 +865,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-period-egypt> ;
     skos:altLabel "Late Period"@eng-latn, "Late Period Egypt (664-332)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Late Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
+    skos:note "The Late Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Late Period Egypt (664-332)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-332" ;
@@ -881,8 +888,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/2nd-millenium-bce> ;
     skos:altLabel "2nd Millenium BCE"@eng-latn, "2nd Millennium BCE"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The second millenium BCE as defined at http://en.wikipedia.org/wiki/2nd_millennium_BC" ;
+    skos:note "The second millenium BCE as defined at http://en.wikipedia.org/wiki/2nd_millennium_BC" ;
     skos:prefLabel "2nd Millenium BCE" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1000" ;
@@ -904,8 +912,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/samanid-ghaznavid-iran> ;
     skos:altLabel "Samanid-Ghaznavid"@eng-latn, "Samanid-Ghaznavid Iran (AD 819-1186)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Iran", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Iran" ;
     skos:prefLabel "Samanid-Ghaznavid Iran (AD 819-1186)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1186" ;
@@ -927,8 +936,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-middle-east> ;
     skos:altLabel "Hellenistic"@eng-latn, "Hellenistic Middle East (330-140 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Macedonian-Seleucid/Ptolemaic/Attalid/Greco-Bactrian", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Macedonian-Seleucid/Ptolemaic/Attalid/Greco-Bactrian" ;
     skos:prefLabel "Hellenistic Middle East (330-140 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-140" ;
@@ -950,8 +960,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/crusader-ottoman-levant> ;
     skos:altLabel "Crusader-Ottoman"@eng-latn, "Crusader-Ottoman Levant (AD 1099-1750)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Crusader-Seljuq-Ayyubid-Mamluk-Ottoman Levant", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Crusader-Seljuq-Ayyubid-Mamluk-Ottoman Levant" ;
     skos:prefLabel "Crusader-Ottoman Levant (AD 1099-1750)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1750" ;
@@ -972,8 +983,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-republican> ;
     skos:altLabel " Roman Republic"@eng-latn, "Hellenistic Greek"@eng-latn, "Hellenistic Greek, Roman Republic"@eng-latn, "Hellenistic Greek, Roman Republic (330 BC-30 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Hellenistic period in Greek history and the middle-to-late Republican period in Roman history. For the purposes of Pleiades, this period is said to begin in the year 330 and end in the year 30 before the birth of Christ." ;
+    skos:note "The Hellenistic period in Greek history and the middle-to-late Republican period in Roman history. For the purposes of Pleiades, this period is said to begin in the year 330 and end in the year 30 before the birth of Christ." ;
     skos:prefLabel "Hellenistic Greek, Roman Republic (330 BC-30 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-30" ;
@@ -995,8 +1007,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-bronze-age-southern-levant> ;
     skos:altLabel "Late Bronze Age"@eng-latn, "Late Bronze Age Southern Levant (1400-1200 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "southern Levant" ;
+    skos:note "southern Levant" ;
     skos:prefLabel "Late Bronze Age Southern Levant (1400-1200 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1200" ;
@@ -1018,8 +1031,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/transition-early-middle-bronze-age-southern-levant> ;
     skos:altLabel "Transition Early-Middle Bronze Age"@eng-latn, "Transition Early-Middle Bronze Age Southern Levant (2100-1900 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "southern Levant" ;
+    skos:note "southern Levant" ;
     skos:prefLabel "Transition Early-Middle Bronze Age Southern Levant (2100-1900 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1900" ;
@@ -1040,8 +1054,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/transition-roman-early-empire-late-antique> ;
     skos:altLabel "Transition Roman Early Empire-Late Antique"@eng-latn, "Transition Roman Early Empire-Late Antique (AD 284-337)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Mediterranean", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Mediterranean" ;
     skos:prefLabel "Transition Roman Early Empire-Late Antique (AD 284-337)" ;
     time:intervalFinishedBy [
         skos:prefLabel "337" ;
@@ -1063,8 +1078,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/khedivate-egypt> ;
     skos:altLabel "Khedivate"@eng-latn, "Khedivate Egypt (AD 1800-1922)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Muhammed Ali-Khedivate Egypt, Alawiyya Egypt, Anglo-Egyptian", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Muhammed Ali-Khedivate Egypt, Alawiyya Egypt, Anglo-Egyptian" ;
     skos:prefLabel "Khedivate Egypt (AD 1800-1922)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1922" ;
@@ -1086,8 +1102,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/egyptian-hittite-levant> ;
     skos:altLabel "Egyptian/Hittite"@eng-latn, "Egyptian/Hittite Levant (1344-1212 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Levant", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Levant" ;
     skos:prefLabel "Egyptian/Hittite Levant (1344-1212 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1212" ;
@@ -1109,8 +1126,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/iron-age-britain> ;
     skos:altLabel "Iron Age"@eng-latn, "Iron Age Britain (ca. 800 BC/BCE - ca. 100 AD/CE)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "A long time period associated with Iron Age Britain.", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "A long time period associated with Iron Age Britain." ;
     skos:prefLabel "Iron Age Britain (ca. 800 BC/BCE - ca. 100 AD/CE)" ;
     time:intervalFinishedBy [
         skos:prefLabel "100" ;
@@ -1131,8 +1149,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-antique> ;
     skos:altLabel "Late Antique"@eng-latn, "Late Antique (AD 300-AD 640)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Late Antique period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 300 and to end in the year 640 after the birth of Christ." ;
+    skos:note "The Late Antique period in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 300 and to end in the year 640 after the birth of Christ." ;
     skos:prefLabel "Late Antique (AD 300-AD 640)" ;
     time:intervalFinishedBy [
         skos:prefLabel "640" ;
@@ -1153,8 +1172,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-byzantine> ;
     skos:altLabel "Middle Byzantine"@eng-latn, "Middle Byzantine (AD 850-1200)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Middle Byzantine period in areas where such designations are appropriate.", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Middle Byzantine period in areas where such designations are appropriate." ;
     skos:prefLabel "Middle Byzantine (AD 850-1200)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1200" ;
@@ -1176,8 +1196,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/perso-ottoman-russian-caucasus> ;
     skos:altLabel "Perso-Ottoman-Russian"@eng-latn, "Perso-Ottoman-Russian Caucasus (AD 1500-1918)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Safavid-Qajar-Ottoman Empire-Russian Empire Caucasus", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Safavid-Qajar-Ottoman Empire-Russian Empire Caucasus" ;
     skos:prefLabel "Perso-Ottoman-Russian Caucasus (AD 1500-1918)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1918" ;
@@ -1198,8 +1219,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-roman-early-empire> ;
     skos:altLabel "Hellenistic-Roman Early Empire"@eng-latn, "Hellenistic-Roman Early Empire (330 BC - AD 300)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Mediterranean", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Mediterranean" ;
     skos:prefLabel "Hellenistic-Roman Early Empire (330 BC - AD 300)" ;
     time:intervalFinishedBy [
         skos:prefLabel "300" ;
@@ -1221,8 +1243,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-age-anatolia> ;
     skos:altLabel "Middle Bronze Age"@eng-latn, "Middle Bronze Age Anatolia (1750-1450 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Anatolia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Anatolia" ;
     skos:prefLabel "Middle Bronze Age Anatolia (1750-1450 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1450" ;
@@ -1244,8 +1267,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-antique-sasanian-middle-east> ;
     skos:altLabel "Late Antique/Sasanian"@eng-latn, "Late Antique/Sasanian Middle East (AD 300-640)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME" ;
     skos:prefLabel "Late Antique/Sasanian Middle East (AD 300-640)" ;
     time:intervalFinishedBy [
         skos:prefLabel "640" ;
@@ -1267,8 +1291,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/parthian-middle-east> ;
     skos:altLabel "Parthian"@eng-latn, "Parthian Middle East (140 BC - AD 226)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Arsacid ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Arsacid ME" ;
     skos:prefLabel "Parthian Middle East (140 BC - AD 226)" ;
     time:intervalFinishedBy [
         skos:prefLabel "226" ;
@@ -1290,8 +1315,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ptolemaic-egypt> ;
     skos:altLabel "Ptolemaic"@eng-latn, "Ptolemaic Egypt (304-30 BCE/BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Ptolemaic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
+    skos:note "The Ptolemaic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Ptolemaic Egypt (304-30 BCE/BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-30" ;
@@ -1312,8 +1338,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ottoman-empire> ;
     skos:altLabel "Ottoman Empire"@eng-latn, "Ottoman Empire (AD 1513-1918)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME, Balkan, Northern Africa", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME, Balkan, Northern Africa" ;
     skos:prefLabel "Ottoman Empire (AD 1513-1918)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1918" ;
@@ -1335,8 +1362,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-medieval-caucasus> ;
     skos:altLabel "Early Medieval"@eng-latn, "Early Medieval Caucasus (AD 850-1200)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Bagratid, Kingdom of Armenia/Kingdom of Georgia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Bagratid, Kingdom of Armenia/Kingdom of Georgia" ;
     skos:prefLabel "Early Medieval Caucasus (AD 850-1200)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1200" ;
@@ -1358,8 +1386,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/1500-ad-middle-east> ;
     skos:altLabel "1500 AD"@eng-latn, "1500 AD Middle East (AD 1500-1500)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME, Greece, Indus", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME, Greece, Indus" ;
     skos:prefLabel "1500 AD Middle East (AD 1500-1500)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1500" ;
@@ -1381,8 +1410,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/chalcolithic-iran> ;
     skos:altLabel "Chalcolithic"@eng-latn, "Chalcolithic Iran (5000-2500 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Iran", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Iran" ;
     skos:prefLabel "Chalcolithic Iran (5000-2500 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-2500" ;
@@ -1404,8 +1434,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/safavid-middle-east> ;
     skos:altLabel "Safavid"@eng-latn, "Safavid Middle East (AD 1501-1725)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Eastern ME, Central Asia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Eastern ME, Central Asia" ;
     skos:prefLabel "Safavid Middle East (AD 1501-1725)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1725" ;
@@ -1426,8 +1457,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/4th-millenium-bce> ;
     skos:altLabel "4th millenium BCE"@eng-latn, "4th millennium BCE"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The fourth millenium BCE as defined at http://en.wikipedia.org/wiki/4th_millennium_BC" ;
+    skos:note "The fourth millenium BCE as defined at http://en.wikipedia.org/wiki/4th_millennium_BC" ;
     skos:prefLabel "4th millenium BCE" ;
     time:intervalFinishedBy [
         skos:prefLabel "-3000" ;
@@ -1449,8 +1481,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/akkadian-ur-iii-mesopotamia> ;
     skos:altLabel "Akkadian-Ur III"@eng-latn, "Akkadian-Ur III Mesopotamia (2335-2000 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Akkadian-Neo-Sumerian Mesopotamia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Akkadian-Neo-Sumerian Mesopotamia" ;
     skos:prefLabel "Akkadian-Ur III Mesopotamia (2335-2000 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-2000" ;
@@ -1471,8 +1504,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-nubian> ;
     skos:altLabel "Middle Nubian"@eng-latn, "Middle Nubian (2300-1600 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "C-Group-Kerma-Middle Nubian-Pan-Grave-MK", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "C-Group-Kerma-Middle Nubian-Pan-Grave-MK" ;
     skos:prefLabel "Middle Nubian (2300-1600 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1600" ;
@@ -1494,8 +1528,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-early-iron-age-iran> ;
     skos:altLabel "Middle Bronze-Early Iron Age"@eng-latn, "Middle Bronze-Early Iron Age Iran (2000-650 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Iran", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Iran" ;
     skos:prefLabel "Middle Bronze-Early Iron Age Iran (2000-650 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-650" ;
@@ -1517,8 +1552,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/colonial-modern-middle-east> ;
     skos:altLabel "Colonial-Modern"@eng-latn, "Colonial-Modern Middle East (AD 1800-2000)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Late Ottoman-Colonial-Mandate Modern Middle east", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Late Ottoman-Colonial-Mandate Modern Middle east" ;
     skos:prefLabel "Colonial-Modern Middle East (AD 1800-2000)" ;
     time:intervalFinishedBy [
         skos:prefLabel "2000" ;
@@ -1539,8 +1575,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/roman-early-empire-late-antique> ;
     skos:altLabel "Roman Early Empire-Late Antique"@eng-latn, "Roman Early Empire-Late Antique (30 BC - AD 640)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Mediterranean", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Mediterranean" ;
     skos:prefLabel "Roman Early Empire-Late Antique (30 BC - AD 640)" ;
     time:intervalFinishedBy [
         skos:prefLabel "640" ;
@@ -1561,8 +1598,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/mediaeval-byzantine> ;
     skos:altLabel "Mediaeval/Byzantine"@eng-latn, "Mediaeval/Byzantine (AD 641-AD 1453)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Mediaeval period in the West, or the period from the end of Late Antiquity (640) to the fall of Constantinople in the East (1453)." ;
+    skos:note "The Mediaeval period in the West, or the period from the end of Late Antiquity (640) to the fall of Constantinople in the East (1453)." ;
     skos:prefLabel "Mediaeval/Byzantine (AD 641-AD 1453)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1453" ;
@@ -1584,8 +1622,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-hittite-anatolia> ;
     skos:altLabel "Middle Hittite"@eng-latn, "Middle Hittite Anatolia (1450-1200 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "New Kingdom Hittite", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "New Kingdom Hittite" ;
     skos:prefLabel "Middle Hittite Anatolia (1450-1200 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1200" ;
@@ -1606,8 +1645,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/proto-byzantine> ;
     skos:altLabel "Proto-Byzantine"@eng-latn, "Proto-Byzantine (AD 500-650)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Early Byzantine; includes Justinian I", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Early Byzantine; includes Justinian I" ;
     skos:prefLabel "Proto-Byzantine (AD 500-650)" ;
     time:intervalFinishedBy [
         skos:prefLabel "650" ;
@@ -1629,8 +1669,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neolithic-egypt> ;
     skos:altLabel "Neolithic"@eng-latn, "Neolithic Egypt (6000-4500 BCE/BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Neolithic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
+    skos:note "The Neolithic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Neolithic Egypt (6000-4500 BCE/BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-4500" ;
@@ -1652,8 +1693,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/new-kingdom-egypt> ;
     skos:altLabel "New Kingdom"@eng-latn, "New Kingdom Egypt (1548-1086)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The New Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
+    skos:note "The New Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "New Kingdom Egypt (1548-1086)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1086" ;
@@ -1675,8 +1717,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/elamite-western-iran> ;
     skos:altLabel "Elamite"@eng-latn, "Elamite Western Iran (3200-540 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Proto-Old-Middle-Neo-Elamite", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Proto-Old-Middle-Neo-Elamite" ;
     skos:prefLabel "Elamite Western Iran (3200-540 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-540" ;
@@ -1698,8 +1741,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neolithic-malta> ;
     skos:altLabel "Neolithic"@eng-latn, "Neolithic Period on Malta (ca. 5,000-2,500BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The neolithic or so-called \"New Stone Age\" as expressed in remains of physical culture on the island of Malta, where it appears to have lasted from around 5,000 to 2,500 BC" ;
+    skos:note "The neolithic or so-called \"New Stone Age\" as expressed in remains of physical culture on the island of Malta, where it appears to have lasted from around 5,000 to 2,500 BC" ;
     skos:prefLabel "Neolithic Period on Malta (ca. 5,000-2,500BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-2500" ;
@@ -1721,8 +1765,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/achaemenid-roman-republic-middle-east> ;
     skos:altLabel "Achaemenid-Roman Republic"@eng-latn, "Achaemenid-Roman Republic Middle East (540-30 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME" ;
     skos:prefLabel "Achaemenid-Roman Republic Middle East (540-30 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-30" ;
@@ -1744,8 +1789,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/hellenistic-parthian-middle-east> ;
     skos:altLabel "Hellenistic-Parthian"@eng-latn, "Hellenistic-Parthian Middle East (330 BC - AD 226)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Seleucid-Early Roman-Arsacid Middle East", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Seleucid-Early Roman-Arsacid Middle East" ;
     skos:prefLabel "Hellenistic-Parthian Middle East (330 BC - AD 226)" ;
     time:intervalFinishedBy [
         skos:prefLabel "226" ;
@@ -1766,8 +1812,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-ottoman-empire> ;
     skos:altLabel "Early Ottoman Empire"@eng-latn, "Early Ottoman Empire (AD 1453-1683)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "ends with the siege of Vienna" ;
+    skos:note "ends with the siege of Vienna" ;
     skos:prefLabel "Early Ottoman Empire (AD 1453-1683)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1683" ;
@@ -1788,8 +1835,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-ottoman-empire> ;
     skos:altLabel "Late Ottoman Empire"@eng-latn, "Late Ottoman Empire (AD 1683-1918)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME, Balkan, Northern Africa", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME, Balkan, Northern Africa" ;
     skos:prefLabel "Late Ottoman Empire (AD 1683-1918)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1918" ;
@@ -1811,8 +1859,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/bronze-age-britain> ;
     skos:altLabel "Bronze Age"@eng-latn, "Bronze Age Britain (ca. 2500 - ca. 800 BC/BCE)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "A long time period associated with Bronze Age Britain.", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "A long time period associated with Bronze Age Britain." ;
     skos:prefLabel "Bronze Age Britain (ca. 2500 - ca. 800 BC/BCE)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-800" ;
@@ -1833,8 +1882,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-nubian> ;
     skos:altLabel "Late Nubian"@eng-latn, "Late Nubian (1600-350 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "NK-Kushite-Meroitic", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "NK-Kushite-Meroitic" ;
     skos:prefLabel "Late Nubian (1600-350 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-350" ;
@@ -1856,8 +1906,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/later-2nd-millennium-bc-mesopotamia> ;
     skos:altLabel "Later 2nd Millennium BC"@eng-latn, "Later 2nd Millennium BC Mesopotamia (1600-1000 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Middle Assyrian/Middle Babylonian/Kassite Mesopotamia, LBA-Early Iron Age Mesopotamia, incl. Sea Peoples", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Middle Assyrian/Middle Babylonian/Kassite Mesopotamia, LBA-Early Iron Age Mesopotamia, incl. Sea Peoples" ;
     skos:prefLabel "Later 2nd Millennium BC Mesopotamia (1600-1000 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1000" ;
@@ -1879,8 +1930,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/mesolithic-levant> ;
     skos:altLabel "Mesolithic"@eng-latn, "Mesolithic Levant (18000-9500 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Epipaleolithic-Protoneolithic Levant, Kebaran-Natufian", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Epipaleolithic-Protoneolithic Levant, Kebaran-Natufian" ;
     skos:prefLabel "Mesolithic Levant (18000-9500 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-9500" ;
@@ -1902,8 +1954,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ptolemaic-roman-egypt> ;
     skos:altLabel "Ptolemaic-Roman"@eng-latn, "Ptolemaic-Roman Egypt (304 BC - AD 640)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Egypt", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Egypt" ;
     skos:prefLabel "Ptolemaic-Roman Egypt (304 BC - AD 640)" ;
     time:intervalFinishedBy [
         skos:prefLabel "640" ;
@@ -1925,8 +1978,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/crusader-seljuq-ayyubid-levant> ;
     skos:altLabel "Crusader/Seljuq-Ayyubid"@eng-latn, "Crusader/Seljuq-Ayyubid Levant (AD 1099-1291)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Latin", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Latin" ;
     skos:prefLabel "Crusader/Seljuq-Ayyubid Levant (AD 1099-1291)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1291" ;
@@ -1947,8 +2001,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/modern> ;
     skos:altLabel "Modern"@eng-latn, "Modern (AD 1700-Present)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Our present, modern era.", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Our present, modern era." ;
     skos:prefLabel "Modern (AD 1700-Present)" ;
     time:intervalFinishedBy [
         skos:prefLabel "2100" ;
@@ -1970,8 +2025,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/old-kingdom-egypt> ;
     skos:altLabel "Old Kingdom"@eng-latn, "Old Kingdom Egypt (2670-2168 BCE/BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Old Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
+    skos:note "The Old Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Old Kingdom Egypt (2670-2168 BCE/BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-2168" ;
@@ -1993,8 +2049,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/pre-pottery-neolithic-middle-east> ;
     skos:altLabel "Pre-Pottery Neolithic"@eng-latn, "Pre-Pottery Neolithic Middle East (9000-6000 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Aceramic Neolithic ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Aceramic Neolithic ME" ;
     skos:prefLabel "Pre-Pottery Neolithic Middle East (9000-6000 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-6000" ;
@@ -2016,8 +2073,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/timurid-middle-east> ;
     skos:altLabel "Timurid"@eng-latn, "Timurid Middle East (AD 1370-1501)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Eastern ME, Central Asia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Eastern ME, Central Asia" ;
     skos:prefLabel "Timurid Middle East (AD 1370-1501)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1501" ;
@@ -2039,8 +2097,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-kingdom-egypt> ;
     skos:altLabel "Middle Kingdom"@eng-latn, "Middle Kingdom Egypt (2010-1640 BCE/BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Middle Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
+    skos:note "The Middle Kingdom period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Middle Kingdom Egypt (2010-1640 BCE/BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1640" ;
@@ -2062,8 +2121,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ubaid-early-dynastic-ii-mesopotamia> ;
     skos:altLabel "Ubaid-Early Dynastic II"@eng-latn, "Ubaid-Early Dynastic II Mesopotamia (5500-2600 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Late Chalcolithic-ED II Mesopotamia, Ubaid-Uruk-Jemdet Nasr-ED Mesopotamia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Late Chalcolithic-ED II Mesopotamia, Ubaid-Uruk-Jemdet Nasr-ED Mesopotamia" ;
     skos:prefLabel "Ubaid-Early Dynastic II Mesopotamia (5500-2600 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-2600" ;
@@ -2085,8 +2145,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-bronze-age-southern-levant> ;
     skos:altLabel "Early Bronze Age"@eng-latn, "Early Bronze Age Southern Levant (3300-2000 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "southern Levant" ;
+    skos:note "southern Levant" ;
     skos:prefLabel "Early Bronze Age Southern Levant (3300-2000 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-2000" ;
@@ -2108,8 +2169,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/roman-middle-east> ;
     skos:altLabel "Roman"@eng-latn, "Roman Middle East (140 BC - AD 640)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME" ;
     skos:prefLabel "Roman Middle East (140 BC - AD 640)" ;
     time:intervalFinishedBy [
         skos:prefLabel "640" ;
@@ -2131,8 +2193,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/caliphate-umayyad-middle-east> ;
     skos:altLabel "Caliphate-Umayyad"@eng-latn, "Caliphate-Umayyad Middle East (AD 632-750)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Early Islamic, Rashidun-Umayyad (starts with death of Muhammed who only controlled Arabia)", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Early Islamic, Rashidun-Umayyad (starts with death of Muhammed who only controlled Arabia)" ;
     skos:prefLabel "Caliphate-Umayyad Middle East (AD 632-750)" ;
     time:intervalFinishedBy [
         skos:prefLabel "750" ;
@@ -2154,8 +2217,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/seljuq-khwarezmian-middle-east> ;
     skos:altLabel "Seljuq-Khwarezmian"@eng-latn, "Seljuq-Khwarezmian Middle East (AD 1037-1258)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME" ;
     skos:prefLabel "Seljuq-Khwarezmian Middle East (AD 1037-1258)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1258" ;
@@ -2176,8 +2240,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-byzantine> ;
     skos:altLabel "Early Byzantine"@eng-latn, "Early Byzantine (AD 650-850)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Early Byzantine Period in areas where such designations are appropriate.", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Early Byzantine Period in areas where such designations are appropriate." ;
     skos:prefLabel "Early Byzantine (AD 650-850)" ;
     time:intervalFinishedBy [
         skos:prefLabel "850" ;
@@ -2198,8 +2263,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-geometric> ;
     skos:altLabel "Middle Geometric"@eng-latn, "Middle Geometric (Greek; 850-750 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Middle Geometric period in ancient Greece, from 850-750 before the birth of Christ." ;
+    skos:note "The Middle Geometric period in ancient Greece, from 850-750 before the birth of Christ." ;
     skos:prefLabel "Middle Geometric (Greek; 850-750 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-750" ;
@@ -2221,8 +2287,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/pottery-neolithic-middle-east> ;
     skos:altLabel "Pottery Neolithic"@eng-latn, "Pottery Neolithic Middle East (6000-4500 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME" ;
     skos:prefLabel "Pottery Neolithic Middle East (6000-4500 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-4500" ;
@@ -2244,8 +2311,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/bronze-age-malta> ;
     skos:altLabel "Bronze Age"@eng-latn, "Bronze Age Malta (ca. 2,500-700 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Bronze age as represented in the remains of physical culture from the island of Malta." ;
+    skos:note "The Bronze age as represented in the remains of physical culture from the island of Malta." ;
     skos:prefLabel "Bronze Age Malta (ca. 2,500-700 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-700" ;
@@ -2267,8 +2335,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-late-iron-age-anatolia> ;
     skos:altLabel "Middle-Late Iron Age"@eng-latn, "Middle-Late Iron Age Anatolia (700-500 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Anatolia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Anatolia" ;
     skos:prefLabel "Middle-Late Iron Age Anatolia (700-500 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-500" ;
@@ -2290,8 +2359,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neolithic-middle-east> ;
     skos:altLabel "Neolithic"@eng-latn, "Neolithic Middle East (9000-4500 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME" ;
     skos:prefLabel "Neolithic Middle East (9000-4500 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-4500" ;
@@ -2313,8 +2383,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/iron-age-italy-latial-culture-i-1000-900-bc> ;
     skos:altLabel "Iron Age"@eng-latn, "Iron Age Italy (Latial Culture I, 1000-900 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Latial I is concentrated around Rome, the Alban Hills, and the Monti della Tolfa.", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Latial I is concentrated around Rome, the Alban Hills, and the Monti della Tolfa." ;
     skos:prefLabel "Iron Age Italy (Latial Culture I, 1000-900 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-900" ;
@@ -2336,8 +2407,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ilkhanate-middle-east> ;
     skos:altLabel "Ilkhanate"@eng-latn, "Ilkhanate Middle East (AD 1258-1335)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Ilkhanid, Hulagu, Early Mongol", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Ilkhanid, Hulagu, Early Mongol" ;
     skos:prefLabel "Ilkhanate Middle East (AD 1258-1335)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1335" ;
@@ -2359,8 +2431,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-iron-age-anatolia> ;
     skos:altLabel "Early Iron Age"@eng-latn, "Early Iron Age Anatolia (1200-700 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "incl. Mitanni" ;
+    skos:note "incl. Mitanni" ;
     skos:prefLabel "Early Iron Age Anatolia (1200-700 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-700" ;
@@ -2381,8 +2454,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/old-nubian> ;
     skos:altLabel "Old Nubian"@eng-latn, "Old Nubian (3800-2300 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "A-Group/Old Nubian-Middle Nubian-OK", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "A-Group/Old Nubian-Middle Nubian-OK" ;
     skos:prefLabel "Old Nubian (3800-2300 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-2300" ;
@@ -2404,8 +2478,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/third-intermediate-period-egypt> ;
     skos:altLabel "Third Intermediate"@eng-latn, "Third Intermediate Period Egypt (1086-664)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Third Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
+    skos:note "The Third Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Third Intermediate Period Egypt (1086-664)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-664" ;
@@ -2427,8 +2502,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/1200-bc-middle-east> ;
     skos:altLabel "1200 BC"@eng-latn, "1200 BC Middle East"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME, Greece", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME, Greece" ;
     skos:prefLabel "1200 BC Middle East" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1199" ;
@@ -2449,8 +2525,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ummayad> ;
     skos:altLabel "Ummayad"@eng-latn, "Ummayad Period (661-750CE)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The period of the Umayyad Caliphate as defined by http://en.wikipedia.org/wiki/Umayyad_Caliphate" ;
+    skos:note "The period of the Umayyad Caliphate as defined by http://en.wikipedia.org/wiki/Umayyad_Caliphate" ;
     skos:prefLabel "Ummayad Period (661-750CE)" ;
     time:intervalFinishedBy [
         skos:prefLabel "750" ;
@@ -2471,8 +2548,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/archaic> ;
     skos:altLabel "Archaic"@eng-latn, "Archaic (Greco-Roman; 750-550 BCE/BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Archaic period in Greek and Roman history. For the purposes of Pleiades, this period is seen to begin in the year 750 and end in the year 550 before the birth of Christ." ;
+    skos:note "The Archaic period in Greek and Roman history. For the purposes of Pleiades, this period is seen to begin in the year 750 and end in the year 550 before the birth of Christ." ;
     skos:prefLabel "Archaic (Greco-Roman; 750-550 BCE/BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-550" ;
@@ -2494,8 +2572,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/2nd-millennium-bc-egypt> ;
     skos:altLabel "2nd Millennium BC"@eng-latn, "2nd Millennium BC Egypt (2000-1000 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Egypt", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Egypt" ;
     skos:prefLabel "2nd Millennium BC Egypt (2000-1000 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1000" ;
@@ -2517,8 +2596,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-bronze-age-anatolia> ;
     skos:altLabel "Early Bronze Age"@eng-latn, "Early Bronze Age Anatolia (2000-1750 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Karum Anatolia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Karum Anatolia" ;
     skos:prefLabel "Early Bronze Age Anatolia (2000-1750 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1750" ;
@@ -2540,8 +2620,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/mamluk-middle-east> ;
     skos:altLabel "Mamluk"@eng-latn, "Mamluk Middle East (AD 1258-1516)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "Western ME" ;
+    skos:note "Western ME" ;
     skos:prefLabel "Mamluk Middle East (AD 1258-1516)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1516" ;
@@ -2563,8 +2644,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neolithic-british> ;
     skos:altLabel "Neolithic"@eng-latn, "Neolithic Period (British Isles; 4,000-2,500 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Neolithic period in the British Isles, after Wikipedia, Neolithic British Isles, http://en.wikipedia.org/wiki/Neolithic_British_Isles." ;
+    skos:note "The Neolithic period in the British Isles, after Wikipedia, Neolithic British Isles, http://en.wikipedia.org/wiki/Neolithic_British_Isles." ;
     skos:prefLabel "Neolithic Period (British Isles; 4,000-2,500 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-2500" ;
@@ -2585,8 +2667,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-antique-late-byzantine> ;
     skos:altLabel "Late Antique-Late Byzantine"@eng-latn, "Late Antique-Late Byzantine (AD 300-1450)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME" ;
     skos:prefLabel "Late Antique-Late Byzantine (AD 300-1450)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1450" ;
@@ -2608,8 +2691,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/2nd-millennium-bc-levant> ;
     skos:altLabel "2nd Millennium BC"@eng-latn, "2nd Millennium BC Levant (2000-1000 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "MBA Levant-LBA Levant-Iron Age I Levant (not sure as these are all taken from southern Levant periodisation)", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "MBA Levant-LBA Levant-Iron Age I Levant (not sure as these are all taken from southern Levant periodisation)" ;
     skos:prefLabel "2nd Millennium BC Levant (2000-1000 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1000" ;
@@ -2631,8 +2715,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/abassid-middle-east> ;
     skos:altLabel "Abassid"@eng-latn, "Abassid Middle East (AD 750-940)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME, northern Africa", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME, northern Africa" ;
     skos:prefLabel "Abassid Middle East (AD 750-940)" ;
     time:intervalFinishedBy [
         skos:prefLabel "940" ;
@@ -2654,8 +2739,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/roman-early-byzantine-middle-east> ;
     skos:altLabel "Roman-Early Byzantine"@eng-latn, "Roman-Early Byzantine Middle East (140 BC - AD 850)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME" ;
     skos:prefLabel "Roman-Early Byzantine Middle East (140 BC - AD 850)" ;
     time:intervalFinishedBy [
         skos:prefLabel "850" ;
@@ -2676,8 +2762,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-byzantine-ottoman-rise> ;
     skos:altLabel "Late Byzantine/Ottoman Rise"@eng-latn, "Late Byzantine/Ottoman Rise (AD 1200-1453)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Aegean, Balkan & Anatolia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Aegean, Balkan & Anatolia" ;
     skos:prefLabel "Late Byzantine/Ottoman Rise (AD 1200-1453)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1453" ;
@@ -2699,8 +2786,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/crusader-byzantine-seljuq-middle-east> ;
     skos:altLabel "Crusader/Byzantine/Seljuq"@eng-latn, "Crusader/Byzantine/Seljuq Middle East (AD 1081-1204)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Latin/1st-4th Crusades-end of Middle Byzantine-Rum/Seljuq", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Latin/1st-4th Crusades-end of Middle Byzantine-Rum/Seljuq" ;
     skos:prefLabel "Crusader/Byzantine/Seljuq Middle East (AD 1081-1204)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1204" ;
@@ -2722,8 +2810,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middle-bronze-age-southern-levant> ;
     skos:altLabel "Middle Bronze Age"@eng-latn, "Middle Bronze Age Southern Levant (2000-1400 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "southern Levant" ;
+    skos:note "southern Levant" ;
     skos:prefLabel "Middle Bronze Age Southern Levant (2000-1400 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1400" ;
@@ -2744,8 +2833,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-geometric> ;
     skos:altLabel "Early Geometric"@eng-latn, "Early Geometric (Greek; 900-850 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Early Geometric period in ancient Greece, from 900-850 before the birth of Christ." ;
+    skos:note "The Early Geometric period in ancient Greece, from 900-850 before the birth of Christ." ;
     skos:prefLabel "Early Geometric (Greek; 900-850 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-850" ;
@@ -2767,8 +2857,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/old-babylonian-assyrian-mesopotamia> ;
     skos:altLabel "Old Babylonian/Assyrian"@eng-latn, "Old Babylonian/Assyrian Mesopotamia (2000-1600 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Mesopotamia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Mesopotamia" ;
     skos:prefLabel "Old Babylonian/Assyrian Mesopotamia (2000-1600 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1600" ;
@@ -2790,8 +2881,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ottoman-decline-mandate-middle-east> ;
     skos:altLabel "Ottoman Decline-Mandate"@eng-latn, "Ottoman Decline-Mandate Middle East (AD 1900-1950)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME" ;
     skos:prefLabel "Ottoman Decline-Mandate Middle East (AD 1900-1950)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1950" ;
@@ -2813,8 +2905,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/ubaid> ;
     skos:altLabel "Ubaid"@eng-latn, "Ubaid period in Mesopotamia (ca. 6500 to 3800 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The prehistoric Ubaid period of Mesopotamia, as defined by Wikipedia following Carter, Robert A. and Philip, Graham Beyond the Ubaid: Transformation and Integration in the Late Prehistoric Societies of the Middle East (Studies in Ancient Oriental Civilization, Number 63) The Oriental Institute of the University of Chicago (2010) ISBN 978-1-885923-66-0 p.2, at http://oi.uchicago.edu/research/pubs/catalog/saoc/saoc63.html" ;
+    skos:note "The prehistoric Ubaid period of Mesopotamia, as defined by Wikipedia following Carter, Robert A. and Philip, Graham Beyond the Ubaid: Transformation and Integration in the Late Prehistoric Societies of the Middle East (Studies in Ancient Oriental Civilization, Number 63) The Oriental Institute of the University of Chicago (2010) ISBN 978-1-885923-66-0 p.2, at http://oi.uchicago.edu/research/pubs/catalog/saoc/saoc63.html" ;
     skos:prefLabel "Ubaid period in Mesopotamia (ca. 6500 to 3800 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-3800" ;
@@ -2836,8 +2929,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/rum-crusader-anatolia> ;
     skos:altLabel "Rum/Crusader"@eng-latn, "Rum/Crusader Anatolia (AD 1077-1307)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Seljuk-Latin States/Francocracy", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Seljuk-Latin States/Francocracy" ;
     skos:prefLabel "Rum/Crusader Anatolia (AD 1077-1307)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1307" ;
@@ -2859,8 +2953,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/13th-century-ad-eastern-mediterranean> ;
     skos:altLabel "13th Century AD"@eng-latn, "13th Century AD Eastern Mediterranean (AD 1200-1300)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Late Byzantine-Ayyubid-Mamluk Western Middle East", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Late Byzantine-Ayyubid-Mamluk Western Middle East" ;
     skos:prefLabel "13th Century AD Eastern Mediterranean (AD 1200-1300)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1300" ;
@@ -2882,8 +2977,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/late-helladic> ;
     skos:altLabel "Late Helladic"@eng-latn, "Late Helladic (Mainland Greece; 1600-1200 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Late Helladic period in the Greek mainland, after Preziosi and Hitchcock, Aegean Art and Architecture, Oxford History of Art, 1998." ;
+    skos:note "The Late Helladic period in the Greek mainland, after Preziosi and Hitchcock, Aegean Art and Architecture, Oxford History of Art, 1998." ;
     skos:prefLabel "Late Helladic (Mainland Greece; 1600-1200 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1200" ;
@@ -2905,8 +3001,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/modern-middle-east> ;
     skos:altLabel "Modern"@eng-latn, "Modern Middle East (AD 1918-2000)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME" ;
     skos:prefLabel "Modern Middle East (AD 1918-2000)" ;
     time:intervalFinishedBy [
         skos:prefLabel "2000" ;
@@ -2928,8 +3025,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/sassanian-middle-east> ;
     skos:altLabel "Sassanian"@eng-latn, "Sassanian Middle East (AD 262-700)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Sassanid", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Sassanid" ;
     skos:prefLabel "Sassanian Middle East (AD 262-700)" ;
     time:intervalFinishedBy [
         skos:prefLabel "700" ;
@@ -2951,8 +3049,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-dynastic-mesopotamia> ;
     skos:altLabel "Early Dynastic"@eng-latn, "Early Dynastic Mesopotamia (2950-2350 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Mesopotamia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Mesopotamia" ;
     skos:prefLabel "Early Dynastic Mesopotamia (2950-2350 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-2350" ;
@@ -2974,8 +3073,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/middleminoan> ;
     skos:altLabel "Middle Minoan"@eng-latn, "Middle Minoan (Crete; 2000-1600 BC/BCE)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Middle Minoan period on Crete, as defined in C. Shelmerdine, The Cambridge Companion to the Aegean Bronze Age (2008), p. 4, figure 1.1." ;
+    skos:note "The Middle Minoan period on Crete, as defined in C. Shelmerdine, The Cambridge Companion to the Aegean Bronze Age (2008), p. 4, figure 1.1." ;
     skos:prefLabel "Middle Minoan (Crete; 2000-1600 BC/BCE)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1600" ;
@@ -2997,8 +3097,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/fatimid-middle-east> ;
     skos:altLabel "Fatimid"@eng-latn, "Fatimid Middle East (AD 950-1150)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "Western ME, northern Africa" ;
+    skos:note "Western ME, northern Africa" ;
     skos:prefLabel "Fatimid Middle East (AD 950-1150)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1150" ;
@@ -3020,8 +3121,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/chalcolithic-mesopotamia> ;
     skos:altLabel "Chalcolithic"@eng-latn, "Chalcolithic Mesopotamia (6200-3750 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Copper Age Mesopotamia, Halaf-Ubaid-Early Uruk Mesopotamia", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Copper Age Mesopotamia, Halaf-Ubaid-Early Uruk Mesopotamia" ;
     skos:prefLabel "Chalcolithic Mesopotamia (6200-3750 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-3750" ;
@@ -3043,8 +3145,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neo-hittite-northern-levant> ;
     skos:altLabel "Neo-Hittite"@eng-latn, "Neo-Hittite Northern Levant (1200-700 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "Syro-Hittite Northern Levant" ;
+    skos:note "Syro-Hittite Northern Levant" ;
     skos:prefLabel "Neo-Hittite Northern Levant (1200-700 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-700" ;
@@ -3066,8 +3169,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/persian-medieval-caucasus> ;
     skos:altLabel "Persian-Medieval"@eng-latn, "Persian-Medieval Caucasus (AD 600-1500)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Persian-Arabic-Early Medieval-Middle Medieval-Turco-Mongol/Late Medieval Caucasus", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Persian-Arabic-Early Medieval-Middle Medieval-Turco-Mongol/Late Medieval Caucasus" ;
     skos:prefLabel "Persian-Medieval Caucasus (AD 600-1500)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1500" ;
@@ -3088,8 +3192,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/3rd-millennium-bc> ;
     skos:altLabel "3rd millennium BC"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The 3rd millennium BC spans the Early to Middle Bronze Age. As described at http://en.wikipedia.org/wiki/3rd_millennium_BC." ;
+    skos:note "The 3rd millennium BC spans the Early to Middle Bronze Age. As described at http://en.wikipedia.org/wiki/3rd_millennium_BC." ;
     skos:prefLabel "3rd millennium BC" ;
     time:intervalFinishedBy [
         skos:prefLabel "-2000" ;
@@ -3111,8 +3216,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neolithic-eastern-med> ;
     skos:altLabel "Neolithic"@eng-latn, "Neolithic Period in the Eastern Mediterranean (ca. 10,000-3,300 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The so-called \"Neolithic\" or \"New Stone Age\" period as defined in the Eastern portion of the Mediterranean basin, lasting roughly from 10,000 - 3,300 BC. See further: http://ancienthistory.about.com/od/artarchaeologyarchitect/g/neolithic.htm" ;
+    skos:note "The so-called \"Neolithic\" or \"New Stone Age\" period as defined in the Eastern portion of the Mediterranean basin, lasting roughly from 10,000 - 3,300 BC. See further: http://ancienthistory.about.com/od/artarchaeologyarchitect/g/neolithic.htm" ;
     skos:prefLabel "Neolithic Period in the Eastern Mediterranean (ca. 10,000-3,300 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-3300" ;
@@ -3134,8 +3240,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/early-middle-bronze-age-iran> ;
     skos:altLabel "Early-Middle Bronze Age"@eng-latn, "Early-Middle Bronze Age Iran (2500-1500 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Iran", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Iran" ;
     skos:prefLabel "Early-Middle Bronze Age Iran (2500-1500 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1500" ;
@@ -3157,8 +3264,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/neo-assyrian-babylonian-middle-east> ;
     skos:altLabel "Neo-Assyrian/Babylonian"@eng-latn, "Neo-Assyrian/Babylonian Middle East (720-540 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME" ;
     skos:prefLabel "Neo-Assyrian/Babylonian Middle East (720-540 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-540" ;
@@ -3180,8 +3288,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/first-intermediate-period-egypt> ;
     skos:altLabel "First Intermediate Period"@eng-latn, "First Intermediate Period Egypt (2168-2010 BCE/BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The First Intermediate Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
+    skos:note "The First Intermediate Period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "First Intermediate Period Egypt (2168-2010 BCE/BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-2010" ;
@@ -3203,8 +3312,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/macedonian-egypt> ;
     skos:altLabel "Macedonian"@eng-latn, "Macedonian Egypt (332-304 BCE/BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Macedonian period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
+    skos:note "The Macedonian period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Macedonian Egypt (332-304 BCE/BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-304" ;
@@ -3225,8 +3335,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/roman> ;
     skos:altLabel " early Empire"@eng-latn, "Roman"@eng-latn, "Roman, early Empire"@eng-latn, "Roman, early Empire (30 BC-AD 300)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Roman period (i.e., the early Roman Empire) in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 30 before the birth of Christ and to end in the year 300 after the birth of Christ." ;
+    skos:note "The Roman period (i.e., the early Roman Empire) in Greek and Roman history. For the purposes of Pleiades, this period is said to begin in the year 30 before the birth of Christ and to end in the year 300 after the birth of Christ." ;
     skos:prefLabel "Roman, early Empire (30 BC-AD 300)" ;
     time:intervalFinishedBy [
         skos:prefLabel "300" ;
@@ -3248,8 +3359,8 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/iron-age-southern-levant> ;
     skos:altLabel "Iron Age"@eng-latn, "Iron Age Southern Levant"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:prefLabel "Iron Age Southern Levant" ;
     time:intervalFinishedBy [
         skos:prefLabel "-550" ;
@@ -3271,8 +3382,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/roman-early-empire-parthian-middle-east> ;
     skos:altLabel "Roman Early Empire/Parthian"@eng-latn, "Roman Early Empire/Parthian Middle East (30 BC - AD 226)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Early Roman/Parthian", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "Early Roman/Parthian" ;
     skos:prefLabel "Roman Early Empire/Parthian Middle East (30 BC - AD 226)" ;
     time:intervalFinishedBy [
         skos:prefLabel "226" ;
@@ -3294,8 +3406,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/paleolithic-middle-east> ;
     skos:altLabel "Paleolithic"@eng-latn, "Paleolithic Middle East (2600000-18000 BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "ME", "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
+    skos:note "ME" ;
     skos:prefLabel "Paleolithic Middle East (2600000-18000 BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-18000" ;
@@ -3317,8 +3430,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/predynastic-egypt> ;
     skos:altLabel "Predynastic"@eng-latn, "Predynastic Egypt (4500-2950 BCE/BC)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The predynastic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
+    skos:note "The predynastic period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Predynastic Egypt (4500-2950 BCE/BC)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-2950" ;
@@ -3340,8 +3454,9 @@
     a skos:Concept ;
     owl:sameAs <http://pleiades.stoa.org/vocabularies/time-periods/second-intermediate-period-egypt> ;
     skos:altLabel "Second Intermediate"@eng-latn, "Second Intermediate Period Egypt (1640-1548)"@eng-latn ;
+    skos:editorialNote "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. " ;
     skos:inScheme <p03wskd> ;
-    skos:note "Spatial coverage values were extracted from the geographic locations of sites to which this period term had been attached. ", "The Second Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
+    skos:note "The Second Intermediate period in Egypt, following the chronology of the UCLA Encyclopedia of Egyptology (compiled by Thomas Schneider): http://www.uee.ucla.edu/contributors/chronology.htm." ;
     skos:prefLabel "Second Intermediate Period Egypt (1640-1548)" ;
     time:intervalFinishedBy [
         skos:prefLabel "-1548" ;
@@ -3442,8 +3557,8 @@
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Old Elamite"@eng-latn ;
+    skos:editorialNote "unsure why GeoDia listed this twice, both inaccurate to the text (2400-2200 B.C. & 2200-2000 B.C.)." ;
     skos:inScheme <p047fhm> ;
-    skos:note "unsure why GeoDia listed this twice, both inaccurate to the text (2400-2200 B.C. & 2200-2000 B.C.)." ;
     skos:prefLabel "Old Elamite" ;
     time:intervalFinishedBy [
         skos:prefLabel "1500 B.C." ;
@@ -3467,8 +3582,9 @@
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Susa II"@eng-latn, "Susa II archaeological period"@eng-latn ;
+    skos:editorialNote "unsure why listed in GeoDia with dates 3700-3500 B.C." ;
     skos:inScheme <p047fhm> ;
-    skos:note "Prehistoric Susa II, corresponds to Mesopotamian Ubaid period.", "unsure why listed in GeoDia with dates 3700-3500 B.C." ;
+    skos:note "Prehistoric Susa II, corresponds to Mesopotamian Ubaid period." ;
     skos:prefLabel "Susa II archaeological period" ;
     time:intervalFinishedBy [
         skos:prefLabel "3100 B.C." ;
@@ -3540,8 +3656,9 @@
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Susa I"@eng-latn, "Susa I archaeological period"@eng-latn ;
+    skos:editorialNote "GeoDia listed the two archaeological periods of Susa I (4200-3700 B.C.) and Susa II (3700-3500 B.C.)." ;
     skos:inScheme <p047fhm> ;
-    skos:note "GeoDia listed the two archaeological periods of Susa I (4200-3700 B.C.) and Susa II (3700-3500 B.C.).", "This period designates prehistoric Susa and corresponds to Ubaid period in Mesopotamia." ;
+    skos:note "This period designates prehistoric Susa and corresponds to Ubaid period in Mesopotamia." ;
     skos:prefLabel "Susa I archaeological period" ;
     time:intervalFinishedBy [
         skos:prefLabel "3500 B.C." ;
@@ -3949,8 +4066,9 @@
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Proto-Elamite"@eng-latn, "Protoliterate"@eng-latn, "Protoliterate: Proto-Elamite"@eng-latn ;
+    skos:editorialNote "Listed as historic period, not archaeological period." ;
     skos:inScheme <p047fhm> ;
-    skos:note "Listed as historic period, not archaeological period.", "This period corresponds to Proto-Literate period in Mesopotamia." ;
+    skos:note "This period corresponds to Proto-Literate period in Mesopotamia." ;
     skos:prefLabel "Protoliterate: Proto-Elamite" ;
     time:intervalFinishedBy [
         skos:prefLabel "2700 B.C." ;
@@ -9177,8 +9295,8 @@
     dcterms:spatial <http://dbpedia.org/resource/Israel> ;
     a skos:Concept ;
     skos:altLabel "Iron III"@eng-latn, "Neo-Babylonian"@eng-latn ;
+    skos:editorialNote "this date: see also Mazar, 1992" ;
     skos:inScheme <p077fc5> ;
-    skos:note "this date: see also Mazar, 1992" ;
     skos:prefLabel "Iron III" ;
     time:intervalFinishedBy [
         skos:prefLabel "539 BCE" ;
@@ -9296,8 +9414,8 @@
     dcterms:spatial <http://dbpedia.org/resource/Roman_Empire> ;
     a skos:Concept ;
     skos:altLabel "Republican"@eng-latn ;
+    skos:editorialNote "GeoDia had 9 separate entries for Republican (unclear), each with different spatial coverages. Could add back later if figure out page sources." ;
     skos:inScheme <p077pzf> ;
-    skos:note "GeoDia had 9 separate entries for Republican (unclear), each with different spatial coverages. Could add back later if figure out page sources." ;
     skos:prefLabel "Republican" ;
     time:intervalFinishedBy [
         skos:prefLabel "142 B.C." ;
@@ -10255,8 +10373,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Archaic"@eng-latn ;
+    skos:editorialNote "Gates notes \"to the end of the Persian Wars\"" ;
     skos:inScheme <p083p5r> ;
-    skos:note "Gates notes \"to the end of the Persian Wars\"" ;
     skos:prefLabel "Archaic" ;
     time:intervalFinishedBy [
         skos:prefLabel "479 BC" ;
@@ -10424,8 +10542,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Protogeometric"@eng-latn ;
+    skos:editorialNote "Gates discusses Greek cities that are now in the territory of Turkey, although he does not refer to Anatolia specifically." ;
     skos:inScheme <p083p5r> ;
-    skos:note "Gates discusses Greek cities that are now in the territory of Turkey, although he does not refer to Anatolia specifically." ;
     skos:prefLabel "Protogeometric" ;
     time:intervalFinishedBy [
         skos:prefLabel "900 BC" ;
@@ -10491,8 +10609,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Crete> ;
     a skos:Concept ;
     skos:altLabel "Old Palace"@eng-latn, "Old Palace (Protopalatial)"@eng-latn, "Protopalatial"@eng-latn ;
+    skos:editorialNote "\"(= Middle Minoan IB)\"" ;
     skos:inScheme <p083p5r> ;
-    skos:note "\"(= Middle Minoan IB)\"" ;
     skos:prefLabel "Old Palace (Protopalatial)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1700 BC" ;
@@ -10589,8 +10707,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iran> ;
     a skos:Concept ;
     skos:altLabel "Achaemenids"@eng-latn, "Archaemenid"@eng-latn ;
+    skos:editorialNote "Gates discusses only the Achaemenids in Persia proper in this chapter." ;
     skos:inScheme <p083p5r> ;
-    skos:note "Gates discusses only the Achaemenids in Persia proper in this chapter." ;
     skos:prefLabel "Achaemenids" ;
     time:intervalFinishedBy [
         skos:prefLabel "330 BC" ;
@@ -10686,8 +10804,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
     skos:altLabel "Early Classical"@eng-latn ;
+    skos:editorialNote "Gates concentrates on Athens, so Greece is most appropriate coverage." ;
     skos:inScheme <p083p5r> ;
-    skos:note "Gates concentrates on Athens, so Greece is most appropriate coverage." ;
     skos:prefLabel "Early Classical" ;
     time:intervalFinishedBy [
         skos:prefLabel "450 BC" ;
@@ -10711,8 +10829,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Geometric"@eng-latn ;
+    skos:editorialNote "Gates discusses Greek cities that are now in the territory of Turkey, although he does not refer to Anatolia specifically." ;
     skos:inScheme <p083p5r> ;
-    skos:note "Gates discusses Greek cities that are now in the territory of Turkey, although he does not refer to Anatolia specifically." ;
     skos:prefLabel "Geometric" ;
     time:intervalFinishedBy [
         skos:prefLabel "700 BC" ;
@@ -10760,8 +10878,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
     skos:altLabel "High Classical"@eng-latn ;
+    skos:editorialNote "Gates concentrates on Athens, so Greece is most appropriate coverage." ;
     skos:inScheme <p083p5r> ;
-    skos:note "Gates concentrates on Athens, so Greece is most appropriate coverage." ;
     skos:prefLabel "High Classical" ;
     time:intervalFinishedBy [
         skos:prefLabel "400 BC" ;
@@ -10857,8 +10975,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Hellenistic"@eng-latn ;
+    skos:editorialNote "Gates notes \"to the Battle of Actium\"" ;
     skos:inScheme <p083p5r> ;
-    skos:note "Gates notes \"to the Battle of Actium\"" ;
     skos:prefLabel "Hellenistic" ;
     time:intervalFinishedBy [
         skos:prefLabel "31 BC" ;
@@ -11266,8 +11384,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Late Classical"@eng-latn ;
+    skos:editorialNote "The chapter associated with this term covers sites in both Greece and Turkey, although map of conquests of Alexander also covers the Levant, Egypt, Iraq, Iran, Afghanistan, and parts of India and Pakistan." ;
     skos:inScheme <p083p5r> ;
-    skos:note "The chapter associated with this term covers sites in both Greece and Turkey, although map of conquests of Alexander also covers the Levant, Egypt, Iraq, Iran, Afghanistan, and parts of India and Pakistan." ;
     skos:prefLabel "Late Classical" ;
     time:intervalFinishedBy [
         skos:prefLabel "323 BC" ;
@@ -11315,8 +11433,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Crete> ;
     a skos:Concept ;
     skos:altLabel "Post-Palatial"@eng-latn ;
+    skos:editorialNote "\"(= Late Minoan IIIA, B, and C)\"" ;
     skos:inScheme <p083p5r> ;
-    skos:note "\"(= Late Minoan IIIA, B, and C)\"" ;
     skos:prefLabel "Post-Palatial" ;
     time:intervalFinishedBy [
         skos:prefLabel "1050 BC" ;
@@ -11388,8 +11506,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Crete> ;
     a skos:Concept ;
     skos:altLabel "Neopalatial"@eng-latn, "New Palace"@eng-latn, "New Palace (Neopalatial)"@eng-latn ;
+    skos:editorialNote "\"(= Middle Minoan III, Late Minoan IA and B)\"" ;
     skos:inScheme <p083p5r> ;
-    skos:note "\"(= Middle Minoan III, Late Minoan IA and B)\"" ;
     skos:prefLabel "New Palace (Neopalatial)" ;
     time:intervalFinishedBy [
         skos:prefLabel "1450 BC" ;
@@ -11437,8 +11555,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Classical"@eng-latn ;
+    skos:editorialNote "Gates notes \"to the death of Alexander the Great\"" ;
     skos:inScheme <p083p5r> ;
-    skos:note "Gates notes \"to the death of Alexander the Great\"" ;
     skos:prefLabel "Classical" ;
     time:intervalFinishedBy [
         skos:prefLabel "323 BC" ;
@@ -11630,8 +11748,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Early Archaic"@eng-latn, "Orientalizing"@eng-latn, "Orientalizing (Early Archaic)"@eng-latn ;
+    skos:editorialNote "Gates discusses Greek cities that are now in the territory of Turkey, although he does not refer to Anatolia specifically." ;
     skos:inScheme <p083p5r> ;
-    skos:note "Gates discusses Greek cities that are now in the territory of Turkey, although he does not refer to Anatolia specifically." ;
     skos:prefLabel "Orientalizing (Early Archaic)" ;
     time:intervalFinishedBy [
         skos:prefLabel "600 BC" ;
@@ -11655,8 +11773,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/India>, <http://dbpedia.org/resource/Pakistan> ;
     a skos:Concept ;
     skos:altLabel "Harappan"@eng-latn, "Harappan, or Mature"@eng-latn ;
+    skos:editorialNote "Indus Valley is defined as \"a region now situated in modern Pakistan and north-west India\"" ;
     skos:inScheme <p083p5r> ;
-    skos:note "Indus Valley is defined as \"a region now situated in modern Pakistan and north-west India\"" ;
     skos:prefLabel "Harappan, or Mature" ;
     time:intervalFinishedBy [
         skos:prefLabel "1900 BC" ;
@@ -22936,8 +23054,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
     skos:altLabel "Persian"@eng-latn ;
+    skos:editorialNote "In GeoDia as \"Achaemenid\". " ;
     skos:inScheme <p08tf6p> ;
-    skos:note "In GeoDia as \"Achaemenid\". " ;
     skos:prefLabel "Persian" ;
     time:intervalFinishedBy [
         skos:prefLabel "331 B.C.E." ;
@@ -22985,8 +23103,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
     skos:altLabel "Neo-Sumerian"@eng-latn ;
+    skos:editorialNote "In chronological discussion on p. 56, refers to this as the Third Dynasty of Ur." ;
     skos:inScheme <p08tf6p> ;
-    skos:note "In chronological discussion on p. 56, refers to this as the Third Dynasty of Ur." ;
     skos:prefLabel "Neo-Sumerian" ;
     time:intervalFinishedBy [
         skos:prefLabel "2004 B.C.E." ;
@@ -23058,8 +23176,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iran> ;
     a skos:Concept ;
     skos:altLabel "Neo-Babylonian"@eng-latn ;
+    skos:editorialNote "In GeoDia as \"Median\". " ;
     skos:inScheme <p08tf6p> ;
-    skos:note "In GeoDia as \"Median\". " ;
     skos:prefLabel "Neo-Babylonian" ;
     time:intervalFinishedBy [
         skos:prefLabel "539 B.C.E." ;
@@ -23107,8 +23225,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
     skos:altLabel "Old Babylonian"@eng-latn ;
+    skos:editorialNote "Old Babylonian and Old Assyrian grouped together under one heading on p. 340." ;
     skos:inScheme <p08tf6p> ;
-    skos:note "Old Babylonian and Old Assyrian grouped together under one heading on p. 340." ;
     skos:prefLabel "Old Babylonian" ;
     time:intervalFinishedBy [
         skos:prefLabel "1600 B.C.E." ;
@@ -23132,8 +23250,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
     skos:altLabel "Jemdet Nasr"@eng-latn ;
+    skos:editorialNote "in chronological discussion on p. 55, provides \"ca.\" before date" ;
     skos:inScheme <p08tf6p> ;
-    skos:note "in chronological discussion on p. 55, provides \"ca.\" before date" ;
     skos:prefLabel "Jemdet Nasr" ;
     time:intervalFinishedBy [
         skos:prefLabel "2900 B.C.E." ;
@@ -23181,8 +23299,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Middle Assyrian"@eng-latn ;
+    skos:editorialNote "Dates different in GeoDia." ;
     skos:inScheme <p08tf6p> ;
-    skos:note "Dates different in GeoDia." ;
     skos:prefLabel "Middle Assyrian" ;
     time:intervalFinishedBy [
         skos:prefLabel "1000 B.C.E." ;
@@ -23206,8 +23324,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Old Assyrian"@eng-latn ;
+    skos:editorialNote "Old Babylonian and Old Assyrian grouped together under one heading on p. 340." ;
     skos:inScheme <p08tf6p> ;
-    skos:note "Old Babylonian and Old Assyrian grouped together under one heading on p. 340." ;
     skos:prefLabel "Old Assyrian" ;
     time:intervalFinishedBy [
         skos:prefLabel "1600 B.C.E." ;
@@ -23231,8 +23349,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Parthian"@eng-latn ;
+    skos:editorialNote "226 A.D. in GeoDia." ;
     skos:inScheme <p08tf6p> ;
-    skos:note "226 A.D. in GeoDia." ;
     skos:prefLabel "Parthian" ;
     time:intervalFinishedBy [
         skos:prefLabel "227 C.E." ;
@@ -23280,8 +23398,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
     skos:altLabel "Uruk"@eng-latn ;
+    skos:editorialNote "in chronological discussion on p. 55, provides \"ca.\" before date" ;
     skos:inScheme <p08tf6p> ;
-    skos:note "in chronological discussion on p. 55, provides \"ca.\" before date" ;
     skos:prefLabel "Uruk" ;
     time:intervalFinishedBy [
         skos:prefLabel "3150 B.C.E." ;
@@ -23305,8 +23423,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
     skos:altLabel "Early Dynastic"@eng-latn ;
+    skos:editorialNote "in chronological discussion on p. 56, provides \"ca.\" before date" ;
     skos:inScheme <p08tf6p> ;
-    skos:note "in chronological discussion on p. 56, provides \"ca.\" before date" ;
     skos:prefLabel "Early Dynastic" ;
     time:intervalFinishedBy [
         skos:prefLabel "2334 B.C.E." ;
@@ -23354,8 +23472,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Chalcolithic"@eng-latn ;
+    skos:editorialNote "Does not seem to be present in this work" ;
     skos:inScheme <p08tf6p> ;
-    skos:note "Does not seem to be present in this work" ;
     skos:prefLabel "Chalcolithic" ;
     time:intervalFinishedBy [
         skos:prefLabel "3750 B.C.E." ;
@@ -23470,8 +23588,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Sumer> ;
     a skos:Concept ;
     skos:altLabel "Bronze Age"@eng-latn ;
+    skos:editorialNote "GeoDia had Amarna 1352-1336 B.C. (Egyptian capital) and Bronze Age 3150-1070 B.C." ;
     skos:inScheme <p0bd664> ;
-    skos:note "GeoDia had Amarna 1352-1336 B.C. (Egyptian capital) and Bronze Age 3150-1070 B.C." ;
     skos:prefLabel "Bronze Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "c.1000 B.C." ;
@@ -23517,8 +23635,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Hyksos rule"@eng-latn, "Second Intermediate Period"@eng-latn ;
+    skos:editorialNote "GeoDia had 1795-1550 B.C., and Hyksos from 1650-1550 B.C." ;
     skos:inScheme <p0bd664> ;
-    skos:note "GeoDia had 1795-1550 B.C., and Hyksos from 1650-1550 B.C." ;
     skos:prefLabel "Second Intermediate Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "1532 B.C." ;
@@ -23587,8 +23705,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
     skos:altLabel "Classical Age"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0bd664> ;
-    skos:note "added" ;
     skos:prefLabel "Classical Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "404 B.C." ;
@@ -23612,8 +23730,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Italy> ;
     a skos:Concept ;
     skos:altLabel "Villanovan period"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0bd664> ;
-    skos:note "added" ;
     skos:prefLabel "Villanovan period" ;
     time:intervalFinishedBy [
         skos:prefLabel "760 B.C." ;
@@ -23705,8 +23823,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
     skos:altLabel "Hellenistic Age"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0bd664> ;
-    skos:note "added" ;
     skos:prefLabel "Hellenistic Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "31 B.C." ;
@@ -23729,8 +23847,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Hittite"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0bd664> ;
-    skos:note "added" ;
     skos:prefLabel "Hittite" ;
     time:intervalFinishedBy [
         skos:prefLabel "1200 B.C." ;
@@ -23753,8 +23871,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Istanbul> ;
     a skos:Concept ;
     skos:altLabel "Byzantine Empire"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0bd664> ;
-    skos:note "added" ;
     skos:prefLabel "Byzantine Empire" ;
     time:intervalFinishedBy [
         skos:prefLabel "640s A.D."
@@ -23771,8 +23889,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
     skos:altLabel "Dark Ages"@eng-latn ;
+    skos:editorialNote "GeoDia had Late Period 664 and 760 B.C. to 332 B.C. (unclear)." ;
     skos:inScheme <p0bd664> ;
-    skos:note "GeoDia had Late Period 664 and 760 B.C. to 332 B.C. (unclear)." ;
     skos:prefLabel "Dark Ages" ;
     time:intervalFinishedBy [
         skos:prefLabel "800 B.C." ;
@@ -23795,8 +23913,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Crete> ;
     a skos:Concept ;
     skos:altLabel "New Palace Period"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0bd664> ;
-    skos:note "added" ;
     skos:prefLabel "New Palace Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "1425 B.C." ;
@@ -23819,8 +23937,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Middle Kingdom"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0bd664> ;
-    skos:note "added" ;
     skos:prefLabel "Middle Kingdom" ;
     time:intervalFinishedBy [
         skos:prefLabel "1640 B.C." ;
@@ -23866,8 +23984,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Crete> ;
     a skos:Concept ;
     skos:altLabel "Old Palace Period"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0bd664> ;
-    skos:note "added" ;
     skos:prefLabel "Old Palace Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "1600 B.C." ;
@@ -23890,8 +24008,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Early Dynastic"@eng-latn ;
+    skos:editorialNote "GeoDia had 3000-2613 B.C." ;
     skos:inScheme <p0bd664> ;
-    skos:note "GeoDia had 3000-2613 B.C." ;
     skos:prefLabel "Early Dynastic" ;
     time:intervalFinishedBy [
         skos:prefLabel "2600 B.C." ;
@@ -23915,8 +24033,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
     skos:altLabel "Assyrian"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0bd664> ;
-    skos:note "added" ;
     skos:prefLabel "Assyrian" ;
     time:intervalFinishedBy [
         skos:prefLabel "605 B.C." ;
@@ -23939,8 +24057,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
     skos:altLabel "Mycenaean"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0bd664> ;
-    skos:note "added" ;
     skos:prefLabel "Mycenaean" ;
     time:intervalFinishedBy [
         skos:prefLabel "1100 B.C." ;
@@ -24044,8 +24162,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Italy> ;
     a skos:Concept ;
     skos:altLabel "Classical"@eng-latn ;
+    skos:editorialNote "Brendel also calls this period \"Response to Greek Classical Art\" (259)." ;
     skos:inScheme <p0ccnvb> ;
-    skos:note "Brendel also calls this period \"Response to Greek Classical Art\" (259)." ;
     skos:prefLabel "Classical" ;
     time:intervalFinishedBy [
         skos:prefLabel "400 B.C." ;
@@ -24142,8 +24260,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Italy> ;
     a skos:Concept ;
     skos:altLabel "Proto-Classical"@eng-latn, "Transitional"@eng-latn ;
+    skos:editorialNote "Brendel also calls this period \"Proto-Classical\" (e.g. 283ff)." ;
     skos:inScheme <p0ccnvb> ;
-    skos:note "Brendel also calls this period \"Proto-Classical\" (e.g. 283ff)." ;
     skos:prefLabel "Transitional" ;
     time:intervalFinishedBy [
         skos:prefLabel "450 B.C." ;
@@ -24215,8 +24333,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Italy> ;
     a skos:Concept ;
     skos:altLabel "Late Classical"@eng-latn ;
+    skos:editorialNote "Brendel earlier calls this period \"Etruscan Art of the Fourth Century\", but then only refers to art of this period as \"Classical\" or \"Late Classical\", with the same temporal boundaries." ;
     skos:inScheme <p0ccnvb> ;
-    skos:note "Brendel earlier calls this period \"Etruscan Art of the Fourth Century\", but then only refers to art of this period as \"Classical\" or \"Late Classical\", with the same temporal boundaries." ;
     skos:prefLabel "Late Classical" ;
     time:intervalFinishedBy [
         skos:prefLabel "300 B.C." ;
@@ -24557,8 +24675,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
     skos:altLabel "Early Canaanite"@eng-latn, "Early Canaanite Period"@eng-latn ;
+    skos:editorialNote "see also Mazar, 1992" ;
     skos:inScheme <p0cfv7g> ;
-    skos:note "see also Mazar, 1992" ;
     skos:prefLabel "Early Canaanite Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "2000 BCE" ;
@@ -24700,8 +24818,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Second Intermediate Period"@eng-latn ;
+    skos:editorialNote "unsure why GeoDia end_label said 1550 B.C." ;
     skos:inScheme <p0cp447> ;
-    skos:note "unsure why GeoDia end_label said 1550 B.C." ;
     skos:prefLabel "Second Intermediate Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "1532 BC" ;
@@ -24749,8 +24867,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Middle Kingdom"@eng-latn ;
+    skos:editorialNote "unsure why GeoDia start_label said 2055 B.C." ;
     skos:inScheme <p0cp447> ;
-    skos:note "unsure why GeoDia start_label said 2055 B.C." ;
     skos:prefLabel "Middle Kingdom" ;
     time:intervalFinishedBy [
         skos:prefLabel "1640 BC" ;
@@ -24846,8 +24964,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Third Intermediate Period"@eng-latn ;
+    skos:editorialNote "unsure why GeoDia start_label said 2055 B.C." ;
     skos:inScheme <p0cp447> ;
-    skos:note "unsure why GeoDia start_label said 2055 B.C." ;
     skos:prefLabel "Third Intermediate Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "712 BC" ;
@@ -24871,8 +24989,9 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "First Intermediate Period"@eng-latn ;
+    skos:editorialNote "unsure why GeoDia dates are 2130-2055 B.C." ;
     skos:inScheme <p0cp447> ;
-    skos:note "Robins' chronology is being used in preference to Freeman's, since it seems to represent the general textbook situation more accurately.", "unsure why GeoDia dates are 2130-2055 B.C." ;
+    skos:note "Robins' chronology is being used in preference to Freeman's, since it seems to represent the general textbook situation more accurately." ;
     skos:prefLabel "First Intermediate Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "2040 BC" ;
@@ -25162,8 +25281,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     skos:altLabel "Iron Age"@eng-latn ;
+    skos:editorialNote "May be an inference, not statement / assertion." ;
     skos:inScheme <p0d39r7> ;
-    skos:note "May be an inference, not statement / assertion." ;
     skos:prefLabel "Iron Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "43 A.D." ;
@@ -25344,8 +25463,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Neolithic"@eng-latn ;
+    skos:editorialNote "See map as ill. 227, page 392." ;
     skos:inScheme <p0f65r2> ;
-    skos:note "See map as ill. 227, page 392." ;
     skos:prefLabel "Neolithic" ;
     time:intervalFinishedBy [
         skos:prefLabel "4500 B.C.E." ;
@@ -25365,8 +25484,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Early Bronze IV/Middle Bronze I"@eng-latn ;
+    skos:editorialNote "See map as ill. 227, page 392." ;
     skos:inScheme <p0f65r2> ;
-    skos:note "See map as ill. 227, page 392." ;
     skos:prefLabel "Early Bronze IV/Middle Bronze I" ;
     time:intervalFinishedBy [
         skos:prefLabel "1925 B.C.E." ;
@@ -25386,8 +25505,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Middle Bronze II"@eng-latn ;
+    skos:editorialNote "See map as ill. 227, page 392." ;
     skos:inScheme <p0f65r2> ;
-    skos:note "See map as ill. 227, page 392." ;
     skos:prefLabel "Middle Bronze II" ;
     time:intervalFinishedBy [
         skos:prefLabel "1550 B.C.E." ;
@@ -25407,8 +25526,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Iron Age"@eng-latn ;
+    skos:editorialNote "See map as ill. 227, page 392." ;
     skos:inScheme <p0f65r2> ;
-    skos:note "See map as ill. 227, page 392." ;
     skos:prefLabel "Iron Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "586 B.C.E." ;
@@ -25428,8 +25547,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Early Bronze"@eng-latn ;
+    skos:editorialNote "See map as ill. 227, page 392." ;
     skos:inScheme <p0f65r2> ;
-    skos:note "See map as ill. 227, page 392." ;
     skos:prefLabel "Early Bronze" ;
     time:intervalFinishedBy [
         skos:prefLabel "2250 B.C.E." ;
@@ -25449,8 +25568,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Persian"@eng-latn ;
+    skos:editorialNote "See map as ill. 227, page 392." ;
     skos:inScheme <p0f65r2> ;
-    skos:note "See map as ill. 227, page 392." ;
     skos:prefLabel "Persian" ;
     time:intervalFinishedBy [
         skos:prefLabel "332 B.C.E." ;
@@ -25470,8 +25589,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Neo-Babylonian"@eng-latn ;
+    skos:editorialNote "this date: see also Mazar, 1992. See map as ill. 227, page 392." ;
     skos:inScheme <p0f65r2> ;
-    skos:note "this date: see also Mazar, 1992. See map as ill. 227, page 392." ;
     skos:prefLabel "Neo-Babylonian" ;
     time:intervalFinishedBy [
         skos:prefLabel "539 B.C.E." ;
@@ -25491,8 +25610,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Hellenistic"@eng-latn ;
+    skos:editorialNote "See map as ill. 227, page 392." ;
     skos:inScheme <p0f65r2> ;
-    skos:note "See map as ill. 227, page 392." ;
     skos:prefLabel "Hellenistic" ;
     time:intervalFinishedBy [
         skos:prefLabel "53 B.C.E." ;
@@ -25512,8 +25631,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Late Bronze"@eng-latn ;
+    skos:editorialNote "See map as ill. 227, page 392." ;
     skos:inScheme <p0f65r2> ;
-    skos:note "See map as ill. 227, page 392." ;
     skos:prefLabel "Late Bronze" ;
     time:intervalFinishedBy [
         skos:prefLabel "1200 B.C.E." ;
@@ -25533,8 +25652,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Chalcolithic"@eng-latn ;
+    skos:editorialNote "See map as ill. 227, page 392." ;
     skos:inScheme <p0f65r2> ;
-    skos:note "See map as ill. 227, page 392." ;
     skos:prefLabel "Chalcolithic" ;
     time:intervalFinishedBy [
         skos:prefLabel "3500 B.C.E." ;
@@ -25562,8 +25681,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Switzerland> ;
     a skos:Concept ;
     skos:altLabel "La Tène D"@eng-latn ;
+    skos:editorialNote "check map references" ;
     skos:inScheme <p0ff3dt> ;
-    skos:note "check map references" ;
     skos:prefLabel "La Tène D" ;
     time:intervalFinishedBy [
         skos:prefLabel "50 BC" ;
@@ -25587,8 +25706,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Ireland>, <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     skos:altLabel "Early Christian"@eng-latn, "Early Christian (Britain, Ireland)"@eng-latn ;
+    skos:editorialNote "Maps pages 116, 119." ;
     skos:inScheme <p0ff3dt> ;
-    skos:note "Maps pages 116, 119." ;
     skos:prefLabel "Early Christian (Britain, Ireland)" ;
     time:intervalFinishedBy [
         skos:prefLabel "AD 500" ;
@@ -25612,8 +25731,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Czech_Republic>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Switzerland> ;
     a skos:Concept ;
     skos:altLabel "La Tène C"@eng-latn ;
+    skos:editorialNote "check map references" ;
     skos:inScheme <p0ff3dt> ;
-    skos:note "check map references" ;
     skos:prefLabel "La Tène C" ;
     time:intervalFinishedBy [
         skos:prefLabel "120 BC" ;
@@ -25661,8 +25780,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     skos:altLabel "Anglo-Saxon"@eng-latn, "Anglo-Saxon (East Britain)"@eng-latn ;
+    skos:editorialNote "Maps pages 110-111." ;
     skos:inScheme <p0ff3dt> ;
-    skos:note "Maps pages 110-111." ;
     skos:prefLabel "Anglo-Saxon (East Britain)" ;
     time:intervalFinishedBy [
         skos:prefLabel "AD 800" ;
@@ -25734,8 +25853,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Ireland>, <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     skos:altLabel "Viking"@eng-latn ;
+    skos:editorialNote "Map page 131." ;
     skos:inScheme <p0ff3dt> ;
-    skos:note "Map page 131." ;
     skos:prefLabel "Viking" ;
     time:intervalFinishedBy [
         skos:prefLabel "AD 1000" ;
@@ -25783,8 +25902,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Italy> ;
     a skos:Concept ;
     skos:altLabel "Romano-Celtic"@eng-latn ;
+    skos:editorialNote "Map page 60." ;
     skos:inScheme <p0ff3dt> ;
-    skos:note "Map page 60." ;
     skos:prefLabel "Romano-Celtic" ;
     time:intervalFinishedBy [
         skos:prefLabel "AD 300" ;
@@ -25808,8 +25927,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Czech_Republic>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Switzerland> ;
     a skos:Concept ;
     skos:altLabel "La Tène A"@eng-latn ;
+    skos:editorialNote "check map references" ;
     skos:inScheme <p0ff3dt> ;
-    skos:note "check map references" ;
     skos:prefLabel "La Tène A" ;
     time:intervalFinishedBy [
         skos:prefLabel "400 BC" ;
@@ -25857,8 +25976,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Czech_Republic>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Switzerland> ;
     a skos:Concept ;
     skos:altLabel "La Tène B"@eng-latn ;
+    skos:editorialNote "check map references" ;
     skos:inScheme <p0ff3dt> ;
-    skos:note "check map references" ;
     skos:prefLabel "La Tène B" ;
     time:intervalFinishedBy [
         skos:prefLabel "250 BC" ;
@@ -25882,8 +26001,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Czech_Republic>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Switzerland> ;
     a skos:Concept ;
     skos:altLabel "La Tène Iron Age"@eng-latn ;
+    skos:editorialNote "check map references" ;
     skos:inScheme <p0ff3dt> ;
-    skos:note "check map references" ;
     skos:prefLabel "La Tène Iron Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "50 BC" ;
@@ -26603,8 +26722,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Switzerland> ;
     a skos:Concept ;
     skos:altLabel "Cultura de Hallstatt"@spa-latn, "Hallstatt-culture"@eng-latn ;
+    skos:editorialNote "Come back later to this source to mine / match to formal p.175-222 & Celtic art periods p.431-450 (SB scanned) though the latter is mainly references to other writers." ;
     skos:inScheme <p0hrtx5> ;
-    skos:note "Come back later to this source to mine / match to formal p.175-222 & Celtic art periods p.431-450 (SB scanned) though the latter is mainly references to other writers." ;
     skos:prefLabel "Cultura de Hallstatt" ;
     time:intervalFinishedBy [
         skos:prefLabel "450 a.C."
@@ -26660,8 +26779,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
     skos:altLabel "Akkadian"@eng-latn ;
+    skos:editorialNote "Removed due to inferences in GeoDia: al-'Ubaid (5500-4000 B.C.), Uruk (4000-3250 B.C.), Jamdat Nasr periods (3250-3000 B.C.), and Ur of the Chaldees (1150-800 B.C.). Note this quote p.15: \"At an archaeological congress of excavators held at Baghdad in 1929 it was agreed that the early stages of human settlement in south Mesopotamia could be classified n successive phases which should be called, after the places where the evidence for each was first discovered, the al-'Ubaid period, the Uruk period, the Jamdat Nasr period, and then the Early Dynastic period, towards the end of which (in IIIb) comes the First Dynasty of Ur.\" p.16: \"Archaeological excavation ... does not of itself offer an absolute chronology in years B.C./A.D.\"" ;
     skos:inScheme <p0j5frx> ;
-    skos:note "Removed due to inferences in GeoDia: al-'Ubaid (5500-4000 B.C.), Uruk (4000-3250 B.C.), Jamdat Nasr periods (3250-3000 B.C.), and Ur of the Chaldees (1150-800 B.C.). Note this quote p.15: \"At an archaeological congress of excavators held at Baghdad in 1929 it was agreed that the early stages of human settlement in south Mesopotamia could be classified n successive phases which should be called, after the places where the evidence for each was first discovered, the al-'Ubaid period, the Uruk period, the Jamdat Nasr period, and then the Early Dynastic period, towards the end of which (in IIIb) comes the First Dynasty of Ur.\" p.16: \"Archaeological excavation ... does not of itself offer an absolute chronology in years B.C./A.D.\"" ;
     skos:prefLabel "Akkadian" ;
     time:intervalFinishedBy [
         skos:prefLabel "2154 B.C." ;
@@ -26685,8 +26804,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
     skos:altLabel "Early Dynastic IIIa"@eng-latn ;
+    skos:editorialNote "Removed due to inferences in GeoDia: al-'Ubaid (5500-4000 B.C.), Uruk (4000-3250 B.C.), Jamdat Nasr periods (3250-3000 B.C.), and Ur of the Chaldees (1150-800 B.C.). Note this quote p.15: \"At an archaeological congress of excavators held at Baghdad in 1929 it was agreed that the early stages of human settlement in south Mesopotamia could be classified n successive phases which should be called, after the places where the evidence for each was first discovered, the al-'Ubaid period, the Uruk period, the Jamdat Nasr period, and then the Early Dynastic period, towards the end of which (in IIIb) comes the First Dynasty of Ur.\" p.16: \"Archaeological excavation ... does not of itself offer an absolute chronology in years B.C./A.D.\"" ;
     skos:inScheme <p0j5frx> ;
-    skos:note "Removed due to inferences in GeoDia: al-'Ubaid (5500-4000 B.C.), Uruk (4000-3250 B.C.), Jamdat Nasr periods (3250-3000 B.C.), and Ur of the Chaldees (1150-800 B.C.). Note this quote p.15: \"At an archaeological congress of excavators held at Baghdad in 1929 it was agreed that the early stages of human settlement in south Mesopotamia could be classified n successive phases which should be called, after the places where the evidence for each was first discovered, the al-'Ubaid period, the Uruk period, the Jamdat Nasr period, and then the Early Dynastic period, towards the end of which (in IIIb) comes the First Dynasty of Ur.\" p.16: \"Archaeological excavation ... does not of itself offer an absolute chronology in years B.C./A.D.\"" ;
     skos:prefLabel "Early Dynastic IIIa" ;
     time:intervalFinishedBy [
         skos:prefLabel "2550 B.C." ;
@@ -26710,8 +26829,9 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
     skos:altLabel "Early Dynastic"@eng-latn, "Early Dynastic period"@eng-latn ;
+    skos:editorialNote "Removed due to inferences in GeoDia: al-'Ubaid (5500-4000 B.C.), Uruk (4000-3250 B.C.), Jamdat Nasr periods (3250-3000 B.C.), and Ur of the Chaldees (1150-800 B.C.). Note this quote p.15: \"At an archaeological congress of excavators held at Baghdad in 1929 it was agreed that the early stages of human settlement in south Mesopotamia could be classified n successive phases which should be called, after the places where the evidence for each was first discovered, the al-'Ubaid period, the Uruk period, the Jamdat Nasr period, and then the Early Dynastic period, towards the end of which (in IIIb) comes the First Dynasty of Ur.\" p.16: \"Archaeological excavation ... does not of itself offer an absolute chronology in years B.C./A.D.\"" ;
     skos:inScheme <p0j5frx> ;
-    skos:note "Removed due to inferences in GeoDia: al-'Ubaid (5500-4000 B.C.), Uruk (4000-3250 B.C.), Jamdat Nasr periods (3250-3000 B.C.), and Ur of the Chaldees (1150-800 B.C.). Note this quote p.15: \"At an archaeological congress of excavators held at Baghdad in 1929 it was agreed that the early stages of human settlement in south Mesopotamia could be classified n successive phases which should be called, after the places where the evidence for each was first discovered, the al-'Ubaid period, the Uruk period, the Jamdat Nasr period, and then the Early Dynastic period, towards the end of which (in IIIb) comes the First Dynasty of Ur.\" p.16: \"Archaeological excavation ... does not of itself offer an absolute chronology in years B.C./A.D.\"", "These are approximate dates." ;
+    skos:note "These are approximate dates." ;
     skos:prefLabel "Early Dynastic period" ;
     time:intervalFinishedBy [
         skos:prefLabel "about 2330 B.C."
@@ -26729,8 +26849,9 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
     skos:altLabel "Isin-Larsa"@eng-latn ;
+    skos:editorialNote "unsure why GeoDia dates are 2130-2055 B.C." ;
     skos:inScheme <p0j5frx> ;
-    skos:note "Robins' chronology is being used in preference to Freeman's, since it seems to represent the general textbook situation more accurately.", "unsure why GeoDia dates are 2130-2055 B.C." ;
+    skos:note "Robins' chronology is being used in preference to Freeman's, since it seems to represent the general textbook situation more accurately." ;
     skos:prefLabel "Isin-Larsa" ;
     time:intervalFinishedBy [
         skos:prefLabel "1740 B.C." ;
@@ -27488,8 +27609,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iraq> ;
     a skos:Concept ;
     skos:altLabel "Ubaid Period"@eng-latn ;
+    skos:editorialNote "Neo-Assyrian 717-612 B.C. was listed in GeoDia but not found in the book on page 20." ;
     skos:inScheme <p0kc8t6> ;
-    skos:note "Neo-Assyrian 717-612 B.C. was listed in GeoDia but not found in the book on page 20." ;
     skos:prefLabel "Ubaid Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "3500 B.C." ;
@@ -27557,8 +27678,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
     skos:altLabel "Middle Bronze Age"@eng-latn, "Middle Canaanite Age"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"" ;
     skos:inScheme <p0kgptq> ;
-    skos:note "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"" ;
     skos:prefLabel "Middle Canaanite Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "1250 B.C.E." ;
@@ -27582,8 +27703,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
     skos:altLabel "Iron Age"@eng-latn, "Israelite Age"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"" ;
     skos:inScheme <p0kgptq> ;
-    skos:note "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"" ;
     skos:prefLabel "Israelite Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "586 B.C.E." ;
@@ -27607,8 +27728,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
     skos:altLabel "Early Bronze Age"@eng-latn, "Early Canaanite Age"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"" ;
     skos:inScheme <p0kgptq> ;
-    skos:note "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"" ;
     skos:prefLabel "Early Canaanite Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "2500 B.C.E." ;
@@ -27632,8 +27753,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
     skos:altLabel "Canaanite Age"@eng-latn, "pre-Israelite"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"" ;
     skos:inScheme <p0kgptq> ;
-    skos:note "Spatial_coverage_label per page 139 quote, \"Therefore, 'the archaeology of the Land of Israel is preferable.'\" Also on page 141: \"the author proposes...the other two terms, 'Canaanite Age' and 'Israelite Age' to replace 'Bronze Age' and 'Iron Age.'\" Sourced from Mazar, 1992, page 29 note 14: \"M. Dothan in BAT, pp. 136-41.\"" ;
     skos:prefLabel "Canaanite Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "1200 B.C.E." ;
@@ -28671,8 +28792,9 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Armenia>, <http://dbpedia.org/resource/Azerbaijan>, <http://dbpedia.org/resource/Georgia_(country)>, <http://dbpedia.org/resource/Iran>, <http://dbpedia.org/resource/Iraq>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Median Monarchy"@eng-latn, "proto-Armenian Satrapy of Greater Armenia"@eng-latn ;
+    skos:editorialNote "Deleted Kingdom of Commagene (163 B.C.-72 A.D.) on 10/20/14 due to problem with this end-date. Found these from the index entry for Armenia." ;
     skos:inScheme <p0kj6dj> ;
-    skos:note "Deleted Kingdom of Commagene (163 B.C.-72 A.D.) on 10/20/14 due to problem with this end-date. Found these from the index entry for Armenia.", "Kingdom was ruled by Romans between 17 A.D.-43 A.D." ;
+    skos:note "Kingdom was ruled by Romans between 17 A.D.-43 A.D." ;
     skos:prefLabel "proto-Armenian Satrapy of Greater Armenia" ;
     time:intervalFinishedBy [
         skos:prefLabel "550 B.C." ;
@@ -31992,8 +32114,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Netherlands> ;
     a skos:Concept ;
     skos:altLabel "Paleolithic"@eng-latn, "Paleolithicum"@nld-latn ;
+    skos:editorialNote "no start date provided: noted only as \"before 8800 B.C.\"" ;
     skos:inScheme <p0pqptc> ;
-    skos:note "no start date provided: noted only as \"before 8800 B.C.\"" ;
     skos:prefLabel "Paleolithicum" ;
     time:intervalFinishedBy [
         skos:prefLabel "8800 B.C."
@@ -32291,8 +32413,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Netherlands> ;
     a skos:Concept ;
     skos:altLabel "Early Paleolithic"@eng-latn, "Paleolithicum vroeg"@nld-latn ;
+    skos:editorialNote "no start date provided: noted only as \"before 300000 BP\"" ;
     skos:inScheme <p0pqptc> ;
-    skos:note "no start date provided: noted only as \"before 300000 BP\"" ;
     skos:prefLabel "Paleolithicum vroeg" ;
     time:intervalFinishedBy [
         skos:prefLabel "300000 C14 BP"
@@ -32598,8 +32720,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Naqada IIId"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Naqada IIId" ;
     time:intervalFinishedBy [
         skos:prefLabel "2670 BCE" ;
@@ -32620,8 +32742,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Sudan> ;
     a skos:Concept ;
     skos:altLabel "Late/Final A-group"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Late/Final A-group" ;
     time:intervalFinishedBy [
         skos:prefLabel "3150 BCE" ;
@@ -32641,8 +32763,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Macedonian"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Macedonian" ;
     time:intervalFinishedBy [
         skos:prefLabel "304 BCE" ;
@@ -32663,8 +32785,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Naqada IIIa"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Naqada IIIa" ;
     time:intervalFinishedBy [
         skos:prefLabel "3150 BCE" ;
@@ -32685,8 +32807,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Badarian"@eng-latn, "Badarian (Middle Egypt)"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Badarian (Middle Egypt)" ;
     time:intervalFinishedBy [
         skos:prefLabel "4000 BCE" ;
@@ -32707,8 +32829,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Sudan> ;
     a skos:Concept ;
     skos:altLabel "Middle A-group"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Middle A-group" ;
     time:intervalFinishedBy [
         skos:prefLabel "3300 BCE" ;
@@ -32728,8 +32850,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Epi-palaeolithic"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Epi-palaeolithic" ;
     time:intervalFinishedBy [
         skos:prefLabel "6000 BCE" ;
@@ -32749,8 +32871,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Old Kingdom"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Old Kingdom" ;
     time:intervalFinishedBy [
         skos:prefLabel "2168 BCE" ;
@@ -32771,8 +32893,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Late Naqada II"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Late Naqada II" ;
     time:intervalFinishedBy [
         skos:prefLabel "3300 BCE" ;
@@ -32792,8 +32914,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Roman"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Roman" ;
     time:intervalFinishedBy [
         skos:prefLabel "394 CE" ;
@@ -32814,8 +32936,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Buto III"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Buto III" ;
     time:intervalFinishedBy [
         skos:prefLabel "3150 BCE" ;
@@ -32836,8 +32958,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Buto V"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Buto V" ;
     time:intervalFinishedBy [
         skos:prefLabel "2800 BCE" ;
@@ -32857,8 +32979,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Naqada IIIb"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Naqada IIIb" ;
     time:intervalFinishedBy [
         skos:prefLabel "2950 BCE" ;
@@ -32878,8 +33000,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Persian Period"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Persian Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "402 BCE" ;
@@ -32899,8 +33021,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Late Period"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Late Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "332 BCE" ;
@@ -32920,8 +33042,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Upper Palaeolithic"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Upper Palaeolithic" ;
     time:intervalFinishedBy [
         skos:prefLabel "35000 BCE" ;
@@ -32942,8 +33064,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Buto I"@eng-latn, "Maadi"@eng-latn, "Maadi/Buto I"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Maadi/Buto I" ;
     time:intervalFinishedBy [
         skos:prefLabel "3400 BCE" ;
@@ -32963,8 +33085,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Middle Kingdom"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Middle Kingdom" ;
     time:intervalFinishedBy [
         skos:prefLabel "1640 BCE" ;
@@ -32984,8 +33106,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Early Dynastic"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Early Dynastic" ;
     time:intervalFinishedBy [
         skos:prefLabel "2670 BCE" ;
@@ -33005,8 +33127,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Naqada IIIc"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Naqada IIIc" ;
     time:intervalFinishedBy [
         skos:prefLabel "2800 BCE" ;
@@ -33027,8 +33149,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Buto II"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Buto II" ;
     time:intervalFinishedBy [
         skos:prefLabel "3300 BCE" ;
@@ -33048,8 +33170,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Ptolemaic"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Ptolemaic" ;
     time:intervalFinishedBy [
         skos:prefLabel "30 BCE" ;
@@ -33069,8 +33191,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Second Persian Period"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Second Persian Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "332 BCE" ;
@@ -33091,8 +33213,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Naqada I-early II"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Naqada I-early II" ;
     time:intervalFinishedBy [
         skos:prefLabel "3400 BCE" ;
@@ -33113,8 +33235,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Sudan> ;
     a skos:Concept ;
     skos:altLabel "Early A-group"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Early A-group" ;
     time:intervalFinishedBy [
         skos:prefLabel "3400 BCE" ;
@@ -33134,8 +33256,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Third Intermediate Period"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Third Intermediate Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "664 BCE" ;
@@ -33155,8 +33277,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "First Intermediate Period"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "First Intermediate Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "2040 BCE" ;
@@ -33177,8 +33299,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Buto IV"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Buto IV" ;
     time:intervalFinishedBy [
         skos:prefLabel "2950 BCE" ;
@@ -33198,8 +33320,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Final Palaeolithic"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Final Palaeolithic" ;
     time:intervalFinishedBy [
         skos:prefLabel "7000 BCE" ;
@@ -33219,8 +33341,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Middle Palaeolithic"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Middle Palaeolithic" ;
     time:intervalFinishedBy [
         skos:prefLabel "40000 BCE" ;
@@ -33240,8 +33362,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "New Kingdom"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "New Kingdom" ;
     time:intervalFinishedBy [
         skos:prefLabel "1086 BCE" ;
@@ -33261,8 +33383,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Predynastic"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Predynastic" ;
     time:intervalFinishedBy [
         skos:prefLabel "2950 BCE" ;
@@ -33282,8 +33404,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Neolithic"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Neolithic" ;
     time:intervalFinishedBy [
         skos:prefLabel "4500 BCE" ;
@@ -33303,8 +33425,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Second Intermediate Period"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Second Intermediate Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "1548 BCE" ;
@@ -33324,8 +33446,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt> ;
     a skos:Concept ;
     skos:altLabel "Lower Palaeolithic"@eng-latn ;
+    skos:editorialNote "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:inScheme <p0qk76z> ;
-    skos:note "UEE notes that this chronology will be replaced/improved as the project goes forward, so may be outdated at some point in the near future -- but in use by contributors and DAI database, so useful to maintain a record of." ;
     skos:prefLabel "Lower Palaeolithic" ;
     time:intervalFinishedBy [
         skos:prefLabel "175000 BCE " ;
@@ -34622,8 +34744,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
     skos:altLabel "Persian"@eng-latn, "Persian (Achaemenid) Empire"@eng-latn ;
+    skos:editorialNote "see also Mazar, 1992" ;
     skos:inScheme <p0qwcp6> ;
-    skos:note "see also Mazar, 1992" ;
     skos:prefLabel "Persian" ;
     time:intervalFinishedBy [
         skos:prefLabel "332 B.C.E." ;
@@ -34750,8 +34872,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
     skos:altLabel "Hasmonean"@eng-latn ;
+    skos:editorialNote "see also Mazar, 1992" ;
     skos:inScheme <p0r2jnt> ;
-    skos:note "see also Mazar, 1992" ;
     skos:prefLabel "Hasmonean" ;
     time:intervalFinishedBy [
         skos:prefLabel "64 B.C." ;
@@ -34778,8 +34900,9 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Tunisia> ;
     a skos:Concept ;
     skos:altLabel "Deuxième époque"@fra-latn, "Second era"@eng-latn ;
+    skos:editorialNote "no date type shown, but context indicates BC" ;
     skos:inScheme <p0rqpwq> ;
-    skos:note "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)", "no date type shown, but context indicates BC" ;
+    skos:note "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)" ;
     skos:prefLabel "Deuxième époque" ;
     time:intervalFinishedBy [
         skos:prefLabel "550/525" ;
@@ -34801,8 +34924,9 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Tunisia> ;
     a skos:Concept ;
     skos:altLabel "First era"@eng-latn, "Première époque"@fra-latn ;
+    skos:editorialNote "no date type shown, but context indicates BC" ;
     skos:inScheme <p0rqpwq> ;
-    skos:note "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)", "no date type shown, but context indicates BC" ;
+    skos:note "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)" ;
     skos:prefLabel "Première époque" ;
     time:intervalFinishedBy [
         skos:prefLabel "675/650" ;
@@ -34823,8 +34947,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Tunisia> ;
     a skos:Concept ;
     skos:altLabel "Fourth era"@eng-latn, "Quatrième époque"@fra-latn ;
+    skos:editorialNote "no designation present (BCE, etc.)" ;
     skos:inScheme <p0rqpwq> ;
-    skos:note "no designation present (BCE, etc.)" ;
     skos:prefLabel "Quatrième époque" ;
     time:intervalFinishedBy [
         skos:prefLabel "146/125" ;
@@ -34846,8 +34970,9 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Tunisia> ;
     a skos:Concept ;
     skos:altLabel "Third era"@eng-latn, "Troisième époque"@fra-latn ;
+    skos:editorialNote "no date type shown, but context indicates BC" ;
     skos:inScheme <p0rqpwq> ;
-    skos:note "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)", "no date type shown, but context indicates BC" ;
+    skos:note "Derived from Carthage tophet chronology, level Tanit IIa; see also Kelsey (1925), Cintas (1970), Lancel (1992, 1995), Aubet and Turton (2001), Docter et al. (2003 Palaeohistoria)" ;
     skos:prefLabel "Troisième époque" ;
     time:intervalFinishedBy [
         skos:prefLabel "300/275" ;
@@ -35026,8 +35151,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Cyprus>, <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
     skos:altLabel "Iron Age"@eng-latn ;
+    skos:editorialNote "Hodos notes that the end of the Iron Age \"segues into the Archaic phase of Classical civilization, which coincides with the Punic era of Mediterranean history, the full development of the city-state in the Greek world, and the very beginning of Rome's Republican period\" (4); also notes that \"in the Near East, Iron Age terminology is replaced in the sixth century BC with Persian periodization\" -- so inference is that the Iron Age ceases to apply at some point around the 6th c. BC." ;
     skos:inScheme <p0tns5v> ;
-    skos:note "Hodos notes that the end of the Iron Age \"segues into the Archaic phase of Classical civilization, which coincides with the Punic era of Mediterranean history, the full development of the city-state in the Greek world, and the very beginning of Rome's Republican period\" (4); also notes that \"in the Near East, Iron Age terminology is replaced in the sixth century BC with Persian periodization\" -- so inference is that the Iron Age ceases to apply at some point around the 6th c. BC." ;
     skos:prefLabel "Iron Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "sixth century BC" ;
@@ -35177,8 +35302,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gordium> ;
     a skos:Concept ;
     skos:altLabel "Medieval"@eng-latn ;
+    skos:editorialNote "added post-GeoDia" ;
     skos:inScheme <p0vhct4> ;
-    skos:note "added post-GeoDia" ;
     skos:prefLabel "Medieval" ;
     time:intervalFinishedBy [
         skos:prefLabel "14th century AD" ;
@@ -35256,8 +35381,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gordium> ;
     a skos:Concept ;
     skos:altLabel "Early Phrygian Destruction"@eng-latn ;
+    skos:editorialNote "added post-GeoDia" ;
     skos:inScheme <p0vhct4> ;
-    skos:note "added post-GeoDia" ;
     skos:prefLabel "Early Phrygian Destruction" ;
     time:intervalFinishedBy [
         skos:prefLabel "800 BC" ;
@@ -35276,8 +35401,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gordium> ;
     a skos:Concept ;
     skos:altLabel "Early Phrygian"@eng-latn ;
+    skos:editorialNote "added post-GeoDia" ;
     skos:inScheme <p0vhct4> ;
-    skos:note "added post-GeoDia" ;
     skos:prefLabel "Early Phrygian" ;
     time:intervalFinishedBy [
         skos:prefLabel "800 BC" ;
@@ -35296,8 +35421,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gordium> ;
     a skos:Concept ;
     skos:altLabel "Later Hellenistic"@eng-latn ;
+    skos:editorialNote "added post-GeoDia" ;
     skos:inScheme <p0vhct4> ;
-    skos:note "added post-GeoDia" ;
     skos:prefLabel "Later Hellenistic" ;
     time:intervalFinishedBy [
         skos:prefLabel "mid 2nd century BC" ;
@@ -35318,8 +35443,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gordium> ;
     a skos:Concept ;
     skos:altLabel "Roman"@eng-latn ;
+    skos:editorialNote "added post-GeoDia" ;
     skos:inScheme <p0vhct4> ;
-    skos:note "added post-GeoDia" ;
     skos:prefLabel "Roman" ;
     time:intervalFinishedBy [
         skos:prefLabel "5th century AD" ;
@@ -35359,8 +35484,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gordium> ;
     a skos:Concept ;
     skos:altLabel "Middle Bronze Age"@eng-latn ;
+    skos:editorialNote "added post-GeoDia" ;
     skos:inScheme <p0vhct4> ;
-    skos:note "added post-GeoDia" ;
     skos:prefLabel "Middle Bronze Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "1500 BC" ;
@@ -35379,8 +35504,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gordium> ;
     a skos:Concept ;
     skos:altLabel "Late Bronze Age"@eng-latn ;
+    skos:editorialNote "added post-GeoDia" ;
     skos:inScheme <p0vhct4> ;
-    skos:note "added post-GeoDia" ;
     skos:prefLabel "Late Bronze Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "12th century BC" ;
@@ -35400,8 +35525,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gordium> ;
     a skos:Concept ;
     skos:altLabel "Early Hellenistic"@eng-latn ;
+    skos:editorialNote "added post-GeoDia" ;
     skos:inScheme <p0vhct4> ;
-    skos:note "added post-GeoDia" ;
     skos:prefLabel "Early Hellenistic" ;
     time:intervalFinishedBy [
         skos:prefLabel "mid 3rd century BC" ;
@@ -35717,8 +35842,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     a skos:Concept ;
     owl:sameAs <http://mis.historiska.se/rdf/period#p312> ;
     skos:altLabel "Roman Iron Age"@eng-latn, "Romersk järnålder"@swe-latn ;
+    skos:editorialNote "The original entries just had \"Kr. f.\", which I assume means \"birth of Christ\", but I don't know if their system is using year 0 or year -1/year 1 " ;
     skos:inScheme <p0vn2fr> ;
-    skos:note "The original entries just had \"Kr. f.\", which I assume means \"birth of Christ\", but I don't know if their system is using year 0 or year -1/year 1 " ;
     skos:prefLabel "Romersk järnålder" ;
     time:intervalFinishedBy [
         skos:prefLabel "400 AD" ;
@@ -35970,8 +36095,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     a skos:Concept ;
     owl:sameAs <http://mis.historiska.se/rdf/period#p311> ;
     skos:altLabel "Förromersk järnålder"@swe-latn, "Pre-Roman Iron Age"@eng-latn ;
+    skos:editorialNote "The original entries just had \"Kr. f.\", which I assume means \"birth of Christ\", but I don't know if their system is using year 0 or year -1/year 1 " ;
     skos:inScheme <p0vn2fr> ;
-    skos:note "The original entries just had \"Kr. f.\", which I assume means \"birth of Christ\", but I don't know if their system is using year 0 or year -1/year 1 " ;
     skos:prefLabel "Förromersk järnålder" ;
     time:intervalFinishedBy [
         skos:prefLabel "0 AD" ;
@@ -36560,8 +36685,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Sardinia> ;
     a skos:Concept ;
     skos:altLabel "Orientalizing"@eng-latn, "Phoenician"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0wf3wd> ;
-    skos:note "added" ;
     skos:prefLabel "Orientalizing" ;
     time:intervalFinishedBy [
         skos:prefLabel "580 BC" ;
@@ -36580,8 +36705,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Sardinia> ;
     a skos:Concept ;
     skos:altLabel "Bonnanaro B/Nuragic I"@eng-latn, "Middle Bronze Age"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0wf3wd> ;
-    skos:note "added" ;
     skos:prefLabel "Middle Bronze Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "1300 BC" ;
@@ -36600,8 +36725,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Sardinia> ;
     a skos:Concept ;
     skos:altLabel "Late Bronze Age"@eng-latn, "Nuragic II"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0wf3wd> ;
-    skos:note "added" ;
     skos:prefLabel "Late Bronze Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "1150 BC" ;
@@ -36640,8 +36765,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Sardinia> ;
     a skos:Concept ;
     skos:altLabel "Geometric"@eng-latn, "Phoenician"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0wf3wd> ;
-    skos:note "added" ;
     skos:prefLabel "Geometric" ;
     time:intervalFinishedBy [
         skos:prefLabel "730 BC" ;
@@ -36680,8 +36805,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Sardinia> ;
     a skos:Concept ;
     skos:altLabel "Final Bronze Age"@eng-latn, "Nuragic III"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0wf3wd> ;
-    skos:note "added" ;
     skos:prefLabel "Final Bronze Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "850 BC" ;
@@ -36700,8 +36825,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Sardinia> ;
     a skos:Concept ;
     skos:altLabel "Copper Age"@eng-latn, "Eneolithic"@eng-latn, "Eneolithic (Copper Age)"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0wf3wd> ;
-    skos:note "added" ;
     skos:prefLabel "Eneolithic (Copper Age)" ;
     time:intervalFinishedBy [
         skos:prefLabel "2200? BC" ;
@@ -36740,8 +36865,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Sardinia> ;
     a skos:Concept ;
     skos:altLabel "Imperial"@eng-latn, "Roman"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0wf3wd> ;
-    skos:note "added" ;
     skos:prefLabel "Imperial" ;
     time:intervalFinishedBy [
         skos:prefLabel "476 AD" ;
@@ -36760,8 +36885,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Sardinia> ;
     a skos:Concept ;
     skos:altLabel "Bonnanaro A"@eng-latn, "Early Bronze Age"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0wf3wd> ;
-    skos:note "added" ;
     skos:prefLabel "Early Bronze Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "1900 BC" ;
@@ -36780,8 +36905,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Sardinia> ;
     a skos:Concept ;
     skos:altLabel "Archaic"@eng-latn, "Phoenician"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0wf3wd> ;
-    skos:note "added" ;
     skos:prefLabel "Archaic" ;
     time:intervalFinishedBy [
         skos:prefLabel "510 BC" ;
@@ -36800,8 +36925,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Sardinia> ;
     a skos:Concept ;
     skos:altLabel "Republican"@eng-latn, "Roman"@eng-latn ;
+    skos:editorialNote "added" ;
     skos:inScheme <p0wf3wd> ;
-    skos:note "added" ;
     skos:prefLabel "Republican" ;
     time:intervalFinishedBy [
         skos:prefLabel "1 BC" ;
@@ -36926,8 +37051,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Iron IIA"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Iron IIA" ;
     time:intervalFinishedBy [
         skos:prefLabel "925 B.C.E." ;
@@ -36951,8 +37076,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Chalcolithic"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:prefLabel "Chalcolithic" ;
     time:intervalFinishedBy [
         skos:prefLabel "3300 B.C.E." ;
@@ -36976,8 +37101,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Late Bronze IIA-B"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Late Bronze IIA-B" ;
     time:intervalFinishedBy [
         skos:prefLabel "1200 B.C.E." ;
@@ -37001,8 +37126,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Middle Bronze IIB-C"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Middle Bronze IIB-C" ;
     time:intervalFinishedBy [
         skos:prefLabel "1550 B.C.E." ;
@@ -37027,8 +37152,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Middle Bronze"@eng-latn, "Middle Bronze Age"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:prefLabel "Middle Bronze" ;
     time:intervalFinishedBy [
         skos:prefLabel "1550 B.C.E." ;
@@ -37052,8 +37177,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
     skos:altLabel "Phoenician"@eng-latn, "Phoenician culture"@eng-latn ;
+    skos:editorialNote "removed Neo-Assyrian (722-586 B.C.) and Neo-Babylonian (586-539 B.C.) since not explicit, and added new sources Amitai, Barton, Savage, King/Stager, and Richard. " ;
     skos:inScheme <p0z3skm> ;
-    skos:note "removed Neo-Assyrian (722-586 B.C.) and Neo-Babylonian (586-539 B.C.) since not explicit, and added new sources Amitai, Barton, Savage, King/Stager, and Richard. " ;
     skos:prefLabel "Phoenician culture" ;
     time:intervalFinishedBy [
         skos:prefLabel "1000 B.C.E." ;
@@ -37077,8 +37202,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Early Bronze IV/Middle Bronze I"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Early Bronze IV/Middle Bronze I" ;
     time:intervalFinishedBy [
         skos:prefLabel "2000 B.C.E." ;
@@ -37102,8 +37227,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Iron I"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:prefLabel "Iron I" ;
     time:intervalFinishedBy [
         skos:prefLabel "1000 B.C.E." ;
@@ -37127,8 +37252,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Late Bronze I"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Late Bronze I" ;
     time:intervalFinishedBy [
         skos:prefLabel "1400 B.C.E." ;
@@ -37152,8 +37277,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Iron"@eng-latn, "Iron Age"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:prefLabel "Iron" ;
     time:intervalFinishedBy [
         skos:prefLabel "586 B.C.E." ;
@@ -37177,8 +37302,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Pre-Pottery Neolithic B"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:prefLabel "Pre-Pottery Neolithic B" ;
     time:intervalFinishedBy [
         skos:prefLabel "6000 B.C.E." ;
@@ -37202,8 +37327,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Late Bronze"@eng-latn, "Late Bronze Age"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:prefLabel "Late Bronze" ;
     time:intervalFinishedBy [
         skos:prefLabel "1200 B.C.E." ;
@@ -37227,8 +37352,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Early Bronze"@eng-latn, "Early Bronze Age"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:prefLabel "Early Bronze" ;
     time:intervalFinishedBy [
         skos:prefLabel "2300 B.C.E." ;
@@ -37252,8 +37377,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Iron IIC"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Iron IIC" ;
     time:intervalFinishedBy [
         skos:prefLabel "586 B.C.E." ;
@@ -37277,8 +37402,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Iron IA"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Iron IA" ;
     time:intervalFinishedBy [
         skos:prefLabel "1150 B.C.E." ;
@@ -37302,8 +37427,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Bronze"@eng-latn, "Bronze Age"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Bronze" ;
     time:intervalFinishedBy [
         skos:prefLabel "1200 B.C.E." ;
@@ -37327,8 +37452,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Iron IB"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Iron IB" ;
     time:intervalFinishedBy [
         skos:prefLabel "1000 B.C.E." ;
@@ -37352,8 +37477,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Pottery Neolithic B"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:prefLabel "Pottery Neolithic B" ;
     time:intervalFinishedBy [
         skos:prefLabel "4300 B.C.E." ;
@@ -37377,8 +37502,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Middle Bronze IIA"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Middle Bronze IIA" ;
     time:intervalFinishedBy [
         skos:prefLabel "1800/1750 B.C.E." ;
@@ -37403,8 +37528,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Iron II"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:prefLabel "Iron II" ;
     time:intervalFinishedBy [
         skos:prefLabel "586 B.C.E." ;
@@ -37428,8 +37553,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Pre-Pottery Neolithic A"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:prefLabel "Pre-Pottery Neolithic A" ;
     time:intervalFinishedBy [
         skos:prefLabel "7500 B.C.E." ;
@@ -37453,8 +37578,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Gaza_Strip>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria>, <http://dbpedia.org/resource/West_Bank> ;
     a skos:Concept ;
     skos:altLabel "Canaanite"@eng-latn, "Canaanite culture"@eng-latn ;
+    skos:editorialNote "removed Neo-Assyrian (722-586 B.C.) and Neo-Babylonian (586-539 B.C.) since not explicit, and added new sources Amitai, Barton, Savage, King/Stager, and Richard. " ;
     skos:inScheme <p0z3skm> ;
-    skos:note "removed Neo-Assyrian (722-586 B.C.) and Neo-Babylonian (586-539 B.C.) since not explicit, and added new sources Amitai, Barton, Savage, King/Stager, and Richard. " ;
     skos:prefLabel "Canaanite culture" ;
     time:intervalFinishedBy [
         skos:prefLabel "1600 B.C.E." ;
@@ -37478,8 +37603,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Early Bronze I"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Early Bronze I" ;
     time:intervalFinishedBy [
         skos:prefLabel "3050 B.C.E." ;
@@ -37503,8 +37628,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Pottery Neolithic A"@eng-latn ;
+    skos:editorialNote "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"" ;
     skos:prefLabel "Pottery Neolithic A" ;
     time:intervalFinishedBy [
         skos:prefLabel "5000 B.C.E." ;
@@ -37528,8 +37653,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Early Bronze II-III"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Early Bronze II-III" ;
     time:intervalFinishedBy [
         skos:prefLabel "2300 B.C.E." ;
@@ -37553,8 +37678,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Jordan> ;
     a skos:Concept ;
     skos:altLabel "Iron IIB"@eng-latn ;
+    skos:editorialNote "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:inScheme <p0z3skm> ;
-    skos:note "Rows 637-658 were previously incorrectly attributed to Winks and Mattern-Parkes, 2004 in GeoDia, and thus also in Krueger, 2013, pp.43-44. Spatial_coverage_name per n.1 page 33: \"Like the editors of IEJ, I find the name 'Palestine' the most suitable geographical term denoting the modern states of Israel and Jordan.\"1992, page 30." ;
     skos:prefLabel "Iron IIB" ;
     time:intervalFinishedBy [
         skos:prefLabel "722 B.C.E." ;
@@ -37581,8 +37706,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
     skos:altLabel "Aegean Bronze Age"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 85." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Aegean Bronze Age" ;
     time:intervalFinishedBy [
         skos:prefLabel "2000 BCE" ;
@@ -37606,8 +37731,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
     skos:altLabel "Early Christian"@eng-latn ;
+    skos:editorialNote "Map on page 235: \"The eastern Mediterranean lands of Canaan and Judaea were centers of Jewish settlement.\"" ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "Map on page 235: \"The eastern Mediterranean lands of Canaan and Judaea were centers of Jewish settlement.\"" ;
     skos:prefLabel "Early Christian" ;
     time:intervalFinishedBy [
         skos:prefLabel "6th century CE" ;
@@ -37631,8 +37756,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "High Classical"@eng-latn, "High Classical Period"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 85." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "High Classical Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "400 BCE" ;
@@ -37655,8 +37780,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Ukraine> ;
     a skos:Concept ;
     skos:altLabel "Early Byzantine"@eng-latn, "Early Byzantine Period"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 235." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 235." ;
     skos:prefLabel "Early Byzantine Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "726 CE" ;
@@ -37680,8 +37805,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Lebanon>, <http://dbpedia.org/resource/Syria> ;
     a skos:Concept ;
     skos:altLabel "Imperial Christian"@eng-latn ;
+    skos:editorialNote "Map on page 235: \"The eastern Mediterranean lands of Canaan and Judaea were centers of Jewish settlement.\"" ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "Map on page 235: \"The eastern Mediterranean lands of Canaan and Judaea were centers of Jewish settlement.\"" ;
     skos:prefLabel "Imperial Christian" ;
     time:intervalFinishedBy [
         skos:prefLabel "476 CE" ;
@@ -37728,8 +37853,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Portugal>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     skos:altLabel "Late Empire"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 171." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 171." ;
     skos:prefLabel "Late Empire" ;
     time:intervalFinishedBy [
         skos:prefLabel "476 CE" ;
@@ -37752,8 +37877,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Belgium>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Netherlands> ;
     a skos:Concept ;
     skos:altLabel "Ottonian Empire"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 235 and pages 450-1." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 235 and pages 450-1." ;
     skos:prefLabel "Ottonian Empire" ;
     time:intervalFinishedBy [
         skos:prefLabel "1024 CE" ;
@@ -37776,8 +37901,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Late Classical"@eng-latn, "Late Classical Period"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 85." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Late Classical Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "323 BCE" ;
@@ -37800,8 +37925,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece> ;
     a skos:Concept ;
     skos:altLabel "Cycladic Culture"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 85." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Cycladic Culture" ;
     time:intervalFinishedBy [
         skos:prefLabel "1600 BCE" ;
@@ -37848,8 +37973,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Portugal>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     skos:altLabel "Roman Empire"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 171." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 171." ;
     skos:prefLabel "Roman Empire" ;
     time:intervalFinishedBy [
         skos:prefLabel "395 CE" ;
@@ -37873,8 +37998,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Hellenistic"@eng-latn, "Hellenistic Period"@eng-latn ;
+    skos:editorialNote "See also map on page 85." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "See also map on page 85." ;
     skos:prefLabel "Hellenistic Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "31/30 BCE" ;
@@ -37898,8 +38023,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/England>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Switzerland> ;
     a skos:Concept ;
     skos:altLabel "Romanesque"@eng-latn, "Romanesque period"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 475." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 475." ;
     skos:prefLabel "Romanesque period" ;
     time:intervalFinishedBy [
         skos:prefLabel "1189 CE" ;
@@ -37922,8 +38047,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Proto-Geometric"@eng-latn, "Proto-Geometric Period"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 85." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Proto-Geometric Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "900 BCE" ;
@@ -37946,8 +38071,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Ukraine> ;
     a skos:Concept ;
     skos:altLabel "Period of Iconoclasm"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 235." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 235." ;
     skos:prefLabel "Period of Iconoclasm" ;
     time:intervalFinishedBy [
         skos:prefLabel "843 CE" ;
@@ -37970,8 +38095,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Orientalizing"@eng-latn, "Orientalizing Period"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 85." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Orientalizing Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "600 BCE" ;
@@ -37994,8 +38119,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Geometric"@eng-latn, "Geometric Period"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 85." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Geometric Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "700 BCE" ;
@@ -38018,8 +38143,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Tunisia> ;
     a skos:Concept ;
     skos:altLabel "Roman Republic"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 171." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 171." ;
     skos:prefLabel "Roman Republic" ;
     time:intervalFinishedBy [
         skos:prefLabel "27 BCE" ;
@@ -38066,8 +38191,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Ukraine> ;
     a skos:Concept ;
     skos:altLabel "Middle Byzantine"@eng-latn, "Middle Byzantine Period"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 235." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 235." ;
     skos:prefLabel "Middle Byzantine Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "1204 CE" ;
@@ -38090,8 +38215,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Portugal>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     skos:altLabel "High Empire"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 171." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 171." ;
     skos:prefLabel "High Empire" ;
     time:intervalFinishedBy [
         skos:prefLabel "192 CE" ;
@@ -38258,8 +38383,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Early Classical"@eng-latn, "Early Classical Period"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 85." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Early Classical Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "450 BCE" ;
@@ -38306,8 +38431,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Belgium>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Germany>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Netherlands> ;
     a skos:Concept ;
     skos:altLabel "Carolingian Empire"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 235 and pages 450-1." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 235 and pages 450-1." ;
     skos:prefLabel "Carolingian Empire" ;
     time:intervalFinishedBy [
         skos:prefLabel "887 CE" ;
@@ -38354,8 +38479,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/France>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Italy>, <http://dbpedia.org/resource/Portugal>, <http://dbpedia.org/resource/Spain>, <http://dbpedia.org/resource/Tunisia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     skos:altLabel "Early Empire"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 171." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 171." ;
     skos:prefLabel "Early Empire" ;
     time:intervalFinishedBy [
         skos:prefLabel "96 CE" ;
@@ -38378,8 +38503,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Egypt>, <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Israel>, <http://dbpedia.org/resource/Russia>, <http://dbpedia.org/resource/Turkey>, <http://dbpedia.org/resource/Ukraine> ;
     a skos:Concept ;
     skos:altLabel "Late Byzantine"@eng-latn, "Late Byzantine Period"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 235." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 235." ;
     skos:prefLabel "Late Byzantine Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "1453 CE" ;
@@ -38402,8 +38527,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Greece>, <http://dbpedia.org/resource/Turkey> ;
     a skos:Concept ;
     skos:altLabel "Archaic"@eng-latn, "Archaic Period"@eng-latn ;
+    skos:editorialNote "For spatial coverage label, please see map on page 85." ;
     skos:inScheme <p0z5nvh> ;
-    skos:note "For spatial coverage label, please see map on page 85." ;
     skos:prefLabel "Archaic Period" ;
     time:intervalFinishedBy [
         skos:prefLabel "480 BCE" ;
@@ -38616,8 +38741,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Denmark> ;
     a skos:Concept ;
     skos:altLabel "Modern"@eng-latn ;
+    skos:editorialNote "Visual timeline fades toward the present, indicating no end date." ;
     skos:inScheme <p0zj6g8> ;
-    skos:note "Visual timeline fades toward the present, indicating no end date." ;
     skos:prefLabel "Modern" ;
     time:intervalFinishedBy [
         skos:prefLabel "present"
@@ -38734,8 +38859,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Poland> ;
     a skos:Concept ;
     skos:altLabel "Modern"@eng-latn ;
+    skos:editorialNote "Visual timeline fades toward the present, indicating no end date." ;
     skos:inScheme <p0zj6g8> ;
-    skos:note "Visual timeline fades toward the present, indicating no end date." ;
     skos:prefLabel "Modern" ;
     time:intervalFinishedBy [
         skos:prefLabel "present"
@@ -38852,8 +38977,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Norway> ;
     a skos:Concept ;
     skos:altLabel "Mesolithic"@eng-latn ;
+    skos:editorialNote "Visual timeline fades out before the -6000 tick on the timeline, indicating no clear start date." ;
     skos:inScheme <p0zj6g8> ;
-    skos:note "Visual timeline fades out before the -6000 tick on the timeline, indicating no clear start date." ;
     skos:prefLabel "Mesolithic" ;
     time:intervalFinishedBy [
         skos:prefLabel "-4000"
@@ -38947,8 +39072,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/United_Kingdom> ;
     a skos:Concept ;
     skos:altLabel "Modern"@eng-latn ;
+    skos:editorialNote "Visual timeline fades toward the present, indicating no end date." ;
     skos:inScheme <p0zj6g8> ;
-    skos:note "Visual timeline fades toward the present, indicating no end date." ;
     skos:prefLabel "Modern" ;
     time:intervalFinishedBy [
         skos:prefLabel "present"
@@ -38985,8 +39110,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iceland> ;
     a skos:Concept ;
     skos:altLabel "Modern"@eng-latn ;
+    skos:editorialNote "Visual timeline fades toward the present, indicating no end date." ;
     skos:inScheme <p0zj6g8> ;
-    skos:note "Visual timeline fades toward the present, indicating no end date." ;
     skos:prefLabel "Modern" ;
     time:intervalFinishedBy [
         skos:prefLabel "present"
@@ -39163,8 +39288,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Norway> ;
     a skos:Concept ;
     skos:altLabel "Post Medieval"@eng-latn ;
+    skos:editorialNote "Visual timeline fades toward the present, indicating no end date." ;
     skos:inScheme <p0zj6g8> ;
-    skos:note "Visual timeline fades toward the present, indicating no end date." ;
     skos:prefLabel "Post Medieval" ;
     time:intervalFinishedBy [
         skos:prefLabel "present"
@@ -39361,8 +39486,8 @@ Chrono-cultural categories are not exactly periods. They have strong chronologic
     dcterms:spatial <http://dbpedia.org/resource/Iceland> ;
     a skos:Concept ;
     skos:altLabel "Early Medieval"@eng-latn ;
+    skos:editorialNote "Visual timeline fades out before the 1000 tick on the timeline, indicating no clear start date." ;
     skos:inScheme <p0zj6g8> ;
-    skos:note "Visual timeline fades out before the 1000 tick on the timeline, indicating no clear start date." ;
     skos:prefLabel "Early Medieval" ;
     time:intervalFinishedBy [
         skos:prefLabel "1100"


### PR DESCRIPTION
`editorialNote` was incorrectly mapped to http://www.w3.org/2004/02/sko…s/core#note rather than http://www.w3.org/2004/02/skos/core#editorialNote.